### PR TITLE
fix(stack): respect PDK layer_type metadata in extract_layer_stack

### DIFF
--- a/src/gsim/common/stack/extractor.py
+++ b/src/gsim/common/stack/extractor.py
@@ -356,7 +356,9 @@ def extract_layer_stack(
         zmax = zmin + thickness
         material = layer_level.material or "unknown"
         gds_layer = get_gds_layer_tuple(layer_level) or (0, 0)
-        layer_type = classify_layer_type(layer_name, material)
+        # Check for explicit layer_type in LayerLevel.info (PDK override)
+        info = getattr(layer_level, "info", None) or {}
+        layer_type = info.get("layer_type") or classify_layer_type(layer_name, material)
         sidewall_angle = getattr(layer_level, "sidewall_angle", 0.0) or 0.0
 
         if layer_type == "substrate" and not include_substrate:

--- a/src/gsim/palace/mesh/config_generator.py
+++ b/src/gsim/palace/mesh/config_generator.py
@@ -161,15 +161,10 @@ def generate_palace_config(
             mat_entry["Permittivity"] = 1.0
             mat_entry["LossTan"] = 0.0
         elif is_via:
-            # Merged via volumes get anisotropic conductivity:
-            # reduced lateral (xy) conductivity prevents unrealistic
-            # horizontal current flow through the merged block.
-            _VIA_LATERAL_FACTOR = 10
             sigma = mat_props.get("conductivity", 0.0)
             mat_entry["Permittivity"] = 1.0
             if sigma > 0:
-                xy_sigma = sigma / _VIA_LATERAL_FACTOR
-                mat_entry["Conductivity"] = [xy_sigma, xy_sigma, sigma]
+                mat_entry["Conductivity"] = sigma
         else:
             # Use anisotropic tensor values when available
             if "permittivity_diagonal" in mat_props:

--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -2,6 +2,14 @@
 
 This module handles extracting polygons from gdsfactory components
 and creating 3D geometry in gmsh.
+
+TODO: Via meshing improvements (tracked 2026-04-14)
+  - Via volumes should use conductivity values from the stack/PDK.
+    The PDK layer_stack should define material/conductivity per via layer.
+  - If conductivity info is missing: warn/log and fall back to 2D PEC surface.
+  - If via is too thin to mesh as 3D (below min_volume_thickness): warn/log
+    and fall back to 2D PEC surface.
+  - Currently all vias are forced to PEC surfaces for testing (line ~293).
 """
 
 from __future__ import annotations
@@ -285,8 +293,15 @@ def add_metals(
         if not surfaces:
             continue
 
-        if layer_type == "conductor" and (planar_conductors or thickness == 0):
-            # Zero-thickness or explicitly planar → 2D PEC surface
+        min_volume_thickness = 0.05  # um — thinner volumes can't mesh as 3D
+        is_planar = (
+            planar_conductors or thickness == 0 or thickness < min_volume_thickness
+        )
+        if layer_type == "conductor" and is_planar:
+            # Zero/thin-thickness or explicitly planar → 2D PEC surface
+            metal_tags[layer_name]["surfaces_xy"].extend(surfaces)
+        elif layer_type == "via":
+            # Force all vias to 2D PEC surfaces (test)
             metal_tags[layer_name]["surfaces_xy"].extend(surfaces)
         elif thickness > 0:
             # Fuse overlapping same-layer surfaces before extrusion so that

--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -314,9 +314,12 @@ def add_metals(
                     # Defer shell extraction until after removeAllDuplicates
                     _conductor_volumes.setdefault(layer_name, []).append(volumetag)
 
-    # Record bounding boxes of via volumes BEFORE removeAllDuplicates
-    # so we can re-identify them after tags get renumbered.
+    # Record bounding boxes of BOTH via and conductor volumes BEFORE
+    # removeAllDuplicates. That call renumbers ALL entity tags globally —
+    # not just the ones it merges — so original tags are never trustworthy
+    # afterwards. We re-identify volumes by bbox after the call.
     _via_bboxes: dict[str, list[tuple[float, ...]]] = {}
+    _conductor_bboxes: dict[str, list[tuple[float, ...]]] = {}
     kernel.synchronize()
     for layer_name, tag_info in metal_tags.items():
         for vtag in tag_info["volumes"]:
@@ -324,35 +327,65 @@ def add_metals(
                 bbox = kernel.getBoundingBox(3, vtag)
                 _via_bboxes.setdefault(layer_name, []).append(bbox)
 
+    for layer_name, vol_tags in _conductor_volumes.items():
+        for vtag in vol_tags:
+            try:
+                bbox = kernel.getBoundingBox(3, vtag)
+                _conductor_bboxes.setdefault(layer_name, []).append(bbox)
+            except Exception:
+                logger.debug(
+                    "Could not get bbox for conductor volume %d, skipping", vtag
+                )
+
     kernel.removeAllDuplicates()
     kernel.synchronize()
 
-    # Re-identify via volumes by matching bounding boxes
+    # Build a single bbox lookup for all post-dedup volumes (avoids O(n²) calls).
     all_vols = kernel.getEntities(3)
+    all_vol_bboxes: dict[int, tuple] = {}
+    for _, vtag in all_vols:
+        try:
+            all_vol_bboxes[vtag] = kernel.getBoundingBox(3, vtag)
+        except Exception:
+            logger.debug("Could not get bbox for volume %d after dedup", vtag)
+
+    # Re-identify via volumes by matching bounding boxes.
     for layer_name, bboxes in _via_bboxes.items():
         metal_tags[layer_name]["volumes"] = []
         for target_bbox in bboxes:
-            for _, vtag in all_vols:
-                try:
-                    bbox = kernel.getBoundingBox(3, vtag)
-                except Exception:
-                    logger.debug("Could not get bbox for volume %d, skipping", vtag)
-                    continue
+            for vtag, bbox in all_vol_bboxes.items():
                 if all(
                     abs(a - b) < 0.01 for a, b in zip(bbox, target_bbox, strict=True)
                 ):
                     metal_tags[layer_name]["volumes"].append(vtag)
                     break
 
-    # Extract shell surfaces from conductor volumes.
-    # After removeAllDuplicates, some volume tags may have been invalidated
-    # (e.g., a conductor volume that shared faces with a via volume).
-    current_vols = {t for _, t in kernel.getEntities(3)}
+    # Re-identify conductor volumes by bbox and update _conductor_volumes.
+    # Without this, removeAllDuplicates()'s global renumbering makes every
+    # original tag appear missing, so all conductors are silently dropped.
+    for layer_name, bboxes in _conductor_bboxes.items():
+        new_vol_tags = []
+        for target_bbox in bboxes:
+            for vtag, bbox in all_vol_bboxes.items():
+                if all(
+                    abs(a - b) < 0.01 for a, b in zip(bbox, target_bbox, strict=True)
+                ):
+                    new_vol_tags.append(vtag)
+                    break
+            else:
+                logger.warning(
+                    "Conductor volume on %s lost during dedup (no bbox match)",
+                    layer_name,
+                )
+        _conductor_volumes[layer_name] = new_vol_tags
+
+    # Extract shell surfaces from conductor volumes (now with correct post-dedup tags).
+    current_vols = {t for _, t in all_vols}
     for layer_name, vol_tags in _conductor_volumes.items():
         for volumetag in vol_tags:
             if volumetag not in current_vols:
                 logger.warning(
-                    "Conductor volume %d on %s invalidated by dedup",
+                    "Conductor volume %d on %s missing after bbox re-identification",
                     volumetag,
                     layer_name,
                 )

--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -2,14 +2,6 @@
 
 This module handles extracting polygons from gdsfactory components
 and creating 3D geometry in gmsh.
-
-TODO: Via meshing improvements (tracked 2026-04-14)
-  - Via volumes should use conductivity values from the stack/PDK.
-    The PDK layer_stack should define material/conductivity per via layer.
-  - If conductivity info is missing: warn/log and fall back to 2D PEC surface.
-  - If via is too thin to mesh as 3D (below min_volume_thickness): warn/log
-    and fall back to 2D PEC surface.
-  - Currently all vias are forced to PEC surfaces for testing (line ~293).
 """
 
 from __future__ import annotations
@@ -301,8 +293,43 @@ def add_metals(
             # Zero/thin-thickness or explicitly planar → 2D PEC surface
             metal_tags[layer_name]["surfaces_xy"].extend(surfaces)
         elif layer_type == "via":
-            # Force all vias to 2D PEC surfaces (test)
-            metal_tags[layer_name]["surfaces_xy"].extend(surfaces)
+            # Decide between 3D volume (with conductivity) and 2D PEC fallback
+            material_name = layer_info["material"]
+            mat_props = stack.materials.get(material_name, {})
+            conductivity = mat_props.get("conductivity", 0.0)
+            via_too_thin = thickness == 0 or thickness < min_volume_thickness
+
+            if via_too_thin:
+                logger.warning(
+                    "Via layer '%s' too thin for 3D meshing "
+                    "(%.3f um < %.3f um), falling back to 2D PEC surface",
+                    layer_name,
+                    thickness,
+                    min_volume_thickness,
+                )
+                metal_tags[layer_name]["surfaces_xy"].extend(surfaces)
+            elif conductivity <= 0:
+                logger.warning(
+                    "Via layer '%s' has no conductivity for material '%s', "
+                    "falling back to 2D PEC surface",
+                    layer_name,
+                    material_name,
+                )
+                metal_tags[layer_name]["surfaces_xy"].extend(surfaces)
+            else:
+                # Extrude via as 3D volume with finite conductivity
+                logger.info(
+                    "Via layer '%s': 3D volume (material=%s, "
+                    "\u03c3=%.2e S/m, thickness=%.3f um)",
+                    layer_name,
+                    material_name,
+                    conductivity,
+                    thickness,
+                )
+                for surfacetag in surfaces:
+                    result = kernel.extrude([(2, surfacetag)], 0, 0, thickness)
+                    volumetag = result[1][1]
+                    metal_tags[layer_name]["volumes"].append(volumetag)
         elif thickness > 0:
             # Fuse overlapping same-layer surfaces before extrusion so that
             # overlapping polygons (e.g. ground planes and spines in a GSG
@@ -682,11 +709,15 @@ def build_entities(
 
         # PEC / zero-thickness surfaces
         if tag_info["surfaces_xy"]:
+            # Via PEC surfaces get higher priority (lower mesh_order) so they
+            # are processed first and survive boolean cuts against conductor
+            # shell surfaces that sit at the same z-height.
+            pec_mesh_order = -1 if is_via else 0
             entities.append(
                 Entity(
                     name=f"{layer_name}_pec",
                     dim=2,
-                    mesh_order=0,
+                    mesh_order=pec_mesh_order,
                     tags=tag_info["surfaces_xy"],
                 )
             )

--- a/src/gsim/palace/mesh/gmsh_utils.py
+++ b/src/gsim/palace/mesh/gmsh_utils.py
@@ -105,7 +105,46 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
 
             processed_in_dim = [e for e in current_group if e.dimtags]
         else:
-            # Keep existing priority-cut logic for dim=2,1,0
+            # --- Pre-step: fragment current-dim entities against higher-dim
+            # entities BEFORE priority cuts.
+            #
+            # The dim=3 fragment can merge floating conductor surfaces that are
+            # coincident with dielectric volume faces, assigning them new tags.
+            # If priority cuts run first (with the old tags), OCC raises
+            # "Unknown entity of dimension N with tag T".  Fragmenting against
+            # the higher-dim entities here refreshes all surface tags so the
+            # subsequent priority cuts operate on valid geometry.
+            if processed_higher_dims:
+                object_dimtags = [dt for e in current_group for dt in e.dimtags]
+                tool_dimtags_hd = [
+                    dt for e in processed_higher_dims for dt in e.dimtags
+                ]
+
+                if object_dimtags and tool_dimtags_hd:
+                    _, out_map = gmsh.model.occ.fragment(
+                        object_dimtags,
+                        tool_dimtags_hd,
+                        removeObject=True,
+                        removeTool=True,
+                    )
+                    gmsh.model.occ.synchronize()
+
+                    idx = 0
+                    for entity in current_group:
+                        new_dimtags: list[tuple[int, int]] = []
+                        for _ in entity.dimtags:
+                            new_dimtags.extend(out_map[idx])
+                            idx += 1
+                        entity.dimtags = list(set(new_dimtags))
+
+                    for entity in processed_higher_dims:
+                        new_dimtags = []
+                        for _ in entity.dimtags:
+                            new_dimtags.extend(out_map[idx])
+                            idx += 1
+                        entity.dimtags = list(set(new_dimtags))
+
+            # Priority cuts among same-dim entities (tags are now fresh).
             for entity in current_group:
                 tool_dimtags = [dt for prev in processed_in_dim for dt in prev.dimtags]
 
@@ -123,7 +162,11 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
                     processed_in_dim.append(entity)
 
         # --- B. Fragment against higher dimensions ---
-        if processed_higher_dims and processed_in_dim:
+        # For dim < 3 this was already done in the pre-step above, so
+        # processed_higher_dims dimtags are already up to date.
+        # For dim == 3 processed_higher_dims is always empty (first iteration),
+        # so this block is effectively a no-op in all cases — kept for clarity.
+        if processed_higher_dims and processed_in_dim and dim == 3:
             object_dimtags = [dt for e in processed_in_dim for dt in e.dimtags]
             tool_dimtags = [dt for e in processed_higher_dims for dt in e.dimtags]
 
@@ -135,7 +178,6 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
             )
             gmsh.model.occ.synchronize()
 
-            # Update tags using the mapping
             idx = 0
             for entity in processed_in_dim:
                 new_dimtags: list[tuple[int, int]] = []


### PR DESCRIPTION
## Summary
`extract_layer_stack` now checks `LayerLevel.info["layer_type"]` before falling back to the name-based heuristic, allowing PDKs to provide explicit layer classification metadata (conductor, via, dielectric, substrate).

## Context
The name-based heuristic in `classify_layer_type` can misclassify layers in PDKs that use non-standard naming conventions:

- Via/contact layers that don't contain `"via"` or `"cont"` in their name get classified as conductors
- ILD dielectric layers named after their metal level get classified as conductors

Misclassified vias are treated as 2D conductor shells instead of solid 3D volumes in the mesh pipeline, which can cause OCC boolean failures. Misclassified ILDs are treated as metals.

Rather than hardcoding more name patterns, this PR lets PDKs set `info={"layer_type": "via"}` (or `"dielectric"`, etc.) on their `LayerLevel` definitions. The `info` dict is a built-in gdsfactory field — the extractor now reads it when present, falling back to the existing heuristic only when absent.