### PR TITLE
fix(mesh): correctly re-identify conductor volumes after dedup and re…

### DIFF
--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -314,9 +314,12 @@ def add_metals(
                     # Defer shell extraction until after removeAllDuplicates
                     _conductor_volumes.setdefault(layer_name, []).append(volumetag)
 
-    # Record bounding boxes of via volumes BEFORE removeAllDuplicates
-    # so we can re-identify them after tags get renumbered.
+    # Record bounding boxes of BOTH via and conductor volumes BEFORE
+    # removeAllDuplicates. That call renumbers ALL entity tags globally —
+    # not just the ones it merges — so original tags are never trustworthy
+    # afterwards. We re-identify volumes by bbox after the call.
     _via_bboxes: dict[str, list[tuple[float, ...]]] = {}
+    _conductor_bboxes: dict[str, list[tuple[float, ...]]] = {}
     kernel.synchronize()
     for layer_name, tag_info in metal_tags.items():
         for vtag in tag_info["volumes"]:
@@ -324,35 +327,65 @@ def add_metals(
                 bbox = kernel.getBoundingBox(3, vtag)
                 _via_bboxes.setdefault(layer_name, []).append(bbox)
 
+    for layer_name, vol_tags in _conductor_volumes.items():
+        for vtag in vol_tags:
+            try:
+                bbox = kernel.getBoundingBox(3, vtag)
+                _conductor_bboxes.setdefault(layer_name, []).append(bbox)
+            except Exception:
+                logger.debug(
+                    "Could not get bbox for conductor volume %d, skipping", vtag
+                )
+
     kernel.removeAllDuplicates()
     kernel.synchronize()
 
-    # Re-identify via volumes by matching bounding boxes
+    # Build a single bbox lookup for all post-dedup volumes (avoids O(n²) calls).
     all_vols = kernel.getEntities(3)
+    all_vol_bboxes: dict[int, tuple] = {}
+    for _, vtag in all_vols:
+        try:
+            all_vol_bboxes[vtag] = kernel.getBoundingBox(3, vtag)
+        except Exception:
+            logger.debug("Could not get bbox for volume %d after dedup", vtag)
+
+    # Re-identify via volumes by matching bounding boxes.
     for layer_name, bboxes in _via_bboxes.items():
         metal_tags[layer_name]["volumes"] = []
         for target_bbox in bboxes:
-            for _, vtag in all_vols:
-                try:
-                    bbox = kernel.getBoundingBox(3, vtag)
-                except Exception:
-                    logger.debug("Could not get bbox for volume %d, skipping", vtag)
-                    continue
+            for vtag, bbox in all_vol_bboxes.items():
                 if all(
                     abs(a - b) < 0.01 for a, b in zip(bbox, target_bbox, strict=True)
                 ):
                     metal_tags[layer_name]["volumes"].append(vtag)
                     break
 
-    # Extract shell surfaces from conductor volumes.
-    # After removeAllDuplicates, some volume tags may have been invalidated
-    # (e.g., a conductor volume that shared faces with a via volume).
-    current_vols = {t for _, t in kernel.getEntities(3)}
+    # Re-identify conductor volumes by bbox and update _conductor_volumes.
+    # Without this, removeAllDuplicates()'s global renumbering makes every
+    # original tag appear missing, so all conductors are silently dropped.
+    for layer_name, bboxes in _conductor_bboxes.items():
+        new_vol_tags = []
+        for target_bbox in bboxes:
+            for vtag, bbox in all_vol_bboxes.items():
+                if all(
+                    abs(a - b) < 0.01 for a, b in zip(bbox, target_bbox, strict=True)
+                ):
+                    new_vol_tags.append(vtag)
+                    break
+            else:
+                logger.warning(
+                    "Conductor volume on %s lost during dedup (no bbox match)",
+                    layer_name,
+                )
+        _conductor_volumes[layer_name] = new_vol_tags
+
+    # Extract shell surfaces from conductor volumes (now with correct post-dedup tags).
+    current_vols = {t for _, t in all_vols}
     for layer_name, vol_tags in _conductor_volumes.items():
         for volumetag in vol_tags:
             if volumetag not in current_vols:
                 logger.warning(
-                    "Conductor volume %d on %s invalidated by dedup",
+                    "Conductor volume %d on %s missing after bbox re-identification",
                     volumetag,
                     layer_name,
                 )

--- a/src/gsim/palace/mesh/gmsh_utils.py
+++ b/src/gsim/palace/mesh/gmsh_utils.py
@@ -105,7 +105,46 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
 
             processed_in_dim = [e for e in current_group if e.dimtags]
         else:
-            # Keep existing priority-cut logic for dim=2,1,0
+            # --- Pre-step: fragment current-dim entities against higher-dim
+            # entities BEFORE priority cuts.
+            #
+            # The dim=3 fragment can merge floating conductor surfaces that are
+            # coincident with dielectric volume faces, assigning them new tags.
+            # If priority cuts run first (with the old tags), OCC raises
+            # "Unknown entity of dimension N with tag T".  Fragmenting against
+            # the higher-dim entities here refreshes all surface tags so the
+            # subsequent priority cuts operate on valid geometry.
+            if processed_higher_dims:
+                object_dimtags = [dt for e in current_group for dt in e.dimtags]
+                tool_dimtags_hd = [
+                    dt for e in processed_higher_dims for dt in e.dimtags
+                ]
+
+                if object_dimtags and tool_dimtags_hd:
+                    _, out_map = gmsh.model.occ.fragment(
+                        object_dimtags,
+                        tool_dimtags_hd,
+                        removeObject=True,
+                        removeTool=True,
+                    )
+                    gmsh.model.occ.synchronize()
+
+                    idx = 0
+                    for entity in current_group:
+                        new_dimtags: list[tuple[int, int]] = []
+                        for _ in entity.dimtags:
+                            new_dimtags.extend(out_map[idx])
+                            idx += 1
+                        entity.dimtags = list(set(new_dimtags))
+
+                    for entity in processed_higher_dims:
+                        new_dimtags = []
+                        for _ in entity.dimtags:
+                            new_dimtags.extend(out_map[idx])
+                            idx += 1
+                        entity.dimtags = list(set(new_dimtags))
+
+            # Priority cuts among same-dim entities (tags are now fresh).
             for entity in current_group:
                 tool_dimtags = [dt for prev in processed_in_dim for dt in prev.dimtags]
 
@@ -123,7 +162,11 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
                     processed_in_dim.append(entity)
 
         # --- B. Fragment against higher dimensions ---
-        if processed_higher_dims and processed_in_dim:
+        # For dim < 3 this was already done in the pre-step above, so
+        # processed_higher_dims dimtags are already up to date.
+        # For dim == 3 processed_higher_dims is always empty (first iteration),
+        # so this block is effectively a no-op in all cases — kept for clarity.
+        if processed_higher_dims and processed_in_dim and dim == 3:
             object_dimtags = [dt for e in processed_in_dim for dt in e.dimtags]
             tool_dimtags = [dt for e in processed_higher_dims for dt in e.dimtags]
 
@@ -135,7 +178,6 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
             )
             gmsh.model.occ.synchronize()
 
-            # Update tags using the mapping
             idx = 0
             for entity in processed_in_dim:
                 new_dimtags: list[tuple[int, int]] = []


### PR DESCRIPTION
This seems to resolve the meshing issues I have in https://github.com/doplaydo/neurophos/issues/19. The changes seem to be substantial though:


removeAllDuplicates() renumbers ALL entity tags globally, not just the ones it merges. Conductor volumes were only checked by original tag (unlike via volumes which used bbox re-identification), so every conductor appeared "invalidated" and was silently dropped from the mesh.

Fix 1 (geometry.py): Save bounding boxes for conductor volumes before removeAllDuplicates() and re-identify them by bbox afterwards, matching the existing pattern used for via volumes.

Fix 2 (gmsh_utils.py): The dim=3 fragment can merge floating conductor surfaces that are coincident with dielectric volume faces, assigning them new OCC tags. The subsequent dim=2 priority cuts then failed with "Unknown OpenCASCADE entity of dimension 2 with tag N". Move the fragment-against-higher-dims step to run BEFORE priority cuts so that all surface tags are refreshed from the fragment output map before any cut is attempted.