### PR TITLE
fix: restore volumetric conductor support and add mesh validation

### DIFF
--- a/nbs/palace_demo_cpw.ipynb
+++ b/nbs/palace_demo_cpw.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "@gf.cell\n",
     "def gsg_electrode(\n",
-    "    length: float = 300,\n",
+    "    length: float = 800,\n",
     "    s_width: float = 20,\n",
     "    g_width: float = 40,\n",
     "    gap_width: float = 15,\n",
@@ -157,17 +157,17 @@
    "outputs": [],
    "source": [
     "# Static PNG (wireframe, filtered to metal + port groups)\n",
-    "# sim.plot_mesh(show_groups=[\"metal\", \"P\"], interactive=False)\n",
+    "sim.plot_mesh(show_groups=[\"metal\", \"P\"], interactive=False)\n",
     "\n",
     "# Interactive wireframe\n",
     "# sim.plot_mesh(show_groups=[\"metal\", \"P\"], interactive=True)\n",
     "\n",
     "# Solid view — coloured surfaces per physical group, boundary transparent\n",
-    "sim.plot_mesh(\n",
-    "    style=\"solid\",\n",
-    "    transparent_groups=[\"Absorbing_boundary\", \"air__airbox\", \"air__passive\"],\n",
-    "    interactive=True,\n",
-    ")"
+    "# sim.plot_mesh(\n",
+    "#     style=\"solid\",\n",
+    "#     transparent_groups=[\"Absorbing_boundary\", \"air__airbox\", \"air__passive\"],\n",
+    "#     interactive=False,\n",
+    "# )"
    ]
   },
   {
@@ -186,10 +186,7 @@
    "outputs": [],
    "source": [
     "# Run simulation on GDSFactory+ cloud\n",
-    "results = sim.run()\n",
-    "\n",
-    "# Run locally (requires local installation of Palace)\n",
-    "# sim.write_config()# results = sim.run_local()"
+    "results = sim.run()"
    ]
   },
   {
@@ -232,7 +229,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "gsim",
    "language": "python",
    "name": "python3"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
   "gdsfactory>=9.32.0",
-  "gdsfactoryplus>=1.4.0",
+  "gdsfactoryplus>=1.5.10",
   "gmsh",
   "meshio>=5.0.0",
   "plotly",

--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+from gsim.palace.models.results import ValidationResult
+
 if TYPE_CHECKING:
     from gdsfactory.component import Component
 
@@ -308,6 +310,106 @@ class PalaceSimMixin:
         mesh_config.show_gui = show_gui
 
         return mesh_config
+
+    # -------------------------------------------------------------------------
+    # Post-mesh validation
+    # -------------------------------------------------------------------------
+
+    def validate_mesh(self) -> ValidationResult:
+        """Validate the generated mesh and config before cloud submission.
+
+        Checks that physical groups are correctly assigned after meshing:
+        conductor surfaces, dielectric volumes, ports, and absorbing boundary.
+        Also verifies the generated config.json structure.
+
+        Call after mesh() and before run().
+
+        Returns:
+            ValidationResult with validation status and messages
+
+        Example:
+            >>> sim.mesh(preset="coarse")
+            >>> result = sim.validate_mesh()
+            >>> print(result)
+        """
+        errors = []
+        warnings_list = []
+
+        mesh_result = getattr(self, "_mesh_result", None) or getattr(
+            self, "_last_mesh_result", None
+        )
+        if mesh_result is None:
+            errors.append("No mesh generated. Call mesh() first.")
+            return ValidationResult(valid=False, errors=errors, warnings=warnings_list)
+
+        groups = mesh_result.groups
+
+        # Check dielectric volumes
+        if not groups.get("volumes"):
+            errors.append("No dielectric volumes in mesh.")
+        else:
+            vol_names = list(groups["volumes"].keys())
+            warnings_list.append(f"Volumes: {vol_names}")
+
+        # Check conductor surfaces (volumetric or PEC)
+        has_conductors = bool(groups.get("conductor_surfaces"))
+        has_pec = bool(groups.get("pec_surfaces"))
+        if not has_conductors and not has_pec:
+            errors.append(
+                "No conductor surfaces in mesh. "
+                "Check that conductor layers have polygons and correct layer_type."
+            )
+        else:
+            if has_conductors:
+                warnings_list.append(
+                    f"Conductor surfaces: {list(groups['conductor_surfaces'].keys())}"
+                )
+            if has_pec:
+                warnings_list.append(
+                    f"PEC surfaces: {list(groups['pec_surfaces'].keys())}"
+                )
+
+        # Check ports
+        port_surfaces = groups.get("port_surfaces", {})
+        if not port_surfaces:
+            errors.append("No port surfaces in mesh.")
+        else:
+            for port_name, port_info in port_surfaces.items():
+                if port_info.get("type") == "cpw":
+                    n_elems = len(port_info.get("elements", []))
+                    if n_elems < 2:
+                        errors.append(
+                            f"CPW port '{port_name}' has {n_elems} elements "
+                            f"(expected >= 2)."
+                        )
+
+        # Check absorbing boundary
+        if not groups.get("boundary_surfaces", {}).get("absorbing"):
+            warnings_list.append(
+                "No absorbing boundary found. This is expected if airbox_margin=0."
+            )
+
+        # Validate config.json if it exists
+        output_dir = getattr(self, "_output_dir", None)
+        if output_dir is not None:
+            import json
+
+            config_path = output_dir / "config.json"
+            if config_path.exists():
+                try:
+                    config = json.loads(config_path.read_text())
+                    boundaries = config.get("Boundaries", {})
+                    if not boundaries.get("Conductivity") and not boundaries.get("PEC"):
+                        errors.append(
+                            "config.json has no Conductivity or PEC boundaries."
+                        )
+                    if not boundaries.get("LumpedPort"):
+                        errors.append("config.json has no LumpedPort entries.")
+                except json.JSONDecodeError as e:
+                    errors.append(f"config.json is invalid JSON: {e}")
+
+        valid = len(errors) == 0
+        return ValidationResult(valid=valid, errors=errors, warnings=warnings_list)
 
     # -------------------------------------------------------------------------
     # Convenience methods

--- a/src/gsim/palace/driven.py
+++ b/src/gsim/palace/driven.py
@@ -684,6 +684,11 @@ class DrivenSim(PalaceSimMixin, BaseModel):
             driven_config=self.driven,
         )
 
