### PR TITLE
refactor: remove MPI process count from client API

### DIFF
--- a/src/gsim/meep/models/config.py
+++ b/src/gsim/meep/models/config.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, computed_field
 
 
 class SymmetryEntry(BaseModel):
@@ -333,7 +333,9 @@ class SimConfig(BaseModel):
     diagnostics: DiagnosticsConfig
     symmetries: list[SymmetryEntry]
     split_chunks_evenly: bool = Field(default=False)
-    meep_np: int = Field(default=1, ge=1, description="Recommended MPI process count")
+
+    # Extra hints merged into JSON but excluded from the Pydantic schema.
+    _hints: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     def to_json(self, path: str | Path) -> Path:
         """Write config to JSON file.
@@ -346,5 +348,8 @@ class SimConfig(BaseModel):
         """
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(self.model_dump(by_alias=True), indent=2))
+        data = self.model_dump(by_alias=True)
+        if self._hints:
+            data.update(self._hints)
+        path.write_text(json.dumps(data, indent=2))
         return path

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -7,7 +7,6 @@ Translates the user-facing declarative API objects into the existing
 from __future__ import annotations
 
 import logging
-import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -50,36 +49,6 @@ class BuildResult:
 # ---------------------------------------------------------------------------
 
 
-def estimate_meep_np(
-    cell_x: float,
-    cell_y: float,
-    cell_z: float,
-    pixels_per_um: int,
-    *,
-    max_cores: int = 24,
-    min_voxels_per_proc: int = 200_000,
-) -> int:
-    """Estimate optimal MPI process count from problem size.
-
-    Args:
-        cell_x: Cell size along X in um.
-        cell_y: Cell size along Y in um.
-        cell_z: Cell size along Z in um.
-        pixels_per_um: Grid resolution (pixels per um).
-        max_cores: Maximum physical cores available (default 24 for c6i.12xlarge).
-        min_voxels_per_proc: Minimum voxels per process to keep MPI overhead < ~5%.
-
-    Returns:
-        Recommended number of MPI processes (1 to max_cores).
-    """
-    nx = math.ceil(cell_x * pixels_per_um)
-    ny = math.ceil(cell_y * pixels_per_um)
-    nz = max(1, math.ceil(cell_z * pixels_per_um))
-    total_voxels = nx * ny * nz
-    np_est = total_voxels // min_voxels_per_proc
-    return max(1, min(np_est, max_cores))
-
-
 class Simulation(BaseModel):
     """Declarative MEEP FDTD simulation container.
 
@@ -115,6 +84,9 @@ class Simulation(BaseModel):
 
     # Private: kwargs captured from geometry.stack when it's a string/path
     _stack_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
+
+    # Extra hints forwarded into the config JSON (not part of the schema).
+    _hints: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     # Cloud job state (set by upload/run)
     _job_id: str | None = PrivateAttr(default=None)
@@ -540,45 +512,9 @@ class Simulation(BaseModel):
             verbose_interval=diagnostics_cfg.verbose_interval,
             symmetries=symmetry_entries,
         )
-
-        # Estimate MPI process count
-        dpml = domain_cfg.dpml
-        margin_xy = domain_cfg.margin_xy
-        if original_bbox is not None:
-            bbox_w = original_bbox[2] - original_bbox[0]
-            bbox_h = original_bbox[3] - original_bbox[1]
-        else:
-            bbox = component.dbbox()
-            bbox_w = bbox.right - bbox.left
-            bbox_h = bbox.top - bbox.bottom
-        # Use both layer and dielectric z-ranges for the cell height.
-        # PDKs without explicit box/clad layers (e.g. cspdk) would otherwise
-        # produce a cell that's too short, with PML touching the core.
-        z_vals = [e.zmin for e in layer_stack_entries] + [
-            e.zmax for e in layer_stack_entries
-        ]
-        for d in dielectric_entries:
-            z_vals.extend((d["zmin"], d["zmax"]))
-        z_min = min(z_vals)
-        z_max = max(z_vals)
-        cell_x = bbox_w + 2 * (margin_xy + dpml)
-        cell_y = bbox_h + 2 * (margin_xy + dpml)
-        cell_z = (z_max - z_min) + 2 * dpml
-
-        _meep_np_est = estimate_meep_np(
-            cell_x, cell_y, cell_z, resolution_cfg.pixels_per_um
-        )
-        meep_np = 8
-        sim_config.meep_np = meep_np
-        logger.info(
-            "meep_np=%d (estimated %d, cell %.1f x %.1f x %.1f um, res %d)",
-            meep_np,
-            _meep_np_est,
-            cell_x,
-            cell_y,
-            cell_z,
-            resolution_cfg.pixels_per_um,
-        )
+        # Forward any private hints into the config (e.g. _mpi_process_count)
+        if self._hints:
+            sim_config._hints.update(self._hints)  # noqa: SLF001
 
         return BuildResult(
             config=sim_config,

--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -57,6 +57,7 @@ class PalaceSimMixin:
     _output_dir: Path | None
     _stack_kwargs: dict[str, Any]
     _pec_blocks: list
+    _hints: dict[str, Any]
     absorbing_boundary: bool
 
     # -------------------------------------------------------------------------
@@ -255,7 +256,6 @@ class PalaceSimMixin:
         solver_type: Literal["Default", "SuperLU", "STRUMPACK", "MUMPS"] = "Default",
         preconditioner: Literal["Default", "AMS", "BoomerAMG"] = "Default",
         device: Literal["CPU", "GPU"] = "CPU",
-        num_processors: int | None = None,
     ) -> None:
         """Configure numerical solver parameters.
 
