### PR TITLE
Implement surface booleans via occ.cut()

### DIFF
--- a/nbs/_palace_qpdk_qubit_resonator.ipynb
+++ b/nbs/_palace_qpdk_qubit_resonator.ipynb
@@ -131,9 +131,7 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "### Configure eigenmode simulation\n",
-    "\n",
-    "The junction port is modelled as a lumped element with a 10 nH inductance."
+    "### Configure Simulation"
    ]
   },
   {
@@ -143,19 +141,65 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gsim.palace import EigenmodeSim\n",
+    "from gsim.common.stack import Layer, LayerStack\n",
+    "from gsim.common.stack.materials import MATERIALS_DB\n",
+    "from gsim.palace import DrivenSim\n",
     "\n",
-    "sim = EigenmodeSim()\n",
+    "# Build a CPW stack matching the etched component layers\n",
+    "substrate_thickness = 500\n",
+    "vacuum_thickness = 500\n",
+    "\n",
+    "stack = LayerStack(pdk_name=\"qpdk\")\n",
+    "stack.layers[\"SUBSTRATE\"] = Layer(\n",
+    "    name=\"SUBSTRATE\",\n",
+    "    gds_layer=(1, 0),\n",
+    "    zmin=0.0,\n",
+    "    zmax=substrate_thickness,\n",
+    "    thickness=substrate_thickness,\n",
+    "    material=\"sapphire\",\n",
+    "    layer_type=\"dielectric\",\n",
+    ")\n",
+    "stack.layers[\"SUPERCONDUCTOR\"] = Layer(\n",
+    "    name=\"SUPERCONDUCTOR\",\n",
+    "    gds_layer=(2, 0),\n",
+    "    zmin=substrate_thickness,\n",
+    "    zmax=substrate_thickness,\n",
+    "    thickness=0,\n",
+    "    material=\"aluminum\",\n",
+    "    layer_type=\"conductor\",\n",
+    ")\n",
+    "stack.layers[\"VACUUM\"] = Layer(\n",
+    "    name=\"VACUUM\",\n",
+    "    gds_layer=(3, 0),\n",
+    "    zmin=substrate_thickness,\n",
+    "    zmax=substrate_thickness + vacuum_thickness,\n",
+    "    thickness=vacuum_thickness,\n",
+    "    material=\"vacuum\",\n",
+    "    layer_type=\"dielectric\",\n",
+    ")\n",
+    "stack.dielectrics = [\n",
+    "    {\n",
+    "        \"name\": \"substrate\",\n",
+    "        \"zmin\": 0.0,\n",
+    "        \"zmax\": substrate_thickness,\n",
+    "        \"material\": \"sapphire\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"name\": \"vacuum\",\n",
+    "        \"zmin\": substrate_thickness,\n",
+    "        \"zmax\": substrate_thickness + vacuum_thickness,\n",
+    "        \"material\": \"vacuum\",\n",
+    "    },\n",
+    "]\n",
+    "stack.materials = {\n",
+    "    \"sapphire\": MATERIALS_DB[\"sapphire\"].to_dict(),\n",
+    "    \"aluminum\": MATERIALS_DB[\"aluminum\"].to_dict(),\n",
+    "    \"vacuum\": MATERIALS_DB[\"vacuum\"].to_dict(),\n",
+    "}\n",
+    "\n",
+    "sim = DrivenSim()\n",
     "sim.set_geometry(etched)\n",
-    "sim.set_stack(substrate_thickness=500, air_above=500)\n",
-    "\n",
-    "# Junction port with 10 nH inductance\n",
-    "sim.add_port(\"junction\", layer=\"SUPERCONDUCTOR\", length=5.0, inductance=10e-9)\n",
-    "\n",
-    "# CPW feed ports\n",
-    "sim.add_cpw_port(\"o1\", layer=\"SUPERCONDUCTOR\", s_width=10.0, gap_width=6.0, length=5.0)\n",
-    "\n",
-    "sim.set_eigenmode(target=5e9, num_modes=3)"
+    "sim.set_stack(stack)"
    ]
   },
   {
@@ -163,7 +207,9 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "### Mesh and run"
+    "### Configure eigenmode simulation\n",
+    "\n",
+    "The junction port is modelled as a lumped element with a 10 nH inductance."
    ]
   },
   {
@@ -173,27 +219,57 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim.set_output_dir(\"./sim_qpdk_qubit_resonator\")\n",
-    "sim.mesh(preset=\"coarse\")\n",
-    "sim.plot_mesh()"
+    "# Junction port with 10 nH inductance\n",
+    "sim.add_port(\"junction\", layer=\"SUPERCONDUCTOR\", length=5.0, inductance=10e-9)\n",
+    "\n",
+    "# CPW feed ports\n",
+    "sim.add_cpw_port(\"o1\", layer=\"SUPERCONDUCTOR\", s_width=10.0, gap_width=6.0, length=5.0)\n",
+    "\n",
+    "sim.set_driven(fmin=7.75e9, fmax=7.8e9, num_points=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "### Mesh and run"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
-    "results = sim.run()\n",
-    "\n",
-    "if results.ok:\n",
-    "    print(\"Eigenvalues\")\n",
-    "    print(f\"{'Freq (GHz)':<16} {'Q':<16}\")\n",
-    "    for ev in results.eigenvalues:\n",
-    "        print(f\"{ev.freq:<16.4f} {ev.quality_factor:<16.4f}\")\n",
-    "else:\n",
-    "    print(\"Simulation failed:\", results.error_msg)"
+    "sim.set_output_dir(\"./sim_qpdk_qubit_resonator\")\n",
+    "sim.mesh(preset=\"graded\", margin=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.plot_mesh(\n",
+    "    style=\"solid\",\n",
+    "    interactive=True,\n",
+    "    transparent_groups=[\"vacuum__None\", \"sapphire__None\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.write_config()\n",
+    "results = sim.run_local()"
    ]
   }
  ],