+        # Validate mesh and config
+        validation = self.validate_mesh()
+        if not validation.valid:
+            raise ValueError(f"Mesh validation failed:\n{validation}")
+
         return config_path
 
     # -------------------------------------------------------------------------

--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -341,6 +341,37 @@ def build_entities(
                 )
             )
 
+        # Volumetric conductors: shell surfaces (volume already removed)
+        if tag_info["volumes"]:
+            xy_tags = []
+            z_tags = []
+            for item in tag_info["volumes"]:
+                if isinstance(item, tuple):
+                    _volumetag, surface_tags = item
+                    for tag in surface_tags:
+                        if gmsh_utils.is_vertical_surface(tag):
+                            z_tags.append(tag)
+                        else:
+                            xy_tags.append(tag)
+            if xy_tags:
+                entities.append(
+                    Entity(
+                        name=f"{layer_name}_xy",
+                        dim=2,
+                        mesh_order=0,
+                        tags=xy_tags,
+                    )
+                )
+            if z_tags:
+                entities.append(
+                    Entity(
+                        name=f"{layer_name}_z",
+                        dim=2,
+                        mesh_order=0,
+                        tags=z_tags,
+                    )
+                )
+
     # --- Port surfaces (dim=2) ---
     for port_name, surf_tags in port_tags.items():
         port_num = int(port_name[1:])

