### PR TITLE
fix(palace): auto-size mesh for all presets, detect CPW gap widths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ src = "src/gsim/__init__.py"
 commit-template = "Release {new-version}"
 
 [tool.codespell]
-ignore-words-list = "doubleclick"
+ignore-words-list = "doubleclick,euclidian"
 
 [tool.interrogate]
 docstring-style = "google"

--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -342,9 +342,13 @@ class PalaceSimMixin:
         else:
             mesh_config = MeshConfig.default()
 
-        # For the default preset, scale refined_mesh_size to the smallest
-        # conductor feature when the user didn't specify one explicitly.
-        if preset in (None, "default") and refined_mesh_size is None:
+        # Scale refined_mesh_size to the smallest conductor feature (polygon
+        # bbox or inter-polygon gap) when the user didn't specify an explicit
+        # value. Runs for every preset — the min(preset, auto) floor inside
+        # auto_refined_mesh_size() means large-feature designs keep the
+        # preset's size, while small-feature designs get proportional
+        # refinement regardless of whether coarse/default/fine was chosen.
+        if refined_mesh_size is None:
             component = self.geometry.component if self.geometry else None
             if component is not None:
                 from gsim.palace.mesh.auto_size import auto_refined_mesh_size

--- a/src/gsim/palace/mesh/auto_size.py
+++ b/src/gsim/palace/mesh/auto_size.py
@@ -6,29 +6,30 @@ import logging
 import math
 from typing import TYPE_CHECKING
 
+import klayout.db as kdb
+
 if TYPE_CHECKING:
     from gsim.common.stack import LayerStack
 
 logger = logging.getLogger(__name__)
 
 
