### PR TITLE
feat: add auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,5 @@ jobs:
       - name: Release GH
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: dist/*


### PR DESCRIPTION
## Summary
- Enable GitHub's built-in release notes generation on tag-triggered releases
- Add `.github/release.yml` to categorize PRs by label (features, bugs, docs, other)

## Test plan
- [ ] Push a tag and verify the GitHub Release page includes auto-generated notes

Generated with [Claude Code](https://claude.com/claude-code)