--- a/src/gsim/palace/mesh/groups.py
+++ b/src/gsim/palace/mesh/groups.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import gmsh
-
 from . import gmsh_utils
 
 if TYPE_CHECKING:
@@ -89,6 +87,21 @@ def assign_physical_groups(
                         "tags": surf_tags,
                     }
 
+    # --- Volumetric conductor surfaces (finite thickness) ---
+    for layer_name, tag_info in metal_tags.items():
+        if tag_info["volumes"]:
+            for suffix in ("_xy", "_z"):
+                name = f"{layer_name}{suffix}"
+                entity = entity_by_name.get(name)
+                pg = pg_map.get(name)
+                if entity and pg is not None:
+                    surf_tags = [t for d, t in entity.dimtags if d == 2]
+                    if surf_tags:
+                        groups["conductor_surfaces"][name] = {
+                            "phys_group": pg,
+                            "tags": surf_tags,
+                        }
+
     # --- Port surfaces ---
     for port_name, tags in port_tags.items():
         port_num = int(port_name[1:])
@@ -138,80 +151,8 @@ def assign_physical_groups(
             "tags": [],  # tags not needed; pg_map is authoritative
         }
 
-    # Label every remaining surface created by volume fragmentation -------
-    # Surfaces already claimed by conductors, ports, or the absorbing
-    # boundary keep their names.  Every other surface is labelled with the
-    # sorted pair of volume names that share it, e.g. "air__substrate".
-    groups["interface_surfaces"] = _assign_interface_surfaces(groups)
-
     kernel.synchronize()
     return groups
-
-
-# ---------------------------------------------------------------------------
-# Interface surface labelling
-# ---------------------------------------------------------------------------
-
-
-def _assign_interface_surfaces(groups: dict) -> dict:
-    """Label volume-boundary surfaces not yet in a physical group.
-
-    Each surface is named ``"vol1__vol2"`` when shared by two volumes, or
-    ``"vol__None"`` when it belongs to only one volume.
-
-    Returns:
-        ``{label: {"phys_group": int, "tags": [int]}}``
-    """
-    # Collect surface tags that already have a physical group
-    assigned: set[int] = set()
-    for section in (
-        "conductor_surfaces",
-        "pec_surfaces",
-        "port_surfaces",
-        "boundary_surfaces",
-    ):
-        for info in groups[section].values():
-            if info.get("type") == "cpw":
-                for elem in info["elements"]:
-                    assigned.update(elem["tags"])
-            else:
-                assigned.update(info.get("tags", []))
-
-    # Build surface → owning-volume-name(s) map
-    surf_to_names: dict[int, list[str]] = {}
-    for vol_name, vol_info in groups["volumes"].items():
-        for vol_tag in vol_info["tags"]:
-            try:
-                boundary = gmsh.model.getBoundary(
-                    [(3, vol_tag)], combined=False, oriented=False, recursive=False
-                )
-            except Exception:
-                logger.debug("Could not query boundary of volume %d", vol_tag)
-                continue
-            for bdim, btag in boundary:
-                if bdim == 2:
-                    surf_to_names.setdefault(btag, [])
-                    if vol_name not in surf_to_names[btag]:
-                        surf_to_names[btag].append(vol_name)
-
-    # Group unassigned surfaces by their sorted owner-name combination
-    label_to_surfs: dict[str, list[int]] = {}
-    for stag, names in surf_to_names.items():
-        if stag in assigned:
-            continue
-        label = "__".join(sorted(names)) if len(names) > 1 else f"{names[0]}__None"
-        label_to_surfs.setdefault(label, []).append(stag)
-
-    # Create physical groups
-    result: dict[str, dict] = {}
-    for label, stags in label_to_surfs.items():
-        phys_group = gmsh_utils.assign_physical_group(2, stags, label)
-        result[label] = {"phys_group": phys_group, "tags": stags}
-        logger.debug(
-            "Interface surface '%s': pg=%d, %d tags", label, phys_group, len(stags)
-        )
-
-    return result
 
 
 __all__ = ["assign_physical_groups"]

