### PR TITLE
Add plot_mesh method to sim classes and improve docs workflow

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: gsim
 site_url: https://gdsfactory.com/gsim
-site_description: Palace EM Simulation API for GDSFactory
+site_description: Simulations API for GDSFactory
 site_author: GDSFactory
 copyright: Copyright © 2026, GDSFactory
 
@@ -17,8 +17,8 @@ extra_css:
 nav:
   - home: index.md
   - examples:
-      - example: nbs/example.md
-      - palace_demo_cpw: nbs/palace_demo_cpw.md
+      - Simple Example: nbs/example.md
+      - Palace CPW: nbs/palace_demo_cpw.md
   - api reference:
       - gsim.palace: api.md
 

--- a/nbs/palace_demo_cpw.ipynb
+++ b/nbs/palace_demo_cpw.ipynb
@@ -5,29 +5,13 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "### Running Palace Simulations on GDSFactory+ Cloud\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from gsim.palace import DrivenSim\n",
-    "# !uv pip install git+https://github.com/gdsfactory/IHP.git --upgrade"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# === Configuration ===\n",
-    "OUTPUT_DIR = \"./palace-sim-cpw\""
+    "# Running Palace Simulations\n",
+    "\n",
+    "[Palace](https://awslabs.github.io/palace/) is an open-source 3D electromagnetic simulator supporting eigenmode, driven (S-parameter), and electrostatic simulations. This notebook demonstrates using the `gsim.palace` API to run a driven simulation on a CPW (coplanar waveguide) structure.\n",
+    "\n",
+    "**Requirements:**\n",
+    "- IHP PDK: `uv pip install ihp-gdsfactory`\n",
+    "- [GDSFactory+](https://gdsfactory.com) account for cloud simulation"
    ]
   },
   {
@@ -45,17 +29,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Import ihp first to avoid circular import issues\n",
-    "from ihp import LAYER, PDK\n",
-    "\n",
     "import gdsfactory as gf\n",
+    "from ihp import LAYER, PDK\n",
     "\n",
     "PDK.activate()\n",
     "\n",
-    "\n",
     "@gf.cell\n",
     "def gsg_electrode(\n",
-    "    length: float = 100,\n",
+    "    length: float = 300,\n",
     "    s_width: float = 20,\n",
     "    g_width: float = 40,\n",
     "    gap_width: float = 15,\n",
@@ -145,11 +126,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from gsim.palace import DrivenSim\n",
+    "\n",
     "# Create simulation object\n",
     "sim = DrivenSim()\n",
     "\n",
     "# Set output directory\n",
-    "sim.set_output_dir(OUTPUT_DIR)\n",
+    "sim.set_output_dir(\"./palace-sim-cpw\")\n",
     "\n",
     "# Set the component geometry\n",
     "sim.set_geometry(c)\n",
@@ -188,18 +171,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gsim.palace import plot_mesh\n",
-    "\n",
     "# Static PNG\n",
-    "plot_mesh(\n",
-    "    f\"{OUTPUT_DIR}/palace.msh\",\n",
-    "    output=f\"{OUTPUT_DIR}/mesh.png\",\n",
-    "    show_groups=[\"metal\", \"P\"],\n",
-    "    interactive=False,\n",
-    ")\n",
+    "sim.plot_mesh(show_groups=[\"metal\", \"P\"], interactive=False)\n",
     "\n",
     "# Interactive\n",
-    "# plot_mesh(f\"{OUTPUT_DIR}/palace.msh\", show_groups=[\"metal\", \"P\"], interactive=True)"
+    "# sim.plot_mesh(show_groups=[\"metal\", \"P\"], interactive=True)"
    ]
   },
   {

--- a/src/gsim/palace/TODO.md
+++ b/src/gsim/palace/TODO.md
@@ -20,17 +20,27 @@ Changes needed:
 
 ## Code Organization
 
-### Extract Common Base Class
-Create a common base module with shared functionality:
+### Extract Common Base Class (Mixin)
+Create a common mixin with shared functionality. File `src/gsim/palace/base.py` exists with `PalaceSimMixin`.
 
-- [ ] Create `src/gsim/palace/base.py` with `PalaceSimBase` class containing:
-  - `set_output_dir()` / `output_dir` property
-  - `set_geometry()`
-  - `set_stack()`
-  - `validate()` base implementation
-  - `_resolve_stack()`
-  - `write_config()` (if signature is identical)
-  - Common private attributes (`_output_dir`, `_last_mesh_result`, etc.)
+Methods to move to mixin (identical across all 3 sim classes):
+- [x] `plot_mesh()` - visualize mesh (added)
+- [ ] `set_output_dir()` / `output_dir` property
+- [ ] `set_geometry()` / `component` / `_component` properties
+- [ ] `set_stack()`
+- [ ] `set_material()`
+- [ ] `set_numerical()`
+- [ ] `_resolve_stack()`
+- [ ] `_build_mesh_config()`
+- [ ] `show_stack()`
+- [ ] `plot_stack()`
+
+Keep in each class (type-specific):
+- `validate()` - different validation rules per type
+- `add_port()` / `add_cpw_port()` - only Driven/Eigenmode
+- `add_terminal()` - only Electrostatic
+- `set_driven()` / `set_eigenmode()` / `set_electrostatic()`
+- `mesh()` / `simulate()` - similar but type-specific logic
 
 ### Break Down Large Files
 Files over 500 lines need refactoring:

--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -1,0 +1,68 @@
+"""Base mixin for Palace simulation classes.
+
+Provides common visualization methods shared across all simulation types.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+class PalaceSimMixin:
+    """Mixin providing common methods for all Palace simulation classes.
+
+    Requires the class to have:
+        - _output_dir: Path | None (private attribute)
+    """
+
+    _output_dir: Path | None
+
+    def plot_mesh(
+        self,
+        output: str | Path | None = None,
+        show_groups: list[str] | None = None,
+        interactive: bool = True,
+    ) -> None:
+        """Plot the mesh wireframe using PyVista.
+
+        Requires mesh() to be called first.
+
+        Args:
+            output: Output PNG path (only used if interactive=False)
+            show_groups: List of group name patterns to show (None = all).
+                Example: ["metal", "P"] to show metal layers and ports.
+            interactive: If True, open interactive 3D viewer.
+                If False, save static PNG to output path.
+
+        Raises:
+            ValueError: If output_dir not set or mesh file doesn't exist
+
+        Example:
+            >>> sim.mesh(preset="default")
+            >>> sim.plot_mesh(show_groups=["metal", "P"])
+        """
+        from gsim.viz import plot_mesh as _plot_mesh
+
+        if self._output_dir is None:
+            raise ValueError("Output directory not set. Call set_output_dir() first.")
+
+        mesh_path = self._output_dir / "palace.msh"
+        if not mesh_path.exists():
+            raise ValueError(
+                f"Mesh file not found: {mesh_path}. Call mesh() first."
+            )
+
+        # Default output path if not interactive
+        if output is None and not interactive:
+            output = self._output_dir / "mesh.png"
+
+        _plot_mesh(
+            msh_path=mesh_path,
+            output=output,
+            show_groups=show_groups,
+            interactive=interactive,
+        )

--- a/src/gsim/palace/driven.py
+++ b/src/gsim/palace/driven.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from gsim.common import Geometry, LayerStack
+from gsim.palace.base import PalaceSimMixin
 from gsim.palace.models import (
     CPWPortConfig,
     DrivenConfig,
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
     from gdsfactory.component import Component
 
 
-class DrivenSim(BaseModel):
+class DrivenSim(PalaceSimMixin, BaseModel):
     """Frequency-domain driven simulation for S-parameter extraction.
 
     This class configures and runs driven simulations that sweep through

--- a/src/gsim/palace/eigenmode.py
+++ b/src/gsim/palace/eigenmode.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from gsim.common import Geometry, LayerStack
+from gsim.palace.base import PalaceSimMixin
 from gsim.palace.models import (
     CPWPortConfig,
     EigenmodeConfig,
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
     from gdsfactory.component import Component
 
 
-class EigenmodeSim(BaseModel):
+class EigenmodeSim(PalaceSimMixin, BaseModel):
     """Eigenmode simulation for finding resonant frequencies.
 
     This class configures and runs eigenmode simulations to find

--- a/src/gsim/palace/electrostatic.py
+++ b/src/gsim/palace/electrostatic.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from gsim.common import Geometry, LayerStack
+from gsim.palace.base import PalaceSimMixin
 from gsim.palace.models import (
     ElectrostaticConfig,
     MaterialConfig,
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
     from gdsfactory.component import Component
 
 
-class ElectrostaticSim(BaseModel):
+class ElectrostaticSim(PalaceSimMixin, BaseModel):
     """Electrostatic simulation for capacitance matrix extraction.
 
     This class configures and runs electrostatic simulations to extract


### PR DESCRIPTION
## Summary
- Add `PalaceSimMixin` with `plot_mesh()` method for all simulation classes (`DrivenSim`, `EigenmodeSim`, `ElectrostaticSim`)
- Update docs workflow to trigger on main branch pushes and deploy to GitHub Pages
- Fix artifact download path nesting issue in docs workflow
- Add `palace_demo_cpw` notebook to mkdocs navigation
- Improve notebook intro with Palace description and requirements

## Changes
- New `src/gsim/palace/base.py` with mixin class
- Updated docs workflow triggers and deployment conditions
- Updated mkdocs.yml navigation
- Updated TODO.md with mixin refactoring plan

## Test plan
- [ ] Verify `sim.plot_mesh()` works after calling `sim.mesh()`
- [ ] Verify docs build and deploy on push to main
- [ ] Verify palace_demo_cpw notebook appears in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)