### PR TITLE
feat: add QPDK resonator notebook to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - Microstrip: nbs/palace_demo_microstrip.md
       - Branch Line Coupler: nbs/palace_demo_BranchLineCoupler.md
       - "Parallel Simulations: Width Sweep": nbs/palace_width_sweep.md
+      - QPDK Resonator: nbs/palace_qpdk_resonator.md
   - API Reference: api.md
 plugins:
   - search

--- a/nbs/palace_qpdk_resonator.ipynb
+++ b/nbs/palace_qpdk_resonator.ipynb
@@ -126,7 +126,9 @@
    "source": [
     "sim.set_output_dir(\"./sim_qpdk_resonator\")\n",
     "sim.mesh(preset=\"graded\", margin=0)\n",
-    "sim.plot_mesh(show_groups=[\"superconductor\", \"P\", \"sapphire\", \"vacuum\"])"
+    "sim.plot_mesh(\n",
+    "    show_groups=[\"superconductor\", \"P\", \"sapphire\", \"vacuum\"], interactive=False\n",
+    ")"
    ]
   },
   {
@@ -180,7 +182,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "gsim",
    "language": "python",
    "name": "python3"
   },

--- a/tests/test_gsim.py
+++ b/tests/test_gsim.py
@@ -11,13 +11,6 @@ def test_package_import():
     assert hasattr(gsim, "__version__")
 
 
-def test_package_version():
-    """Test that package version is accessible."""
-    import gsim
-
-    assert gsim.__version__ == "0.0.5"
-
-
 def test_palace_submodule_import():
     """Test that palace submodule can be imported."""
     from gsim import palace


### PR DESCRIPTION
## Summary
- Add `palace_qpdk_resonator` notebook to mkdocs nav under Palace section
- Remove hardcoded version assertion in `test_gsim.py` (was failing after 0.0.6 bump)

## Test plan
- [ ] Verify docs build succeeds with the new notebook
- [ ] Verify all tests pass