--- a/tests/palace/test_mesh_integration.py
+++ b/tests/palace/test_mesh_integration.py
@@ -1,0 +1,336 @@
+"""Integration tests for mesh generation with IHP-style components.
+
+These tests verify that mesh generation produces correct physical groups
+and Palace config without actually running Palace.
+
+Note: gmsh segfaults on macOS (headless OpenGL issue), so these tests
+only run on Linux (CI).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import gdsfactory as gf
+import pytest
+
+from gsim.common import Layer, LayerStack
+from gsim.palace import DrivenSim
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "darwin", reason="gmsh segfaults on macOS"
+)
+
+
+def _make_cpw_component():
+    """Create an IHP-style GSG electrode component."""
+    gf.gpdk.PDK.activate()
+
+    @gf.cell
+    def gsg_electrode(
+        length: float = 300,
+        s_width: float = 20,
+        g_width: float = 40,
+        gap_width: float = 15,
+        layer=(99, 0),
+    ) -> gf.Component:
+        c = gf.Component()
+        r1 = c << gf.c.rectangle((length, g_width), centered=True, layer=layer)
+        r1.move((0, (g_width + s_width) / 2 + gap_width))
+        c << gf.c.rectangle((length, s_width), centered=True, layer=layer)
+        r3 = c << gf.c.rectangle((length, g_width), centered=True, layer=layer)
+        r3.move((0, -(g_width + s_width) / 2 - gap_width))
+
+        c.add_port(
+            name="o1",
+            center=(-length / 2, 0),
+            width=s_width,
+            orientation=0,
+            port_type="electrical",
+            layer=layer,
+        )
+        c.add_port(
+            name="o2",
+            center=(length / 2, 0),
+            width=s_width,
+            orientation=180,
+            port_type="electrical",
+            layer=layer,
+        )
+        return c
+
+    return gsg_electrode()
+
+
+def _make_sim(component, tmp_path, planar_conductors=False):
+    """Create, configure, and mesh a DrivenSim."""
+    sim = DrivenSim()
+    sim.set_output_dir(str(tmp_path / "palace-sim"))
+    sim.set_geometry(component)
+    sim.set_stack(substrate_thickness=2.0, air_above=300.0)
+    sim.add_cpw_port("o1", layer="topmetal2", s_width=20, gap_width=15, length=5.0)
+    sim.add_cpw_port("o2", layer="topmetal2", s_width=20, gap_width=15, length=5.0)
+    sim.set_driven(fmin=1e9, fmax=100e9, num_points=40)
+    sim.mesh(preset="coarse", planar_conductors=planar_conductors)
+    return sim
+
+
+@pytest.fixture(scope="module")
+def volumetric_sim(tmp_path_factory):
+    """Mesh once with volumetric conductors, share across tests."""
+    tmp_path = tmp_path_factory.mktemp("volumetric")
+    component = _make_cpw_component()
+    return _make_sim(component, tmp_path, planar_conductors=False)
+
+
+@pytest.fixture(scope="module")
+def planar_sim(tmp_path_factory):
+    """Mesh once with planar conductors, share across tests."""
+    tmp_path = tmp_path_factory.mktemp("planar")
+    component = _make_cpw_component()
+    return _make_sim(component, tmp_path, planar_conductors=True)
+
+
+class TestCPWMeshVolumetricConductors:
+    """Test mesh generation with volumetric (non-planar) conductors."""
+
+    def test_mesh_has_conductor_surfaces(self, volumetric_sim):
+        """Volumetric conductors must produce metal_xy and metal_z groups."""
+        groups = volumetric_sim._mesh_result.groups
+        conductor_names = list(groups["conductor_surfaces"].keys())
+        assert any("xy" in name for name in conductor_names), (
+            f"No _xy conductor surfaces found. Got: {conductor_names}"
+        )
+        assert any("z" in name for name in conductor_names), (
+            f"No _z conductor surfaces found. Got: {conductor_names}"
+        )
+
+    def test_mesh_has_volumes(self, volumetric_sim):
+        """Dielectric volumes must be present."""
+        groups = volumetric_sim._mesh_result.groups
+        assert len(groups["volumes"]) > 0, "No dielectric volumes found"
+
+    def test_mesh_has_port_surfaces(self, volumetric_sim):
+        """CPW ports must produce port surface groups."""
+        groups = volumetric_sim._mesh_result.groups
+        assert "P1" in groups["port_surfaces"], "Port P1 not found"
+        assert "P2" in groups["port_surfaces"], "Port P2 not found"
+        for port_name in ("P1", "P2"):
+            port = groups["port_surfaces"][port_name]
+            assert port["type"] == "cpw"
+            assert len(port["elements"]) >= 2, f"{port_name} should have >=2 elements"
+
+    def test_mesh_has_absorbing_boundary(self, volumetric_sim):
+        """Absorbing boundary surfaces must be present."""
+        groups = volumetric_sim._mesh_result.groups
+        assert "absorbing" in groups["boundary_surfaces"], "No absorbing boundary"
+
+    def test_config_json_valid(self, volumetric_sim):
+        """Generated config.json must have required Palace sections."""
+        volumetric_sim.write_config()
+        config_path = Path(volumetric_sim._output_dir) / "config.json"
+        assert config_path.exists()
+
+        config = json.loads(config_path.read_text())
+        assert config["Problem"]["Type"] == "Driven"
+        assert "Domains" in config
+        boundaries = config["Boundaries"]
+        assert "Conductivity" in boundaries, "Missing Conductivity boundary"
+        assert len(boundaries["Conductivity"]) > 0, "No conductor entries"
+        assert "LumpedPort" in boundaries, "Missing LumpedPort boundary"
+        assert len(boundaries["LumpedPort"]) == 2, "Expected 2 lumped ports"
+        assert "Absorbing" in boundaries, "Missing Absorbing boundary"
+
+
+class TestCPWMeshPlanarConductors:
+    """Test mesh generation with planar (PEC) conductors."""
+
+    def test_mesh_has_pec_surfaces(self, planar_sim):
+        """Planar conductors must produce PEC surface groups."""
+        groups = planar_sim._mesh_result.groups
+        assert len(groups["pec_surfaces"]) > 0, "No PEC surfaces found"
+
+    def test_config_json_has_pec(self, planar_sim):
+        """Config must include PEC boundary when using planar conductors."""
+        planar_sim.write_config()
+        config_path = Path(planar_sim._output_dir) / "config.json"
+        config = json.loads(config_path.read_text())
+        assert "PEC" in config["Boundaries"], "Missing PEC boundary"
+
+
+# ---------------------------------------------------------------------------
+# QPDK-style: zero-thickness superconductor on sapphire
+# ---------------------------------------------------------------------------
+
+QPDK_LAYER = (2, 0)
+SUBSTRATE_LAYER = (1, 0)
+VACUUM_LAYER = (3, 0)
+
+
+def _make_qpdk_component():
+    """Create a QPDK-style CPW with zero-thickness conductor on sapphire."""
+    gf.gpdk.PDK.activate()
+
+    @gf.cell
+    def qpdk_cpw(
+        length: float = 500,
+        s_width: float = 10,
+        g_width: float = 50,
+        gap_width: float = 6,
+    ) -> gf.Component:
+        c = gf.Component()
+        # Ground plane with gap (simplified: two ground strips + signal)
+        r1 = c << gf.c.rectangle((length, g_width), centered=True, layer=QPDK_LAYER)
+        r1.move((0, (g_width + s_width) / 2 + gap_width))
+        c << gf.c.rectangle((length, s_width), centered=True, layer=QPDK_LAYER)
+        r3 = c << gf.c.rectangle((length, g_width), centered=True, layer=QPDK_LAYER)
+        r3.move((0, -(g_width + s_width) / 2 - gap_width))
+
+        # Substrate and vacuum full-area rectangles
+        bbox_h = 2 * g_width + 2 * gap_width + s_width
+        for layer in (SUBSTRATE_LAYER, VACUUM_LAYER):
+            c << gf.c.rectangle((length, bbox_h), centered=True, layer=layer)
+
+        c.add_port(
+            name="o1",
+            center=(-length / 2, 0),
+            width=s_width,
+            orientation=0,
+            port_type="electrical",
+            layer=QPDK_LAYER,
+        )
+        c.add_port(
+            name="o2",
+            center=(length / 2, 0),
+            width=s_width,
+            orientation=180,
+            port_type="electrical",
+            layer=QPDK_LAYER,
+        )
+        return c
+
+    return qpdk_cpw()
+
+
+def _make_qpdk_stack():
+    """Build a sapphire + superconductor + vacuum stack (QPDK-style)."""
+    substrate_thickness = 500
+    stack = LayerStack()
+    stack.layers["sapphire"] = Layer(
+        name="sapphire",
+        gds_layer=SUBSTRATE_LAYER,
+        zmin=0,
+        zmax=substrate_thickness,
+        thickness=substrate_thickness,
+        material="sapphire",
+        layer_type="dielectric",
+        mesh_resolution="coarse",
+    )
+    stack.layers["superconductor"] = Layer(
+        name="superconductor",
+        gds_layer=QPDK_LAYER,
+        zmin=substrate_thickness,
+        zmax=substrate_thickness,
+        thickness=0,
+        material="niobium",
+        layer_type="conductor",
+        mesh_resolution="fine",
+    )
+    stack.layers["vacuum"] = Layer(
+        name="vacuum",
+        gds_layer=VACUUM_LAYER,
+        zmin=substrate_thickness,
+        zmax=substrate_thickness + 500,
+        thickness=500,
+        material="vacuum",
+        layer_type="dielectric",
+        mesh_resolution="coarse",
+    )
+    stack.dielectrics = [
+        {"material": "sapphire", "zmin": 0, "zmax": substrate_thickness},
+        {
+            "material": "vacuum",
+            "zmin": substrate_thickness,
+            "zmax": substrate_thickness + 500,
+        },
+    ]
+    stack.materials = {
+        "sapphire": {
+            "type": "dielectric",
+            "permittivity": 9.3,
+            "loss_tangent": 0.0,
+        },
+        "vacuum": {"type": "dielectric", "permittivity": 1.0, "loss_tangent": 0.0},
+        "niobium": {"type": "conductor", "conductivity": 0.0},
+    }
+    return stack
+
+
+def _make_qpdk_sim(component, stack, tmp_path):
+    """Create, configure, and mesh a QPDK-style DrivenSim."""
+    sim = DrivenSim()
+    sim.set_output_dir(str(tmp_path / "palace-sim-qpdk"))
+    sim.set_geometry(component)
+    sim.set_stack(stack)
+    sim.add_cpw_port("o1", layer="superconductor", s_width=10, gap_width=6, length=5.0)
+    sim.add_cpw_port("o2", layer="superconductor", s_width=10, gap_width=6, length=5.0)
+    sim.set_driven(fmin=5e9, fmax=10e9, num_points=20)
+    sim.mesh(preset="coarse", margin=0)
+    return sim
+
+
+@pytest.fixture(scope="module")
+def qpdk_sim(tmp_path_factory):
+    """Mesh once with QPDK-style zero-thickness conductors."""
+    tmp_path = tmp_path_factory.mktemp("qpdk")
+    component = _make_qpdk_component()
+    stack = _make_qpdk_stack()
+    return _make_qpdk_sim(component, stack, tmp_path)
+
+
+class TestQPDKMesh:
+    """Test mesh generation with QPDK-style zero-thickness conductors."""
+
+    def test_mesh_has_pec_surfaces(self, qpdk_sim):
+        """Zero-thickness conductors must produce PEC surface groups."""
+        groups = qpdk_sim._last_mesh_result.groups
+        assert len(groups["pec_surfaces"]) > 0, (
+            f"No PEC surfaces found. Got: {groups['pec_surfaces']}"
+        )
+
+    def test_mesh_has_volumes(self, qpdk_sim):
+        """Sapphire and vacuum volumes must be present."""
+        groups = qpdk_sim._last_mesh_result.groups
+        vol_names = list(groups["volumes"].keys())
+        assert len(vol_names) >= 2, f"Expected >= 2 volumes, got: {vol_names}"
+
+    def test_mesh_has_port_surfaces(self, qpdk_sim):
+        """CPW ports must produce port surface groups."""
+        groups = qpdk_sim._last_mesh_result.groups
+        assert "P1" in groups["port_surfaces"], "Port P1 not found"
+        assert "P2" in groups["port_surfaces"], "Port P2 not found"
+
+    def test_no_conductor_volume_surfaces(self, qpdk_sim):
+        """Zero-thickness conductors must NOT produce volumetric surfaces."""
+        groups = qpdk_sim._last_mesh_result.groups
+        assert len(groups["conductor_surfaces"]) == 0, (
+            f"Unexpected volumetric conductor surfaces: "
+            f"{list(groups['conductor_surfaces'].keys())}"
+        )
+
+    def test_config_json_has_pec_not_conductivity(self, qpdk_sim):
+        """Config must have PEC boundary (not Conductivity) for superconductors."""
+        qpdk_sim.write_config()
+        config_path = Path(qpdk_sim._output_dir) / "config.json"
+        config = json.loads(config_path.read_text())
+        boundaries = config["Boundaries"]
+        assert "PEC" in boundaries, "Missing PEC boundary for superconductor"
+        assert "LumpedPort" in boundaries, "Missing LumpedPort"
+        assert len(boundaries["LumpedPort"]) == 2, "Expected 2 lumped ports"
+
+    def test_validate_mesh_passes(self, qpdk_sim):
+        """validate_mesh() must pass for a valid QPDK setup."""
+        result = qpdk_sim.validate_mesh()
+        assert result.valid, f"Validation failed:\n{result}"


### PR DESCRIPTION
## Summary
The QPDK PR (#28) broke IHP demos by dropping volumetric conductor surfaces from the new boolean pipeline, and introduced duplicate physical groups that crashed Palace.

**Mesh fixes:**
- Add volumetric conductor shell surfaces (`_xy`/`_z`) to `build_entities()` — restores IHP metal visibility in `plot_mesh`
- Remove duplicate `_assign_interface_surfaces()` that created overlapping physical groups causing Palace crash (`face cannot have multiple boundary elements`)

**Validation:**
- Add `validate_mesh()` method to all sim classes — checks physical groups, ports, volumes, boundaries, and config.json structure
- Auto-validate in `DrivenSim.write_config()` before cloud submission — catches bad meshes before wasting cloud compute

**Tests (13 new, Linux CI only):**
- IHP-style: volumetric conductor surfaces, dielectric volumes, CPW ports, absorbing boundary, config.json
- QPDK-style: zero-thickness PEC surfaces, sapphire+vacuum volumes, no spurious volumetric surfaces, config PEC boundary

## Test plan
- [ ] Run `uv run pytest tests/` — 229 existing tests pass, 13 new skip on macOS
- [ ] Trigger docs workflow to verify notebook execution
- [ ] Verify IHP CPW demo meshes correctly with metal visible in plot_mesh