### PR TITLE
chore: pin gdsfactoryplus minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
   "gdsfactory~=9.39",
-  "gdsfactoryplus",
+  "gdsfactoryplus>=1.6.4",
   "gmsh",
   "meshio>=5.0.0",
   "plotly",


### PR DESCRIPTION
## Summary
- Pin `gdsfactoryplus>=1.6.4` — previously unpinned, now requires the minimum version needed for log streaming support.