### PR TITLE
Add inplane port offset

### DIFF
--- a/src/gsim/palace/driven.py
+++ b/src/gsim/palace/driven.py
@@ -108,6 +108,7 @@ class DrivenSim(PalaceSimMixin, BaseModel):
         from_layer: str | None = None,
         to_layer: str | None = None,
         length: float | None = None,
+        offset: float = 0.0,
         impedance: float = 50.0,
         resistance: float | None = None,
         inductance: float | None = None,
@@ -123,6 +124,8 @@ class DrivenSim(PalaceSimMixin, BaseModel):
             from_layer: Bottom layer for via ports
             to_layer: Top layer for via ports
             length: Port extent along direction (um)
+            offset: Shift the port inward along the waveguide (um).
+                Positive moves away from the boundary, into the conductor.
             impedance: Port impedance (Ohms)
             resistance: Series resistance (Ohms)
             inductance: Series inductance (H)
@@ -132,6 +135,7 @@ class DrivenSim(PalaceSimMixin, BaseModel):
 
         Example:
             >>> sim.add_port("o1", layer="topmetal2", length=5.0)
+            >>> sim.add_port("o1", layer="topmetal2", length=5.0, offset=2.0)
             >>> sim.add_port(
             ...     "feed", from_layer="metal1", to_layer="topmetal2", geometry="via"
             ... )
@@ -146,6 +150,7 @@ class DrivenSim(PalaceSimMixin, BaseModel):
                 from_layer=from_layer,
                 to_layer=to_layer,
                 length=length,
+                offset=offset,
                 impedance=impedance,
                 resistance=resistance,
                 inductance=inductance,
@@ -374,6 +379,7 @@ class DrivenSim(PalaceSimMixin, BaseModel):
                     length=port_config.length or gf_port.width,
                     impedance=port_config.impedance,
                     excited=port_config.excited,
+                    offset=port_config.offset,
                 )
             elif port_config.geometry == "via" and (
                 port_config.from_layer is not None and port_config.to_layer is not None

--- a/src/gsim/palace/eigenmode.py
+++ b/src/gsim/palace/eigenmode.py
@@ -97,6 +97,7 @@ class EigenmodeSim(PalaceSimMixin, BaseModel):
         from_layer: str | None = None,
         to_layer: str | None = None,
         length: float | None = None,
+        offset: float = 0.0,
         impedance: float = 50.0,
         resistance: float | None = None,
         inductance: float | None = None,
@@ -112,6 +113,8 @@ class EigenmodeSim(PalaceSimMixin, BaseModel):
             from_layer: Bottom layer for via ports
             to_layer: Top layer for via ports
             length: Port extent along direction (um)
+            offset: Shift the port inward along the waveguide (um).
+                Positive moves away from the boundary, into the conductor.
             impedance: Port impedance (Ohms)
             resistance: Series resistance (Ohms)
             inductance: Series inductance (H)
@@ -121,6 +124,7 @@ class EigenmodeSim(PalaceSimMixin, BaseModel):
 
         Example:
             >>> sim.add_port("o1", layer="topmetal2", length=5.0)
+            >>> sim.add_port("o1", layer="topmetal2", length=5.0, offset=2.0)
             >>> sim.add_port(
             ...     "junction", layer="SUPERCONDUCTOR", length=5.0, inductance=10e-9
             ... )
@@ -133,6 +137,7 @@ class EigenmodeSim(PalaceSimMixin, BaseModel):
                 from_layer=from_layer,
                 to_layer=to_layer,
                 length=length,
+                offset=offset,
                 impedance=impedance,
                 resistance=resistance,
                 inductance=inductance,
@@ -298,6 +303,7 @@ class EigenmodeSim(PalaceSimMixin, BaseModel):
                     length=port_config.length or gf_port.width,
                     impedance=port_config.impedance,
                     excited=port_config.excited,
+                    offset=port_config.offset,
                 )
             elif port_config.geometry == "via" and (
                 port_config.from_layer is not None and port_config.to_layer is not None

--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -734,7 +734,7 @@ def build_entities(
                 Entity(
                     name=port_name,
                     dim=2,
-                    mesh_order=1,
+                    mesh_order=-1,
                     tags=surf_tags,
                 )
             )

--- a/src/gsim/palace/models/ports.py
+++ b/src/gsim/palace/models/ports.py
@@ -26,6 +26,8 @@ class PortConfig(BaseModel):
         from_layer: Bottom layer for via ports
         to_layer: Top layer for via ports
         length: Port extent along direction (um)
+        offset: Shift the port along the waveguide direction (um).
+            Positive moves in the port orientation direction.
         impedance: Port impedance (Ohms)
         excited: Whether this port is excited
         geometry: Port geometry type ("inplane" or "via")
@@ -48,6 +50,11 @@ class PortConfig(BaseModel):
     )
     excited: bool = True
     geometry: Literal["inplane", "via"] = "inplane"
