### PR TITLE
feat: add 2D effective-index MEEP simulation mode

### DIFF
--- a/nbs/_meep_2d.ipynb
+++ b/nbs/_meep_2d.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2D MEEP Simulations\n",
+    "\n",
+    "This notebook demonstrates **2D effective-index FDTD** simulations using `gsim.meep`.\n",
+    "\n",
+    "2D simulations collapse the z-dimension, making them 10–100× faster than full 3D. They use an effective-index approximation and enforce TE polarization.\n",
+    "\n",
+    "**When to use 2D:**\n",
+    "- Quick design-space exploration and parameter sweeps\n",
+    "- Verifying port connectivity and mode coupling before committing to 3D\n",
+    "- Components where vertical confinement is well-described by an effective index\n",
+    "\n",
+    "**Requirements:**\n",
+    "\n",
+    "- [GDSFactory+](https://gdsfactory.com) account for cloud simulation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load a pcell from UBC PDK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "gf.gpdk.PDK.activate()\n",
+    "\n",
+    "c = gf.components.coupler(gap=0.5)\n",
+    "c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure 2D simulation\n",
+    "\n",
+    "The only difference from a 3D simulation is `sim.solver.is_3d = False`.\n",
+    "This collapses the z-dimension, ignores sidewall angles, and enforces TE polarization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gsim import meep\n",
+    "\n",
+    "sim = meep.Simulation()\n",
+    "\n",
+    "sim.geometry(component=c)\n",
+    "sim.materials = {\"si\": 3.47, \"SiO2\": 1.44}\n",
+    "sim.source(port=\"o1\", wavelength=1.55, wavelength_span=0.01, num_freqs=21)\n",
+    "sim.monitors = [\"o1\", \"o2\", \"o3\"]\n",
+    "sim.domain(pml=1.0, margin=0.5)\n",
+    "sim.solver(resolution=25, is_3d=False)\n",
+    "sim.solver.stop_when_energy_decayed()\n",
+    "\n",
+    "print(sim.validate_config())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we skip `z_crop` in `sim.geometry(...)` — it's irrelevant in 2D since the z-dimension is collapsed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Preview geometry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.plot_2d(slices=\"z\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run 2D simulation on cloud"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = sim.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.plot_interactive()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gsim",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/src/gsim/meep/models/api.py
+++ b/src/gsim/meep/models/api.py
@@ -166,6 +166,15 @@ class FDTD(BaseModel):
 
     model_config = ConfigDict(validate_assignment=True)
 
+    is_3d: bool = Field(
+        default=True,
+        description=(
+            "Run a full 3D simulation (True) or an effective-index 2D "
+            "simulation (False). 2D collapses the z-dimension, ignores "
+            "sidewall angles, and enforces transverse-electric parity "
+            "(EVEN_Y+ODD_Z)."
+        ),
+    )
     resolution: int = Field(default=32, ge=4, description="Pixels per micrometer")
 
     # Stopping criteria (flat fields instead of variant classes)

--- a/src/gsim/meep/models/config.py
+++ b/src/gsim/meep/models/config.py
@@ -310,6 +310,16 @@ class SimConfig(BaseModel):
 
     model_config = ConfigDict(validate_assignment=True)
 
