### PR TITLE
fix: add missing trame core package to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "plotly",
   "pydantic>=2.10.6",
   "pyvista>=0.43.0",
+  "trame",
   "trame-vtk",
   "trame-vuetify",
 ]


### PR DESCRIPTION
- Add `trame` to dependencies — `trame-vtk` and `trame-vuetify` were listed but the core package was missing