### PR TITLE
feat: auto-label PRs for categorized release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,8 @@
 changelog:
+  exclude:
+    authors:
+      - github-actions[bot]
+      - dependabot[bot]
   categories:
     - title: New Features
       labels:
@@ -6,6 +10,9 @@ changelog:
     - title: Bug Fixes
       labels:
         - bug
+    - title: Refactoring
+      labels:
+        - refactor
     - title: Documentation
       labels:
         - documentation

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,27 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened, edited]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const labels = [];
+            if (/^feat(\(.*?\))?[:!]/.test(title)) labels.push('enhancement');
+            else if (/^fix(\(.*?\))?[:!]/.test(title)) labels.push('bug');
+            else if (/^docs(\(.*?\))?[:!]/.test(title)) labels.push('documentation');
+            else if (/^refactor(\(.*?\))?[:!]/.test(title)) labels.push('refactor');
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels,
+              });
+            }


### PR DESCRIPTION
## Summary
- Add labeler workflow that auto-assigns labels (enhancement, bug, documentation, refactor) from PR title prefixes (feat:, fix:, docs:, refactor:)
- Update release.yml categories to include refactoring and exclude bot authors from contributor lists
- PRs without conventional prefixes fall into "Other Changes"