--- a/src/gsim/palace/mesh/gmsh_utils.py
+++ b/src/gsim/palace/mesh/gmsh_utils.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import math
 
 import gmsh
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Minimalistic meshwell-style entity + boolean pipeline
@@ -251,6 +254,33 @@ def create_box(
     return volumetag
 
 
+def _create_wire_loop(
+    kernel,
+    pts_x: list[float],
+    pts_y: list[float],
+    z: float,
+    meshseed: float = 0,
+) -> int | None:
+    """Create a closed curve loop from polygon vertices.
+
+    Returns:
+        Curve loop tag, or None if fewer than 3 valid edges.
+    """
+    verts = [
+        kernel.addPoint(pts_x[v], pts_y[v], z, meshseed, -1) for v in range(len(pts_x))
+    ]
+    lines = []
+    for v in range(len(verts)):
+        try:
+            ltag = kernel.addLine(verts[v], verts[(v + 1) % len(verts)], -1)
+            lines.append(ltag)
+        except Exception:
+            pass  # Skip degenerate (zero-length) lines
+    if len(lines) < 3:
+        return None
+    return kernel.addCurveLoop(lines, tag=-1)
+
+
 def create_polygon_surface(
     kernel,
     pts_x: list[float],
@@ -260,6 +290,10 @@ def create_polygon_surface(
     holes: list[tuple[list[float], list[float]]] | None = None,
 ) -> int | None:
     """Create a planar surface from polygon vertices at z height.
+
+    Holes are removed via ``occ.cut()`` for robustness — the OCC kernel
+    handles boolean subtraction more reliably than passing multiple curve
+    loops to ``addPlaneSurface``.
 
     Args:
         kernel: gmsh.model.occ kernel
@@ -272,55 +306,42 @@ def create_polygon_surface(
     Returns:
         Surface tag, or None if polygon is invalid
     """
-    numvertices = len(pts_x)
-    if numvertices < 3:
+    if len(pts_x) < 3:
         return None
 
-    linetaglist = []
-    vertextaglist = []
-
-    # Create vertices
-    for v in range(numvertices):
-        vertextag = kernel.addPoint(pts_x[v], pts_y[v], z, meshseed, -1)
-        vertextaglist.append(vertextag)
-
-    # Create lines connecting vertices
-    for v in range(numvertices):
-        pt_start = vertextaglist[v]
-        pt_end = vertextaglist[(v + 1) % numvertices]
-        try:
-            linetag = kernel.addLine(pt_start, pt_end, -1)
-            linetaglist.append(linetag)
-        except Exception:
-            pass  # Skip degenerate lines
-
-    if len(linetaglist) < 3:
+    exterior_loop = _create_wire_loop(kernel, pts_x, pts_y, z, meshseed)
+    if exterior_loop is None:
         return None
 
-    # Create outer curve loop
-    curvetag = kernel.addCurveLoop(linetaglist, tag=-1)
+    exterior_surf = kernel.addPlaneSurface([exterior_loop], tag=-1)
 
-    # Create hole curve loops
-    all_loops = [curvetag]
-    for hx, hy in holes or []:
-        hole_lines = []
-        hole_verts = []
-        for v in range(len(hx)):
-            vtag = kernel.addPoint(hx[v], hy[v], z, meshseed, -1)
-            hole_verts.append(vtag)
-        for v in range(len(hx)):
-            try:
-                ltag = kernel.addLine(hole_verts[v], hole_verts[(v + 1) % len(hx)], -1)
-                hole_lines.append(ltag)
-            except Exception:
-                pass
-        if len(hole_lines) >= 3:
-            hole_loop = kernel.addCurveLoop(hole_lines, tag=-1)
-            all_loops.append(hole_loop)
+    if not holes:
+        return exterior_surf
 
-    surfacetag = kernel.addPlaneSurface(all_loops, tag=-1)
+    # Build hole surfaces and subtract them via boolean cut
+    hole_dimtags: list[tuple[int, int]] = []
+    for hx, hy in holes:
+        hloop = _create_wire_loop(kernel, list(hx), list(hy), z, meshseed)
+        if hloop is not None:
+            hsurf = kernel.addPlaneSurface([hloop], tag=-1)
+            hole_dimtags.append((2, hsurf))
 
-    return surfacetag
+    if not hole_dimtags:
+        return exterior_surf
+
+    result, _ = kernel.cut(
+        [(2, exterior_surf)],
+        hole_dimtags,
+        removeObject=True,
+        removeTool=True,
+    )
+    kernel.synchronize()
+
+    if result:
+        return result[0][1]
+
+    logger.warning("Boolean cut for polygon holes returned empty result")
+    return None
 
 
 def extrude_polygon(


### PR DESCRIPTION
For complex surfaces with holes like what we have in the transmon example, the current implementation was adding surfaces with loops. However, OCC wasn't performing any cuts, so for robustness we should do the cuts explicitly.

This fixes the meshing issues in the transmon example, which was only showing a large superconductor region:

<img width="918" height="530" alt="transmon_mesh" src="https://github.com/user-attachments/assets/a1084433-8d22-41e5-952b-c8912bd88888" />