+    is_3d: bool = Field(
+        default=True,
+        description=(
+            "True for full 3D FDTD, False for effective-index 2D. "
+            "When False the runner collapses cell_z to 0, skips "
+            "background slabs, places geometry at z=0, and uses "
+            "transverse-electric parity (EVEN_Y+ODD_Z) for "
+            "eigenmode sources."
+        ),
+    )
     gds_filename: str = Field(description="GDS file with 2D layout")
     component_bbox: list[float] | None = Field(
         default=None,

--- a/src/gsim/meep/ports.py
+++ b/src/gsim/meep/ports.py
@@ -44,6 +44,8 @@ def extract_port_info(
     component: Component,
     layer_stack: LayerStack,
     source_port: str | None = None,
+    *,
+    is_3d: bool = True,
 ) -> list[PortData]:
     """Extract port information from a gdsfactory component.
 
@@ -51,13 +53,14 @@ def extract_port_info(
         component: gdsfactory Component with ports
         layer_stack: LayerStack to determine z-coordinates
         source_port: Name of the source port. If None, first port is the source.
+        is_3d: If False, all port z-centers are set to 0 (2D mode).
 
     Returns:
         List of PortData objects ready for JSON serialization
     """
     ports: list[PortData] = []
 
-    z_center = _get_z_center(layer_stack)
+    z_center = _get_z_center(layer_stack) if is_3d else 0.0
 
     for i, gf_port in enumerate(component.ports):
         normal_axis, direction = get_port_normal(gf_port.orientation)

--- a/src/gsim/meep/script.py
+++ b/src/gsim/meep/script.py
@@ -201,7 +201,12 @@ def build_background_slabs(config, materials):
     These infinite-XY slabs fill the simulation cell at each z-range with
     the correct cladding/substrate material.  They must come FIRST in the
     geometry list so that patterned prisms (added later) take precedence.
+
+    Skipped entirely in 2D mode (no z-dimension).
     """
+    if not config.get("is_3d", True):
+        return []
+
     slabs = []
     for diel in sorted(config["dielectrics"], key=lambda d: d["zmin"]):
         mat = materials.get(diel["material"])
@@ -305,12 +310,16 @@ def build_geometry(config, materials):
       1. Extract polygons from the GDS for that layer's gds_layer
       2. Extrude to 3D as mp.Prism with correct z-range and material
       3. Handle polygon holes via Delaunay triangulation
+
+    In 2D mode (is_3d=False), all prisms are placed at z=0 and sidewall
+    angles are ignored, matching gplugins behaviour.
     """
     gds_filename = config["gds_filename"]
     component = load_gds_component(gds_filename)
 
     accuracy = config["accuracy"]
     simplify_tol = accuracy["simplify_tol"]
+    is_3d = config.get("is_3d", True)
 
     geometry = []
     total_vertices = 0
@@ -318,12 +327,15 @@ def build_geometry(config, materials):
     for layer_entry in config["layer_stack"]:
         material_name = layer_entry["material"]
         mat = materials.get(material_name, mp.Medium())
-        zmin = layer_entry["zmin"]
+        zmin = layer_entry["zmin"] if is_3d else 0
         zmax = layer_entry["zmax"]
-        height = zmax - zmin
+        height = zmax - zmin if is_3d else (layer_entry["zmax"] - layer_entry["zmin"])
         gds_layer = layer_entry["gds_layer"]
         sidewall_angle_deg = layer_entry["sidewall_angle"]
-        sw_rad = math.radians(sidewall_angle_deg) if sidewall_angle_deg else 0
+        if is_3d and sidewall_angle_deg:
+            sw_rad = math.radians(sidewall_angle_deg)
+        else:
+            sw_rad = 0
 
         if height <= 0:
             continue
@@ -371,7 +383,13 @@ def build_geometry(config, materials):
 # ---------------------------------------------------------------------------
 
 def get_port_z_span(config):
-    """Get z-span for ports from layer stack."""
+    """Get z-span for ports from layer stack.
+
+    In 2D mode returns an arbitrary large value (20 um) since the
+    z-dimension is collapsed and the size doesn't affect the simulation.
+    """
+    if not config.get("is_3d", True):
+        return 20
     zmin = min(l["zmin"] for l in config["layer_stack"])
     zmax = max(l["zmax"] for l in config["layer_stack"])
     return zmax - zmin
@@ -384,6 +402,9 @@ def build_sources(config):
     along the propagation direction (into the device).  This separates
     the soft source from the port monitor so eigenmode coefficients
     measure the true incident amplitude rather than half of it.
+
+    In 2D mode (is_3d=False), enforces transverse-electric parity
+    (EVEN_Y + ODD_Z) to match gplugins 2D convention.
     """
     fdtd = config["fdtd"]
     fcen = fdtd["fcen"]
@@ -392,6 +413,8 @@ def build_sources(config):
     z_span = get_port_z_span(config)
     port_margin = config["domain"]["port_margin"]
     source_port_offset = config["domain"].get("source_port_offset", 0.1)
+    is_3d = config.get("is_3d", True)
+    eig_parity = mp.NO_PARITY if is_3d else mp.EVEN_Y + mp.ODD_Z
 
     sources = []
     for port in config["ports"]:
@@ -430,6 +453,7 @@ def build_sources(config):
             direction=prop_axis,
             eig_kpoint=kpoint,
             eig_match_freq=True,
+            eig_parity=eig_parity,
         )
         sources.append(eig_src)
 
@@ -515,6 +539,9 @@ def extract_s_params(config, sim, monitors):
       alpha[band, freq, 0] = forward (+normal_axis) coefficient
       alpha[band, freq, 1] = backward (-normal_axis) coefficient
 
+    In 2D mode, uses transverse-electric parity (EVEN_Y + ODD_Z) for
+    eigenmode decomposition.
+
     Port "direction" field = direction of incoming mode along normal_axis:
       "+" -> incoming goes +normal, outgoing (reflected/transmitted) goes -normal
       "-" -> incoming goes -normal, outgoing (reflected/transmitted) goes +normal
@@ -576,10 +603,13 @@ def extract_s_params(config, sim, monitors):
         return info
 
     # Get incident coefficient at source port for normalization
+    is_3d = config.get("is_3d", True)
+    eig_parity = mp.NO_PARITY if is_3d else mp.EVEN_Y + mp.ODD_Z
+
     src_dir = ports[source_port]["direction"]
     src_kp = _port_kpoint(ports[source_port])
     src_ob = sim.get_eigenmode_coefficients(
-        monitors[source_port], [1], eig_parity=mp.NO_PARITY,
+        monitors[source_port], [1], eig_parity=eig_parity,
         kpoint_func=lambda f, n, kp=src_kp: kp,
     )
     incident_coeffs = src_ob.alpha[0, :, _incoming_idx(src_dir)]
@@ -606,7 +636,7 @@ def extract_s_params(config, sim, monitors):
 
             port_kp = _port_kpoint(ports[port_i])
             ob = sim.get_eigenmode_coefficients(
-                monitors[port_i], [1], eig_parity=mp.NO_PARITY,
+                monitors[port_i], [1], eig_parity=eig_parity,
                 kpoint_func=lambda f, n, kp=port_kp: kp,
             )
 
@@ -722,20 +752,26 @@ def save_geometry_diagnostics(sim, config, cell_center):
         # plot2D is collective — all ranks call it, only master saves
         pass
 
-    domain = config["domain"]
-    dpml = domain["dpml"]
-    z_min = min(l["zmin"] for l in config["layer_stack"])
-    z_max = max(l["zmax"] for l in config["layer_stack"])
-    z_core = (z_min + z_max) / 2
+    is_3d = config.get("is_3d", True)
+
+    if is_3d:
+        z_min = min(l["zmin"] for l in config["layer_stack"])
+        z_max = max(l["zmax"] for l in config["layer_stack"])
+        z_core = (z_min + z_max) / 2
+    else:
+        z_core = 0
 
     # XY cross-section at z=core center
     try:
         fig, ax = plt.subplots(1, 1, figsize=(10, 8))
-        xy_plane = mp.Volume(
-            center=mp.Vector3(cell_center.x, cell_center.y, z_core),
-            size=mp.Vector3(sim.cell_size.x, sim.cell_size.y, 0),
-        )
-        sim.plot2D(ax=ax, output_plane=xy_plane)
+        if is_3d:
+            xy_plane = mp.Volume(
+                center=mp.Vector3(cell_center.x, cell_center.y, z_core),
+                size=mp.Vector3(sim.cell_size.x, sim.cell_size.y, 0),
+            )
+            sim.plot2D(ax=ax, output_plane=xy_plane)
+        else:
+            sim.plot2D(ax=ax)
         ax.set_title(f"XY cross-section at z={z_core:.3f} um (core center)")
         ax.set_xlabel("x (um)")
         ax.set_ylabel("y (um)")
@@ -794,17 +830,24 @@ def save_field_snapshot(sim, config, cell_center):
         logger.warning("matplotlib not available, skipping field snapshot")
         return
 
-    z_min = min(l["zmin"] for l in config["layer_stack"])
-    z_max = max(l["zmax"] for l in config["layer_stack"])
-    z_core = (z_min + z_max) / 2
+    is_3d = config.get("is_3d", True)
+    if is_3d:
+        z_min = min(l["zmin"] for l in config["layer_stack"])
+        z_max = max(l["zmax"] for l in config["layer_stack"])
+        z_core = (z_min + z_max) / 2
+    else:
+        z_core = 0
 
     try:
         fig, ax = plt.subplots(1, 1, figsize=(10, 8))
-        xy_plane = mp.Volume(
-            center=mp.Vector3(cell_center.x, cell_center.y, z_core),
-            size=mp.Vector3(sim.cell_size.x, sim.cell_size.y, 0),
-        )
-        sim.plot2D(ax=ax, output_plane=xy_plane, fields=mp.Ey)
+        if is_3d:
+            xy_plane = mp.Volume(
+                center=mp.Vector3(cell_center.x, cell_center.y, z_core),
+                size=mp.Vector3(sim.cell_size.x, sim.cell_size.y, 0),
+            )
+            sim.plot2D(ax=ax, output_plane=xy_plane, fields=mp.Ey)
+        else:
+            sim.plot2D(ax=ax, fields=mp.Ey)
         ax.set_title(f"Ey field at z={z_core:.3f} um (post-run)")
         ax.set_xlabel("x (um)")
         ax.set_ylabel("y (um)")
@@ -948,15 +991,25 @@ def compile_animation_mp4(fps=15):
 
 def save_epsilon_raw(sim, config, cell_center):
     """Save raw epsilon array as .npy for XY slice at core center."""
-    z_min = min(l["zmin"] for l in config["layer_stack"])
-    z_max = max(l["zmax"] for l in config["layer_stack"])
-    z_core = (z_min + z_max) / 2
+    is_3d = config.get("is_3d", True)
+    if is_3d:
+        z_min = min(l["zmin"] for l in config["layer_stack"])
+        z_max = max(l["zmax"] for l in config["layer_stack"])
+        z_core = (z_min + z_max) / 2
+    else:
+        z_core = 0
 
     try:
-        xy_plane = mp.Volume(
-            center=mp.Vector3(cell_center.x, cell_center.y, z_core),
-            size=mp.Vector3(sim.cell_size.x, sim.cell_size.y, 0),
-        )
+        if is_3d:
+            xy_plane = mp.Volume(
+                center=mp.Vector3(cell_center.x, cell_center.y, z_core),
+                size=mp.Vector3(sim.cell_size.x, sim.cell_size.y, 0),
+            )
+        else:
+            xy_plane = mp.Volume(
+                center=cell_center,
+                size=mp.Vector3(sim.cell_size.x, sim.cell_size.y, 0),
+            )
         eps_data = sim.get_array(vol=xy_plane, component=mp.Dielectric)
         if mp.am_master():
             np.save("meep_epsilon_xy.npy", eps_data)
@@ -1000,6 +1053,7 @@ def main():
 
     resolution = config["resolution"]["pixels_per_um"]
     fdtd = config["fdtd"]
+    is_3d = config.get("is_3d", True)
 
     # Compute simulation cell from component bounds + layer z-range
     # Use original component bbox if available (port extension changes GDS bbox)
@@ -1011,16 +1065,6 @@ def main():
         bbox_left, bbox_right = bbox.left, bbox.right
         bbox_bottom, bbox_top = bbox.bottom, bbox.top
 
-    # Use both layers and dielectrics for z-range so that PDKs without
-    # explicit box/clad layers (e.g. cspdk) still get enough headroom.
-    z_vals = [l["zmin"] for l in config["layer_stack"]] + [
-        l["zmax"] for l in config["layer_stack"]
-    ]
-    for d in config.get("dielectrics", []):
-        z_vals.extend((d["zmin"], d["zmax"]))
-    z_min = min(z_vals)
-    z_max = max(z_vals)
-
     domain = config["domain"]
     dpml = domain["dpml"]
     margin_xy = domain["margin_xy"]
@@ -1028,16 +1072,39 @@ def main():
     # XY: margin_xy is gap between geometry bbox and PML
     cell_x = (bbox_right - bbox_left) + 2 * (margin_xy + dpml)
     cell_y = (bbox_top - bbox_bottom) + 2 * (margin_xy + dpml)
-    # Z: margin_z_above/below is already baked into the stack via z_crop,
-    #    so only add dpml beyond the stack extent
-    cell_z = (z_max - z_min) + 2 * dpml
-    cell_center = mp.Vector3(
-        (bbox_right + bbox_left) / 2,
-        (bbox_top + bbox_bottom) / 2,
-        (z_max + z_min) / 2,
-    )
 
-    logger.info("Cell size: %.2f x %.2f x %.2f um", cell_x, cell_y, cell_z)
+    if is_3d:
+        # Use both layers and dielectrics for z-range so that PDKs without
+        # explicit box/clad layers (e.g. cspdk) still get enough headroom.
+        z_vals = [l["zmin"] for l in config["layer_stack"]] + [
+            l["zmax"] for l in config["layer_stack"]
+        ]
+        for d in config.get("dielectrics", []):
+            z_vals.extend((d["zmin"], d["zmax"]))
+        z_min = min(z_vals)
+        z_max = max(z_vals)
+
+        # Z: margin_z_above/below is already baked into the stack via z_crop,
+        #    so only add dpml beyond the stack extent
+        cell_z = (z_max - z_min) + 2 * dpml
+        cell_center = mp.Vector3(
+            (bbox_right + bbox_left) / 2,
+            (bbox_top + bbox_bottom) / 2,
+            (z_max + z_min) / 2,
+        )
+    else:
+        # 2D mode: collapse z-dimension
+        cell_z = 0
+        cell_center = mp.Vector3(
+            (bbox_right + bbox_left) / 2,
+            (bbox_top + bbox_bottom) / 2,
+            0,
+        )
+
+    logger.info(
+        "Cell size: %.2f x %.2f x %.2f um (%s)",
+        cell_x, cell_y, cell_z, "3D" if is_3d else "2D",
+    )
     logger.info("PML: %.2f um, margin_xy: %.2f", dpml, margin_xy)
     logger.info("Resolution: %s pixels/um", resolution)
 
@@ -1134,9 +1201,12 @@ def main():
     _anim_plane = None
 
     if diag_animation:
-        z_min_anim = min(l["zmin"] for l in config["layer_stack"])
-        z_max_anim = max(l["zmax"] for l in config["layer_stack"])
-        z_core_anim = (z_min_anim + z_max_anim) / 2
+        if is_3d:
+            z_min_anim = min(l["zmin"] for l in config["layer_stack"])
+            z_max_anim = max(l["zmax"] for l in config["layer_stack"])
+            z_core_anim = (z_min_anim + z_max_anim) / 2
+        else:
+            z_core_anim = 0
         _anim_plane = mp.Volume(
             center=mp.Vector3(cell_center.x, cell_center.y, z_core_anim),
             size=mp.Vector3(sim.cell_size.x, sim.cell_size.y, 0),

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -418,6 +418,8 @@ class Simulation(BaseModel):
         if not validation.valid:
             raise ValueError("Invalid configuration:\n" + "\n".join(validation.errors))
 
+        is_3d = self.solver.is_3d
+
         # Resolve stack
         self._ensure_stack()
         if self.geometry.stack is None:
@@ -425,8 +427,9 @@ class Simulation(BaseModel):
         if self.geometry.component is None:
             raise ValueError("No geometry set.")
 
-        # Apply z-crop if requested
-        self._apply_z_crop()
+        # Apply z-crop if requested (only meaningful in 3D)
+        if is_3d:
+            self._apply_z_crop()
 
         import gdsfactory as gf
 
@@ -489,7 +492,7 @@ class Simulation(BaseModel):
 
         # Extract port info from original component
         port_infos = extract_port_info(
-            original_component, stack, source_port=source_cfg.port
+            original_component, stack, source_port=source_cfg.port, is_3d=is_3d
         )
 
         # Resolve materials
@@ -517,6 +520,7 @@ class Simulation(BaseModel):
 
         # Build SimConfig
         sim_config = SimConfig(
+            is_3d=is_3d,
             gds_filename="layout.gds",
             component_bbox=original_bbox,
             layer_stack=layer_stack_entries,

--- a/tests/meep/test_meep_models.py
+++ b/tests/meep/test_meep_models.py
@@ -864,6 +864,160 @@ class TestSourceConfig:
 # ---------------------------------------------------------------------------
 
 
+class TestSimConfig2D:
+    """Test SimConfig is_3d field."""
+
+    @pytest.fixture
+    def sim_kwargs(self):
+        """Returns default keyword arguments for SimConfig."""
+        from gsim.meep.models.config import AccuracyConfig, DiagnosticsConfig
+
+        return dict(
+            gds_filename="layout.gds",
+            verbose_interval=0,
+            layer_stack=[],
+            dielectrics=[],
+            ports=[],
+            materials={},
+            wavelength=WavelengthConfig(wavelength=1.55, bandwidth=0.1, num_freqs=11),
+            source=SourceConfig(),
+            stopping=StoppingConfig(
+                mode="fixed",
+                max_time=100.0,
+                decay_dt=50.0,
+                decay_component="Ey",
+                threshold=0.05,
+                dft_min_run_time=100,
+            ),
+            resolution=ResolutionConfig(pixels_per_um=32),
+            domain=DomainConfig(
+                dpml=1.0,
+                margin_xy=0.5,
+                margin_z_above=0.5,
+                margin_z_below=0.5,
+                port_margin=0.5,
+                extend_ports=0.0,
+                source_port_offset=0.1,
+                distance_source_to_monitors=0.2,
+            ),
+            accuracy=AccuracyConfig(
+                eps_averaging=False,
+                subpixel_maxeval=0,
+                subpixel_tol=1e-4,
+                simplify_tol=0.0,
+            ),
+            diagnostics=DiagnosticsConfig(
+                save_geometry=True,
+                save_fields=True,
+                save_epsilon_raw=False,
+                save_animation=False,
+                animation_interval=0.5,
+                preview_only=False,
+                verbose_interval=0,
+            ),
+            symmetries=[],
+        )
+
+    def test_default_is_3d(self, sim_kwargs):
+        cfg = SimConfig(**sim_kwargs)
+        assert cfg.is_3d is True
+
+    def test_set_2d(self, sim_kwargs):
+        cfg = SimConfig(**sim_kwargs, is_3d=False)
+        assert cfg.is_3d is False
+
+    def test_json_roundtrip_2d(self, tmp_path, sim_kwargs):
+        cfg = SimConfig(**sim_kwargs, is_3d=False)
+        path = tmp_path / "config.json"
+        cfg.to_json(path)
+        data = json.loads(path.read_text())
+        assert data["is_3d"] is False
+
+    def test_json_roundtrip_3d(self, tmp_path, sim_kwargs):
+        cfg = SimConfig(**sim_kwargs, is_3d=True)
+        path = tmp_path / "config.json"
+        cfg.to_json(path)
+        data = json.loads(path.read_text())
+        assert data["is_3d"] is True
+
+
+class TestPortExtraction2D:
+    """Test port extraction in 2D mode (z=0)."""
+
+    def test_ports_z_zero_in_2d(self):
+        from gsim.common.stack.extractor import Layer, LayerStack
+        from gsim.meep.ports import extract_port_info
+
+        stack = LayerStack(
+            layers={
+                "core": Layer(
+                    name="core",
+                    gds_layer=(1, 0),
+                    zmin=0.0,
+                    zmax=0.22,
+                    thickness=0.22,
+                    material="si",
+                    layer_type="dielectric",
+                ),
+            }
+        )
+
+        import gdsfactory as gf
+
+        c = gf.components.straight(length=10, width=0.5)
+        ports = extract_port_info(c, stack, is_3d=False)
+        for p in ports:
+            assert p.center[2] == 0.0, "2D ports must have z=0"
+
+    def test_ports_z_nonzero_in_3d(self):
+        from gsim.common.stack.extractor import Layer, LayerStack
+        from gsim.meep.ports import extract_port_info
+
+        stack = LayerStack(
+            layers={
+                "core": Layer(
+                    name="core",
+                    gds_layer=(1, 0),
+                    zmin=0.0,
+                    zmax=0.22,
+                    thickness=0.22,
+                    material="si",
+                    layer_type="dielectric",
+                ),
+            }
+        )
+
+        import gdsfactory as gf
+
+        c = gf.components.straight(length=10, width=0.5)
+        ports = extract_port_info(c, stack, is_3d=True)
+        for p in ports:
+            assert p.center[2] != 0.0, "3D ports must have nonzero z"
+
+
+class TestScript2D:
+    """Test that the runner script includes 2D mode support."""
+
+    def test_script_has_is_3d_check(self):
+        from gsim.meep.script import generate_meep_script
+
+        script = generate_meep_script()
+        assert "is_3d" in script
+
+    def test_script_has_te_parity(self):
+        from gsim.meep.script import generate_meep_script
+
+        script = generate_meep_script()
+        assert "EVEN_Y" in script
+        assert "ODD_Z" in script
+
+    def test_script_valid_python_with_2d(self):
+        from gsim.meep.script import generate_meep_script
+
+        script = generate_meep_script()
+        ast.parse(script)
+
+
 class TestScriptSymmetry:
     """Test that the runner script includes symmetry support."""
 

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -404,3 +404,100 @@ class TestConfigTranslation:
         cfg = sim._diagnostics_config()
         assert cfg.save_animation is True
         assert cfg.preview_only is True
+
+
+# ---------------------------------------------------------------------------
+# 2D mode tests
+# ---------------------------------------------------------------------------
+
+
+class Test2DMode:
+    """Tests for 2D simulation mode (is_3d=False)."""
+
+    def test_fdtd_is_3d_default_true(self):
+        f = FDTD()
+        assert f.is_3d is True
+
+    def test_fdtd_is_3d_false(self):
+        f = FDTD(is_3d=False)
+        assert f.is_3d is False
+
+    def test_solver_assignment(self):
+        sim = Simulation()
+        sim.solver.is_3d = False
+        assert sim.solver.is_3d is False
+
+    def test_solver_callable(self):
+        sim = Simulation()
+        sim.solver(is_3d=False)
+        assert sim.solver.is_3d is False
+
+    def test_build_config_2d_port_z_zero(self):
+        """In 2D mode, build_config produces port z-centers at 0."""
+        import gdsfactory as gf
+
+        c = gf.components.straight(length=10, width=0.5)
+
+        sim = Simulation()
+        sim.geometry.component = c
+        sim.materials = {"si": 3.47, "SiO2": 1.44}
+        sim.source.port = "o1"
+        sim.monitors = ["o1", "o2"]
+        sim.solver.is_3d = False
+
+        result = sim.build_config()
+        for port in result.config.ports:
+            assert port.center[2] == 0.0
+
+    def test_build_config_2d_is_3d_false_in_config(self):
+        """build_config with is_3d=False sets is_3d=False in SimConfig."""
+        import gdsfactory as gf
+
+        c = gf.components.straight(length=10, width=0.5)
+
+        sim = Simulation()
+        sim.geometry.component = c
+        sim.materials = {"si": 3.47, "SiO2": 1.44}
+        sim.source.port = "o1"
+        sim.monitors = ["o1", "o2"]
+        sim.solver.is_3d = False
+
+        result = sim.build_config()
+        assert result.config.is_3d is False
+
+    def test_build_config_3d_default(self):
+        """Default build_config should be 3D."""
+        import gdsfactory as gf
+
+        c = gf.components.straight(length=10, width=0.5)
+
+        sim = Simulation()
+        sim.geometry.component = c
+        sim.materials = {"si": 3.47, "SiO2": 1.44}
+        sim.source.port = "o1"
+        sim.monitors = ["o1", "o2"]
+
+        result = sim.build_config()
+        assert result.config.is_3d is True
+
+    def test_write_config_2d_json(self, tmp_path):
+        """write_config with is_3d=False produces JSON with is_3d=false."""
+        import json
+
+        import gdsfactory as gf
+
+        c = gf.components.straight(length=10, width=0.5)
+
+        sim = Simulation()
+        sim.geometry.component = c
+        sim.materials = {"si": 3.47, "SiO2": 1.44}
+        sim.source.port = "o1"
+        sim.monitors = ["o1", "o2"]
+        sim.solver.is_3d = False
+
+        out = sim.write_config(tmp_path / "sim2d")
+        config_data = json.loads((out / "sim_config.json").read_text())
+        assert config_data["is_3d"] is False
+        # Ports should have z=0
+        for port in config_data["ports"]:
+            assert port["center"][2] == 0.0


### PR DESCRIPTION
## Summary
- Add `is_3d` flag (default `True`) to `FDTD` model and `SimConfig`, matching gplugins `is_3d=False` convention
- When `is_3d=False`: cell z-dimension collapses to 0, geometry placed at z=0 without sidewall angles, background slabs skipped, eigenmode sources/monitors use transverse-electric parity (EVEN_Y+ODD_Z)
- Add example notebook `nbs/_meep_2d.ipynb` demonstrating the 2D workflow

**Usage:**
```python
sim = meep.Simulation()
sim.solver.is_3d = False  # everything else stays the same
```

**Files changed:** `models/api.py`, `models/config.py`, `ports.py`, `script.py`, `simulation.py`, tests, notebook