### PR TITLE
ci: add test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libglu1-mesa libgl1-mesa-glx libxrender1 libxcursor1 libxft2 libxinerama1
       - name: Install UV
         uses: astral-sh/setup-uv@v6
       - name: Create environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libglu1-mesa libgl1-mesa-glx libxrender1 libxcursor1 libxft2 libxinerama1
+        run: sudo apt-get update && sudo apt-get install -y libglu1-mesa libegl1 libgl1 libxrender1 libxcursor1 libxft2 libxinerama1
       - name: Install UV
         uses: astral-sh/setup-uv@v6
       - name: Create environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+      - name: Create environment
+        run: uv sync --dev --all-extras
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that runs pytest on PRs and pushes to main
- Uses uv for dependency management, matching the existing pre-commit workflow

## Test plan
- [ ] Verify the workflow triggers on a PR
- [ ] Verify pytest runs successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)