### PR TITLE
fix: silence ty warnings in viz.py and rename 2D page to "2D FDTD"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,7 @@ nav:
       - Ring Coupler: nbs/meep_ring_coupler.md
       - Directional Coupler: nbs/meep_dc.md
       - Crossing: nbs/meep_crossing.md
-      - 2D Effective-Index: nbs/meep_2d.md
+      - 2D FDTD: nbs/meep_2d.md
   - FEM for RF:
       - CPW (Lumped Ports): nbs/palace_cpw_lumped.md
       - CPW (Wave Ports): nbs/palace_cpw_waveport.md

--- a/nbs/meep_2d.ipynb
+++ b/nbs/meep_2d.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# 2D MEEP Simulations\n",
+    "# 2D FDTD\n",
     "\n",
     "This notebook demonstrates **2D effective-index FDTD** simulations using `gsim.meep`.\n",
     "\n",

--- a/src/gsim/viz.py
+++ b/src/gsim/viz.py
@@ -93,8 +93,8 @@ def _plot_wireframe(
     mio = meshio.read(msh_path)
     group_map: dict[int, str] = {tag: name for name, (tag, _) in mio.field_data.items()}
 
-    mesh = cast(pv.DataSet, pv.read(msh_path))
-    plotter = cast(Any, _make_plotter(interactive))
+    mesh = cast(pv.DataSet, pv.read(msh_path))  # ty: ignore[redundant-cast]
+    plotter = cast(Any, _make_plotter(interactive))  # ty: ignore[redundant-cast]
 
     if show_groups:
         ids = [
@@ -187,7 +187,7 @@ def _plot_solid(
     transparent_mask = np.isin(plain_names, transparent_groups)
     opaque_mask = ~transparent_mask
 
-    plotter = cast(Any, _make_plotter(interactive))
+    plotter = cast(Any, _make_plotter(interactive))  # ty: ignore[redundant-cast]
 
     # Opaque surfaces with categorical colour map -------------------------
     if np.any(opaque_mask):
@@ -461,7 +461,8 @@ def sample_topview_field(
 
     probe = pv.StructuredGrid(Xi, Yi, Zi)
     sampled = probe.sample(
-        cast(pv.DataSet, source), snap_to_closest_point=snap_to_closest_point
+        cast(pv.DataSet, source),  # ty: ignore[redundant-cast]
+        snap_to_closest_point=snap_to_closest_point,
     )
 
     if field not in sampled.point_data:
@@ -499,7 +500,7 @@ def sample_topview_field(
             )
         )
         if not valid.any() and not snap_to_closest_point:
-            sampled = probe.sample(cast(pv.DataSet, source), snap_to_closest_point=True)
+            sampled = probe.sample(cast(pv.DataSet, source), snap_to_closest_point=True)  # ty: ignore[redundant-cast]
             arr = sampled.point_data[field]
             if arr.ndim == 2:
                 values = (
@@ -605,7 +606,7 @@ def plot_topview(
             msg = "No points available for direct surface plotting."
             raise ValueError(msg)
 
-        surf = source.extract_surface(algorithm="dataset_surface").triangulate()
+        surf = source.extract_surface(algorithm="dataset_surface").triangulate()  # ty: ignore[unknown-argument]
         if surf.n_cells == 0 or field not in surf.point_data:
             logger.warning(
                 "plot_topview: direct surface plot unavailable for %s; "
@@ -875,7 +876,7 @@ def plot_cross_section(
         Z3[:, :] = origin
 
     probe_grid = pv.StructuredGrid(X3, Y3, Z3)
-    sampled = probe_grid.sample(cast(pv.DataSet, sliced))
+    sampled = probe_grid.sample(cast(pv.DataSet, sliced))  # ty: ignore[redundant-cast]
 
     if field not in sampled.point_data:
         available = list(sampled.point_data.keys())
@@ -1158,7 +1159,8 @@ def _sample_topview_field_duplicate(
 
     probe = pv.StructuredGrid(Xi, Yi, Zi)
     sampled = probe.sample(
-        cast(pv.DataSet, source), snap_to_closest_point=snap_to_closest_point
+        cast(pv.DataSet, source),  # ty: ignore[redundant-cast]
+        snap_to_closest_point=snap_to_closest_point,
     )
 
     if field not in sampled.point_data:
@@ -1196,7 +1198,7 @@ def _sample_topview_field_duplicate(
             )
         )
         if not valid.any() and not snap_to_closest_point:
-            sampled = probe.sample(cast(pv.DataSet, source), snap_to_closest_point=True)
+            sampled = probe.sample(cast(pv.DataSet, source), snap_to_closest_point=True)  # ty: ignore[redundant-cast]
             arr = sampled.point_data[field]
             if arr.ndim == 2:
                 values = (
@@ -1302,7 +1304,7 @@ def _plot_topview_duplicate(
             msg = "No points available for direct surface plotting."
             raise ValueError(msg)
 
-        surf = source.extract_surface(algorithm="dataset_surface").triangulate()
+        surf = source.extract_surface(algorithm="dataset_surface").triangulate()  # ty: ignore[unknown-argument]
         if surf.n_cells == 0 or field not in surf.point_data:
             logger.warning(
                 "plot_topview: direct surface plot unavailable for %s; "
@@ -1572,7 +1574,7 @@ def _plot_cross_section_duplicate(
         Z3[:, :] = origin
 
     probe_grid = pv.StructuredGrid(X3, Y3, Z3)
-    sampled = probe_grid.sample(cast(pv.DataSet, sliced))
+    sampled = probe_grid.sample(cast(pv.DataSet, sliced))  # ty: ignore[redundant-cast]
 
     if field not in sampled.point_data:
         available = list(sampled.point_data.keys())


### PR DESCRIPTION
## Summary
- Silence 10 `ty` diagnostics in `src/gsim/viz.py` (8 `redundant-cast` from pyvista stub improvements + 2 `unknown-argument` from `extract_surface(algorithm=...)` no longer appearing in the stubs). Runtime behavior is unchanged — these are stub-only issues.
- Rename docs nav entry "2D Effective-Index" → "2D FDTD" in `mkdocs.yml` and the matching H1 in `nbs/meep_2d.ipynb`, so https://gdsfactory.github.io/gsim/nbs/meep_2d/ renders as "2D FDTD".

## Context
`bver bump patch` was failing because its full-tree pre-commit run hit these pre-existing `ty` failures. CI didn't catch them because `pre-commit/action` only runs hooks on PR-changed files and `ty` only checks the paths it's given (it doesn't follow imports project-wide). The underlying drift came from a pyvista stub update, not any `.py` edit on `main`.