-def min_conductor_feature_size(component, stack: LayerStack) -> float | None:
-    """Smallest polygon bbox dimension across all conductor layers (um).
-
-    Scans every polygon on every conductor-typed layer in the stack and
-    returns the smallest of its bbox width / height. Used as a proxy for
-    the minimum feature that mesh elements must resolve.
-
-    Returns None if the component has no polygons on conductor layers, or
-    if the stack declares no conductors.
-    """
-    conductor_gds: set[tuple[int, int]] = {
+def _conductor_gds_tuples(stack: LayerStack) -> set[tuple[int, int]]:
+    """Return the set of ``(layer, datatype)`` tuples for conductor layers."""
+    return {
         tuple(layer.gds_layer)
         for layer in stack.layers.values()
         if layer.layer_type == "conductor"
     }
+
+
+def _conductor_polygons_by_layer(
+    component, stack: LayerStack
+) -> dict[tuple[int, int], list[kdb.Polygon]]:
+    """Group conductor polygons by their ``(layer, datatype)`` GDS tuple."""
+    conductor_gds = _conductor_gds_tuples(stack)
     if not conductor_gds:
-        return None
+        return {}
 
     layout = component.kcl.layout
     index_to_gds: dict[int, tuple[int, int]] = {}
@@ -37,12 +38,20 @@ def min_conductor_feature_size(component, stack: LayerStack) -> float | None:
             info = layout.get_info(layer_index)
             index_to_gds[layer_index] = (info.layer, info.datatype)
 
-    min_dim = math.inf
+    grouped: dict[tuple[int, int], list[kdb.Polygon]] = {}
     polygons_by_index = component.get_polygons()
     for layer_index, polys in polygons_by_index.items():
         gds_tuple = index_to_gds.get(layer_index)
         if gds_tuple is None or gds_tuple not in conductor_gds:
             continue
+        grouped.setdefault(gds_tuple, []).extend(polys)
+    return grouped
+
+
+def _min_bbox_dim(component, stack: LayerStack) -> float | None:
+    """Smallest bbox width/height across all conductor polygons (um)."""
+    min_dim = math.inf
+    for polys in _conductor_polygons_by_layer(component, stack).values():
         for poly in polys:
             points = list(poly.each_point_hull())
             if len(points) < 3:
@@ -55,8 +64,91 @@ def min_conductor_feature_size(component, stack: LayerStack) -> float | None:
                 min_dim = min(min_dim, w)
             if h > 0:
                 min_dim = min(min_dim, h)
-
     return min_dim if math.isfinite(min_dim) else None
+
+
+def min_conductor_gap(
+    component,
+    stack: LayerStack,
+    max_gap_um: float = 500.0,
+) -> float | None:
+    """Smallest edge-to-edge gap between conductor polygons (um).
+
+    Uses klayout's ``kdb.Region.space_check`` with the Euclidean metric to
+    find the minimum distance between distinct polygons on the same
+    conductor layer. Field concentration happens in these gaps, so mesh
+    refinement should resolve them.
+
+    Note:
+        Only same-layer gaps are considered. Cross-layer gap measurement
+        is significantly more complex (it would require projecting
+        polygons onto a common plane and accounting for z-separation)
+        and is not attempted here; for the CPW pathology this targets
+        (signal + coplanar grounds), same-layer is sufficient.
+
+    Args:
+        component: gdsfactory Component whose polygons are inspected.
+        stack: Layer stack (used to identify conductor layers).
+        max_gap_um: Upper bound on gaps to detect, in um. Gaps larger
+            than this are ignored. A generous default (500 um) covers
+            any realistic on-chip feature.
+
+    Returns:
+        Minimum same-layer conductor gap in um, or ``None`` when no
+        conductor layer has a detectable gap (e.g. a single polygon,
+        or no conductors declared).
+    """
+    grouped = _conductor_polygons_by_layer(component, stack)
+    if not grouped:
+        return None
+
+    dbu = component.kcl.layout.dbu  # um per integer unit
+    threshold_dbu = round(max_gap_um / dbu)
+
+    min_gap = math.inf
+    for polys in grouped.values():
+        if len(polys) < 2:
+            continue
+        region = kdb.Region()
+        for poly in polys:
+            region.insert(poly)
+        pairs = region.space_check(
+            threshold_dbu,
+            False,  # whole_edges
+            kdb.Region.Euclidian,
+        )
+        for ep in pairs:
+            d_um = ep.distance() * dbu
+            if d_um > 0:
+                min_gap = min(min_gap, d_um)
+
+    return min_gap if math.isfinite(min_gap) else None
+
+
+def min_conductor_feature_size(component, stack: LayerStack) -> float | None:
+    """Smallest conductor feature to resolve, in um.
+
+    Returns the minimum of:
+
+    * the smallest polygon bbox width / height across all conductor
+      layers, and
+    * the smallest edge-to-edge gap between same-layer conductor
+      polygons (see :func:`min_conductor_gap`).
+
+    The gap is just as important as polygon width for mesh refinement:
+    in a CPW, the 15 um gap between signal and ground is the real
+    field-concentration site even when the trace itself is wider.
+
+    Returns None if the component has no polygons on conductor layers,
+    or the stack declares no conductors.
+    """
+    bbox_min = _min_bbox_dim(component, stack)
+    gap_min = min_conductor_gap(component, stack)
+
+    candidates = [v for v in (bbox_min, gap_min) if v is not None]
+    if not candidates:
+        return None
+    return min(candidates)
 
 
 def auto_refined_mesh_size(
@@ -66,6 +158,9 @@ def auto_refined_mesh_size(
     cells_per_feature: int = 4,
 ) -> float:
     """Pick ``refined_mesh_size`` scaled to the smallest conductor feature.
+
+    "Smallest conductor feature" is the minimum of polygon bbox dimension
+    and inter-polygon gap on each conductor layer — whichever is tighter.
 
     Returns ``min(preset_size, min_feature / cells_per_feature)`` so designs
     with small features get proportionally refined meshes while large designs
@@ -81,4 +176,5 @@ def auto_refined_mesh_size(
 __all__ = [
     "auto_refined_mesh_size",
     "min_conductor_feature_size",
+    "min_conductor_gap",
 ]

--- a/tests/palace/test_auto_size.py
+++ b/tests/palace/test_auto_size.py
@@ -9,6 +9,7 @@ from gsim.common.stack.extractor import Layer, LayerStack
 from gsim.palace.mesh.auto_size import (
     auto_refined_mesh_size,
     min_conductor_feature_size,
+    min_conductor_gap,
 )
 
 
@@ -45,6 +46,58 @@ def _narrow_trace(width: float = 2.0, length: float = 100.0) -> gf.Component:
     return c
 
 
+def _cpw_component(
+    s_width: float = 20.0,
+    gap: float = 15.0,
+    ground_width: float = 40.0,
+    length: float = 300.0,
+) -> gf.Component:
+    """Create a CPW layout: signal trace plus two coplanar ground planes.
+
+    Signal centered at y=0, extending along x. Grounds on either side in y,
+    separated from signal by ``gap``.
+    """
+    c = gf.Component()
+    half_l = length / 2
+    half_s = s_width / 2
+    # Signal: s_width wide (y span) x length (x span)
+    c.add_polygon(
+        [(-half_l, -half_s), (half_l, -half_s), (half_l, half_s), (-half_l, half_s)],
+        layer=(1, 0),
+    )
+    # Lower ground: y in [-(half_s+gap+ground_width), -(half_s+gap)]
+    c.add_polygon(
+        [
+            (-half_l, -(half_s + gap + ground_width)),
+            (half_l, -(half_s + gap + ground_width)),
+            (half_l, -(half_s + gap)),
+            (-half_l, -(half_s + gap)),
+        ],
+        layer=(1, 0),
+    )
+    # Upper ground: y in [half_s+gap, half_s+gap+ground_width]
+    c.add_polygon(
+        [
+            (-half_l, half_s + gap),
+            (half_l, half_s + gap),
+            (half_l, half_s + gap + ground_width),
+            (-half_l, half_s + gap + ground_width),
+        ],
+        layer=(1, 0),
+    )
+    return c
+
+
+def _two_far_polys() -> gf.Component:
+    """Two small polygons separated by a larger distance than any bbox dim."""
+    c = gf.Component()
+    # 50um x 50um at origin
+    c.add_polygon([(0, 0), (50, 0), (50, 50), (0, 50)], layer=(1, 0))
+    # 50um x 50um at (500, 0) — gap is ~450um, bigger than any bbox (50)
+    c.add_polygon([(500, 0), (550, 0), (550, 50), (500, 50)], layer=(1, 0))
+    return c
+
+
 class TestMinConductorFeatureSize:
     """Tests for min_conductor_feature_size."""
 
@@ -63,6 +116,47 @@ class TestMinConductorFeatureSize:
         component = _narrow_trace(width=2.0)
         stack = _conductor_stack(gds_layer=(99, 0))
         assert min_conductor_feature_size(component, stack) is None
+
+    def test_cpw_gap_beats_trace_width(self):
+        """For a CPW with 20 um trace + 15 um gap, should return 15 (gap)."""
+        component = _cpw_component(s_width=20.0, gap=15.0, ground_width=40.0)
+        stack = _conductor_stack()
+        result = min_conductor_feature_size(component, stack)
+        assert result == pytest.approx(15.0)
+
+    def test_single_polygon_falls_back_to_bbox(self):
+        """No gap exists — min_conductor_gap is None, bbox min wins."""
+        component = _narrow_trace(width=3.0, length=50.0)
+        stack = _conductor_stack()
+        # No gap possible; falls back to bbox min = 3.0
+        assert min_conductor_gap(component, stack) is None
+        assert min_conductor_feature_size(component, stack) == pytest.approx(3.0)
+
+    def test_far_apart_polygons_bbox_wins(self):
+        """Gap larger than any bbox dim — bbox min wins."""
+        component = _two_far_polys()
+        stack = _conductor_stack()
+        # Both polygons are 50um squares, separated by ~450um
+        assert min_conductor_feature_size(component, stack) == pytest.approx(50.0)
+
+
+class TestMinConductorGap:
+    """Tests for min_conductor_gap."""
+
+    def test_cpw_returns_gap(self):
+        component = _cpw_component(s_width=20.0, gap=15.0)
+        stack = _conductor_stack()
+        assert min_conductor_gap(component, stack) == pytest.approx(15.0)
+
+    def test_single_polygon_returns_none(self):
+        component = _narrow_trace()
+        stack = _conductor_stack()
+        assert min_conductor_gap(component, stack) is None
+
+    def test_no_conductor_layer_returns_none(self):
+        component = _narrow_trace()
+        stack = _conductor_stack(gds_layer=(99, 0))
+        assert min_conductor_gap(component, stack) is None
 
 
 class TestAutoRefinedMeshSize:
@@ -84,3 +178,12 @@ class TestAutoRefinedMeshSize:
         component = _narrow_trace()
         empty_stack = LayerStack()
         assert auto_refined_mesh_size(component, empty_stack, preset_size=5.0) == 5.0
+
+    def test_cpw_end_to_end(self):
+        """CPW with 20 um trace + 15 um gap, preset=5.0 -> 15/4 = 3.75."""
+        component = _cpw_component(s_width=20.0, gap=15.0, ground_width=40.0)
+        stack = _conductor_stack()
+        # min_feature = 15 (gap), /4 = 3.75 < preset 5.0
+        assert auto_refined_mesh_size(
+            component, stack, preset_size=5.0
+        ) == pytest.approx(3.75)

--- a/tests/palace/test_auto_sizing_integration.py
+++ b/tests/palace/test_auto_sizing_integration.py
@@ -1,0 +1,150 @@
+"""Integration tests for mesh auto-sizing gating in ``_build_mesh_config``.
+
+These tests exercise the pure-config path only — no gmsh invocation, so
+they run anywhere including macOS.
+"""
+
+from __future__ import annotations
+
+import gdsfactory as gf
+import pytest
+
+from gsim.common import Geometry
+from gsim.common.stack.extractor import Layer, LayerStack
+from gsim.palace import DrivenSim
+
+
+@pytest.fixture(autouse=True)
+def _activate_pdk():
+    """Activate the generic PDK for every test in this module."""
+    gf.gpdk.PDK.activate()
+
+
+def _conductor_stack(gds_layer: tuple[int, int] = (1, 0)) -> LayerStack:
+    """Return a minimal stack with a single conductor layer."""
+    stack = LayerStack()
+    stack.layers["metal"] = Layer(
+        name="metal",
+        gds_layer=gds_layer,
+        zmin=0.0,
+        zmax=0.5,
+        thickness=0.5,
+        material="copper",
+        layer_type="conductor",
+    )
+    return stack
+
+
+def _small_feature_component(width: float = 2.0) -> gf.Component:
+    """Component with a very narrow trace (width um wide)."""
+    c = gf.Component()
+    half_w = width / 2
+    c.add_polygon(
+        [(-50, -half_w), (50, -half_w), (50, half_w), (-50, half_w)],
+        layer=(1, 0),
+    )
+    return c
+
+
+def _make_sim(component: gf.Component, stack: LayerStack) -> DrivenSim:
+    """Build a DrivenSim wired to the given component and stack without gmsh."""
+    sim = DrivenSim()
+    sim.geometry = Geometry(component=component)
+    # Bypass lazy-stack resolution — use the pre-built stack directly.
+    sim.stack = stack
+    sim._stack_kwargs = {"_prebuilt": True}
+    return sim
+
+
+# Preset nominal refined_mesh_size values
+PRESET_REFINED = {
+    "coarse": 10.0,
+    "default": 5.0,
+    "fine": 2.0,
+}
+
+
+@pytest.mark.parametrize("preset", ["coarse", "default", "fine"])
+def test_autosizing_fires_for_every_preset(preset):
+    """With small features and no explicit override, auto-sizing must
+    shrink refined_mesh_size below the preset's nominal value.
+
+    With a 2 um trace, auto_size = 2/4 = 0.5 um, which is below every
+    preset's nominal (10.0 / 5.0 / 2.0). So it must fire in all cases.
+    """
+    sim = _make_sim(_small_feature_component(width=2.0), _conductor_stack())
+    mesh_config = sim._build_mesh_config(
+        preset=preset,
+        refined_mesh_size=None,
+        max_mesh_size=None,
+        margin=None,
+        airbox_margin=None,
+        fmax=None,
+        planar_conductors=None,
+        show_gui=False,
+    )
+    assert mesh_config.refined_mesh_size < PRESET_REFINED[preset], (
+        f"preset={preset}: expected auto-sizer to shrink refined_mesh_size "
+        f"below {PRESET_REFINED[preset]}, got {mesh_config.refined_mesh_size}"
+    )
+    assert mesh_config.refined_mesh_size == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize("preset", ["coarse", "default", "fine"])
+def test_explicit_override_bypasses_autosizing(preset):
+    """When user passes an explicit refined_mesh_size, auto-sizing must NOT
+    overwrite it regardless of preset.
+    """
+    sim = _make_sim(_small_feature_component(width=2.0), _conductor_stack())
+    user_size = 7.5
+    mesh_config = sim._build_mesh_config(
+        preset=preset,
+        refined_mesh_size=user_size,
+        max_mesh_size=None,
+        margin=None,
+        airbox_margin=None,
+        fmax=None,
+        planar_conductors=None,
+        show_gui=False,
+    )
+    assert mesh_config.refined_mesh_size == user_size
+
+
+def test_autosizing_noop_for_large_features():
+    """Designs with large features keep the preset size."""
+    # 100 um trace, default preset (5.0 um). auto = min(5.0, 100/4) = 5.0.
+    c = _small_feature_component(width=100.0)
+    sim = _make_sim(c, _conductor_stack())
+    mesh_config = sim._build_mesh_config(
+        preset="default",
+        refined_mesh_size=None,
+        max_mesh_size=None,
+        margin=None,
+        airbox_margin=None,
+        fmax=None,
+        planar_conductors=None,
+        show_gui=False,
+    )
+    assert mesh_config.refined_mesh_size == PRESET_REFINED["default"]
+
+
+def test_autosizing_cpw_gap_fires():
+    """CPW with 15 um gap drives refinement below preset even though trace
+    is 20 um wide.
+    """
+    from tests.palace.test_auto_size import _cpw_component
+
+    c = _cpw_component(s_width=20.0, gap=15.0, ground_width=40.0)
+    sim = _make_sim(c, _conductor_stack())
+    mesh_config = sim._build_mesh_config(
+        preset="default",
+        refined_mesh_size=None,
+        max_mesh_size=None,
+        margin=None,
+        airbox_margin=None,
+        fmax=None,
+        planar_conductors=None,
+        show_gui=False,
+    )
+    # min_feature = 15 (gap), /4 = 3.75 < preset 5.0
+    assert mesh_config.refined_mesh_size == pytest.approx(3.75)


### PR DESCRIPTION
## Summary

Two independent bugs in mesh auto-sizing, fixed together because either alone leaves a half-broken state.

**Gating.** `_build_mesh_config` previously ran auto-sizing only when `preset in (None, "default")`. Small-featured designs using `coarse` or `fine` silently under-resolved. Dropped the preset gate; kept the explicit-override check (`refined_mesh_size is None`).

**Measurement.** `min_conductor_feature_size` only scanned polygon bounding boxes. For CPWs, field concentration lives in the inter-conductor *gap*, not any polygon dimension — a 20 µm trace with 15 µm gaps reported `min_feature=20`. Added `min_conductor_gap` using klayout's `Region.space_check` with Euclidean metric; `min_conductor_feature_size` now returns `min(bbox_min, gap_min)`. Cross-layer gap measurement deliberately out of scope (3D projection, not a region op).

## Downstream impact on notebooks

| Notebook | Before | After |
|---|---|---|
| `palace_qpdk_resonator.ipynb` (s=10, gap=6) | 2.5 µm | 1.5 µm |
| `_palace_qpdk_eigenmode.ipynb` | 2.5 | 1.5 |
| `_palace_qpdk_qubit_resonator.ipynb` | 2.5 | 1.5 |
| `palace_cpw_via.ipynb`, `palace_cpw_fields.ipynb`, `palace_cpw_lumped.ipynb` (s=20, gap=15) | 5.0 | 3.75 |
| `_palace_mach_zehnder.ipynb` (`preset="coarse"`) | 10 (no auto-size) | auto-sized |

Notebooks with explicit `refined_mesh_size=2.0` (`_palace_cpw.ipynb`, `palace_cpw_waveport.ipynb`) are unaffected. Microstrip notebook unaffected (no same-layer gap).

Expected: ~30–40% finer meshes around CPW gaps → meshes grow, S-parameter accuracy improves, runtimes go up.

## Config

Added `"euclidian"` to codespell `ignore-words-list` — it's the klayout API constant spelling (`kdb.Region.Euclidian`), not our typo.