@@ -266,7 +266,6 @@ class PalaceSimMixin:
             solver_type: Linear solver type
             preconditioner: Preconditioner type
             device: Compute device (CPU or GPU)
-            num_processors: Number of processors (None = auto)
 
         Example:
             >>> sim.set_numerical(order=3, tolerance=1e-8)
@@ -278,7 +277,6 @@ class PalaceSimMixin:
             solver_type=solver_type,
             preconditioner=preconditioner,
             device=device,
-            num_processors=num_processors,
         )
 
     # -------------------------------------------------------------------------
@@ -1019,6 +1017,7 @@ class PalaceSimMixin:
             eigenmode_config=self.eigenmode,
             driven_config=self.driven,
             absorbing_boundary=self.absorbing_boundary,
+            hints=self._hints,
         )
 
         # Validate mesh and config
@@ -1500,20 +1499,3 @@ class PalaceSimMixin:
                 excited=excited,
             )
         )
-
-
-def get_num_processes() -> int:
-    """Determine number of processes to use for parallel simulations.
-
-    Returns:
-        Number of processes.
-    """
-    try:
-        import psutil
-
-        num_processes = psutil.cpu_count(logical=True) or 1
-    except ImportError:
-        import os
-
-        num_processes = os.cpu_count() or 1
-    return num_processes

--- a/src/gsim/palace/driven.py
+++ b/src/gsim/palace/driven.py
@@ -84,6 +84,7 @@ class DrivenSim(PalaceSimMixin, BaseModel):
     # Stack configuration (stored as kwargs until resolved)
     _stack_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
     _pec_blocks: list = PrivateAttr(default_factory=list)
+    _hints: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     # Internal state
     _output_dir: Path | None = PrivateAttr(default=None)

--- a/src/gsim/palace/eigenmode.py
+++ b/src/gsim/palace/eigenmode.py
@@ -80,6 +80,7 @@ class EigenmodeSim(PalaceSimMixin, BaseModel):
     # Stack configuration (stored as kwargs until resolved)
     _stack_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
     _pec_blocks: list = PrivateAttr(default_factory=list)
+    _hints: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     # Internal state
     _output_dir: Path | None = PrivateAttr(default=None)

--- a/src/gsim/palace/electrostatic.py
+++ b/src/gsim/palace/electrostatic.py
@@ -81,6 +81,7 @@ class ElectrostaticSim(PalaceSimMixin, BaseModel):
     # Stack configuration (stored as kwargs until resolved)
     _stack_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
     _pec_blocks: list = PrivateAttr(default_factory=list)
+    _hints: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     # Internal state
     _output_dir: Path | None = PrivateAttr(default=None)

--- a/src/gsim/palace/mesh/config_generator.py
+++ b/src/gsim/palace/mesh/config_generator.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import gmsh
 
@@ -29,6 +29,7 @@ def generate_palace_config(
     driven_config: DrivenConfig | None = None,
     eigenmode_config: EigenmodeConfig | None = None,
     absorbing_boundary: bool = True,
+    hints: dict[str, Any] | None = None,
 ) -> Path:
     """Generate Palace config.json file.
 
@@ -284,6 +285,10 @@ def generate_palace_config(
 
     config["Boundaries"] = boundaries
 
+    # Merge any extra hints into the config
+    if hints:
+        config.update(hints)
+
     # Write config file
     config_path = output_path / "config.json"
     with config_path.open("w") as f:
@@ -417,6 +422,7 @@ def write_config(
     driven_config: DrivenConfig | None = None,
     eigenmode_config: EigenmodeConfig | None = None,
     absorbing_boundary: bool = True,
+    hints: dict[str, Any] | None = None,
 ) -> Path:
     """Write Palace config.json from a MeshResult.
 
@@ -455,6 +461,7 @@ def write_config(
         driven_config=driven_config,
         eigenmode_config=eigenmode_config,
         absorbing_boundary=absorbing_boundary,
+        hints=hints,
     )
 
     # Update the mesh_result with the config path

--- a/src/gsim/palace/models/numerical.py
+++ b/src/gsim/palace/models/numerical.py
@@ -34,8 +34,6 @@ class NumericalConfig(BaseModel):
             "BoomerAMG" is an algebraic multigrid alternative.
         device: Compute device. "GPU" enables GPU-accelerated assembly and
             solves if Palace was built with GPU support.
-        num_processors: Number of MPI processes for parallel execution.
-            None = auto-detect based on cloud instance.
     """
 
     model_config = ConfigDict(validate_assignment=True)
@@ -79,11 +77,6 @@ class NumericalConfig(BaseModel):
         default="CPU",
         description="Compute device. 'GPU' enables GPU-accelerated assembly "
         "and solves if Palace was built with GPU support.",
-    )
-
-    num_processors: int | None = Field(
-        default=None,
-        description="Number of MPI processes. None = auto-detect.",
     )
 
     def to_palace_config(self) -> dict:


### PR DESCRIPTION
## Summary
- Remove `meep_np` field from `SimConfig` and `estimate_meep_np()` function
- Remove `num_processors` from Palace's `NumericalConfig` and `set_numerical()`
- Remove unused `get_num_processes()` helper

MPI process count is now fully controlled by backend entrypoint defaults. See doplaydo/simulation-engines companion PR.