### PR TITLE
feat: add sim-data- prefix to download dir and trame dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Simulation outputs
+sim-data-*/
 palace-sim-*/
-dev-palace-simulation-*/
 
 # files
 *.c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,23 +6,23 @@ requires = ["setuptools>=61", "uv", "build", "wheel"]
 authors = [{name = "GDSFactory", email = "contact@gdsfactory.com"}]
 classifiers = [
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent"
 ]
 dependencies = [
   "gdsfactory>=9.32.0",
-  "gdsfactoryplus>=1.3.12",
+  "gdsfactoryplus>=1.4.0",
   "gmsh",
   "meshio>=5.0.0",
   "plotly",
   "pydantic>=2.10.6",
-  "pyvista>=0.43.0"
+  "pyvista>=0.43.0",
+  "trame-vtk",
+  "trame-vuetify"
 ]
 description = ""
 name = "gsim"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = "~=3.12.0"
 version = "0.0.3"
 
 [project.optional-dependencies]

--- a/src/gsim/gcloud.py
+++ b/src/gsim/gcloud.py
@@ -172,7 +172,9 @@ def run_simulation(
         _handle_failed_job(finished_job, output_dir, verbose)
 
     # Download
-    raw_results = sim.download_results(finished_job)
+    raw_results = sim.download_results(
+        finished_job, output_dir=f"sim-data-{finished_job.job_name}"
+    )
 
     # Flatten results: gdsfactoryplus returns extracted directories,
     # but we want a dict of filename -> Path for individual files


### PR DESCRIPTION
- Prefix simulation result downloads with "sim-data-" for clearer naming
- Add trame-vtk and trame-vuetify dependencies for pyvista interactive visualization