### PR TITLE
docs: add palace width sweep notebook to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - Palace:
       - CPW: nbs/palace_demo_cpw.md
       - Microstrip: nbs/palace_demo_microstrip.md
+      - Width Sweep: nbs/palace_width_sweep.md
   - api reference:
       - gsim.palace: api.md
 plugins:


### PR DESCRIPTION
## Summary
- Add the `palace_width_sweep` notebook to the Palace section in mkdocs nav

## Test plan
- [ ] Verify `just nbdocs && just docs` builds successfully with the new entry
- [ ] Confirm the Width Sweep page appears under Palace in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)