### PR TITLE
fix: support DerivedLayer PDKs (cspdk) in meep simulation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,8 +50,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libglu1-mesa libosmesa6 xvfb
       - name: Create environment
         run: just dev
-      - name: Install ubcpdk (unreleased)
-        run: uv pip install ubcpdk@git+https://github.com/gdsfactory/ubc.git
+      - name: Install ubcpdk
+        run: uv pip install ubcpdk
       - name: Create ipykernel
         run: uv run --no-sync python -m ipykernel install --user --name gsim
       - name: Run notebook
@@ -82,8 +82,8 @@ jobs:
         run: cargo install svgbob_cli
       - name: Create environment
         run: just dev
-      - name: Install ubcpdk (unreleased)
-        run: uv pip install ubcpdk@git+https://github.com/gdsfactory/ubc.git
+      - name: Install ubcpdk
+        run: uv pip install ubcpdk
       - name: Download all notebook artifacts
         uses: actions/download-artifact@v4
         with:

--- a/src/gsim/common/stack/_layer_utils.py
+++ b/src/gsim/common/stack/_layer_utils.py
@@ -17,6 +17,10 @@ def get_gds_layer_tuple(layer_level: LayerLevel) -> tuple[int, int] | None:
     """Extract GDS layer tuple (layer, datatype) from a gdsfactory LayerLevel.
 
     Returns ``None`` when the layer cannot be parsed (callers decide fallback).
+
+    When the primary ``layer`` is a ``DerivedLayer`` (e.g. ``WG - GRA`` in
+    cspdk), falls back to ``derived_layer`` which typically holds the simple
+    GDS layer used for polygon extraction.
     """
     layer: Any = layer_level.layer
 
@@ -57,8 +61,20 @@ def get_gds_layer_tuple(layer_level: LayerLevel) -> tuple[int, int] | None:
     try:
         return (int(layer), 0)  # ty: ignore[invalid-argument-type]
     except (TypeError, ValueError):
-        logger.warning("Could not parse layer %s", layer)
-        return None
+        pass
+
+    # Fallback: DerivedLayer (e.g. cspdk core = WG - GRA) — use derived_layer
+    derived = getattr(layer_level, "derived_layer", None)
+    if derived is not None and derived is not layer:
+        # Build a temporary LayerLevel with the derived_layer as its layer
+        # so we can recurse through the same parsing logic.
+        temp = LayerLevel(layer=derived, thickness=0, zmin=0)
+        result = get_gds_layer_tuple(temp)
+        if result is not None:
+            return result
+
+    logger.warning("Could not parse layer %s", layer)
+    return None
 
 
 def classify_layer_type(


### PR DESCRIPTION
## Summary
- **DerivedLayer support**: `get_gds_layer_tuple()` now falls back to `derived_layer` when the primary `layer` is a `DerivedLayer` (e.g. cspdk's `WG - GRA`). Previously this returned `None` → `(0,0)`, causing the runner to find zero polygons and simulate an empty geometry.
- **Z-range from dielectrics**: Cell height (`cell_z`) and plot bbox now include the dielectric z-range, not just patterned layers. PDKs like cspdk that don't define explicit box/clad `LayerLevel`s were getting a cell that was too short, with PML touching the waveguide core.
- **docs CI**: Install ubcpdk from PyPI instead of git.

## Test plan
- [x] All 229 tests pass
- [x] Verified `get_gds_layer_tuple()` returns `(3, 0)` for cspdk core layer
- [x] Verified full stack extraction with cspdk produces correct layers and dielectrics
- [ ] Re-run cspdk coupler simulation to confirm geometry appears in animation