+    offset: float = Field(
+        default=0.0,
+        description="Shift port inward along the waveguide (um). "
+        "Positive moves away from the boundary, into the conductor.",
+    )
 
     @model_validator(mode="after")
     def validate_layer_config(self) -> Self:

--- a/src/gsim/palace/ports/config.py
+++ b/src/gsim/palace/ports/config.py
@@ -87,6 +87,7 @@ def configure_inplane_port(
     length: float,
     impedance: float = 50.0,
     excited: bool = True,
+    offset: float = 0.0,
 ):
     """Configure gdsfactory port(s) as inplane (lumped) ports for Palace simulation.
 
@@ -99,10 +100,13 @@ def configure_inplane_port(
         length: Port extent along direction in um (perpendicular to port width)
         impedance: Port impedance in Ohms (default: 50)
         excited: Whether port is excited vs just measured (default: True)
+        offset: Shift port inward along the waveguide (um).
+            Positive moves away from the boundary, into the conductor.
 
     Examples:
         ```python
         configure_inplane_port(c.ports["o1"], layer="topmetal2", length=5.0)
+        configure_inplane_port(c.ports["o1"], layer="topmetal2", length=5.0, offset=2.0)
         configure_inplane_port(c.ports, layer="topmetal2", length=5.0)  # all ports
         ```
     """
@@ -115,6 +119,8 @@ def configure_inplane_port(
         port.info["length"] = length
         port.info["impedance"] = impedance
         port.info["excited"] = excited
+        port.info["offset"] = offset
+
 
 
 def configure_via_port(
@@ -336,6 +342,20 @@ def extract_ports(component, stack: LayerStack) -> list[PalacePort]:
                     layer = stack.layers[layer_name]
                     zmin = layer.zmin
                     zmax = layer.zmax
+                
+                # Apply longitudinal offset for inplane ports
+                offset = info.get("offset", 0.0)
+                if offset != 0.0:
+                    import numpy as np
+
+                    orientation_rad = np.deg2rad(
+                        float(port.orientation) if port.orientation is not None else 0.0
+                    )
+                    longitudinal = np.array(
+                        [np.cos(orientation_rad), np.sin(orientation_rad)]
+                    )
+                    shifted = np.array([center[0], center[1]]) - longitudinal * offset
+                    center = (float(shifted[0]), float(shifted[1]))
             else:
                 raise ValueError(f"Lumped port '{port.name}' missing layer info")
 


### PR DESCRIPTION
## Summary

Motivated by Bug 3 in [`gdsfactory/gsim#52`](https://github.com/gdsfactory/gsim/issues/52), this PR adds an `offset` parameter to `add_port` for `geometry="inplane"`, consistent with the existing behavior in `add_cpw_port`.

## What `offset` does

When adding an inplane port, the port face is by default placed at the gdsfactory port center — typically at the domain boundary. `offset` shifts the port center inward along the longitudinal direction (away from the boundary, into the component), allowing the port face to be placed at a specific position along the feed trace rather than at its end.

A positive offset moves the port away from the domain boundary and into the component, mirroring the behavior already available for CPW ports.

## Changes

The implementation follows the same pattern as `add_cpw_port`.

### `src/gsim/palace/mesh/geometry.py`

At line 737, `mesh_order` for non-CPW port surfaces was changed from `1` to `-1`. In Gmsh, `mesh_order` controls the priority with which physical groups are assigned to mesh entities — a lower value means higher priority. With `mesh_order=1`, offset inplane port surfaces were being processed at the same priority as CPW port elements, causing them to be overridden or missed during mesh entity assignment. Setting `mesh_order=-1` gives them the highest priority, ensuring the port surface is correctly embedded and named in the mesh regardless of its position relative to other surfaces.