### PR TITLE
fix: replace Unicode arrow with ASCII for Windows compatibility

### DIFF
--- a/src/gsim/common/polygon_utils.py
+++ b/src/gsim/common/polygon_utils.py
@@ -211,7 +211,7 @@ def inspect_layers(
     if not polys_by_layer:
         raise ValueError("Component has no polygons")
 
-    # Build layer-index → name mapping
+    # Build layer-index -> name mapping
     layer_names: dict[object, str] = {}
     try:
         layout = component.kcl.layout

--- a/src/gsim/common/viz/render2d.py
+++ b/src/gsim/common/viz/render2d.py
@@ -223,8 +223,8 @@ def _plot_single_prism_slice(
     )
 
     # Compute total polygon area per layer for draw-order tiebreaking
-    # and alpha assignment.  Larger area → background → draw first / more
-    # transparent.  Smaller area → patterned → draw last / most opaque.
+    # and alpha assignment.  Larger area -> background -> draw first / more
+    # transparent.  Smaller area -> patterned -> draw last / most opaque.
     def _layer_area(name: str) -> float:
         if name not in geometry_model.prisms:
             return float("inf")
@@ -248,7 +248,7 @@ def _plot_single_prism_slice(
         ),
     )
 
-    # Mesh-order → zorder: lower mesh_order = background = lower zorder
+    # Mesh-order -> zorder: lower mesh_order = background = lower zorder
     mesh_orders = np.unique(
         [geometry_model.layer_mesh_orders.get(n, 0) for n in sorted_names]
     )
@@ -272,7 +272,7 @@ def _plot_single_prism_slice(
     _layer_alpha: dict[str, float] = {}
     for n in layer_names:
         ratio = layer_areas.get(n, max_area) / max_area if max_area > 0 else 1.0
-        # Map: ratio 1.0 (largest area) → alpha 0.35, ratio ~0 → alpha 0.90
+        # Map: ratio 1.0 (largest area) -> alpha 0.35, ratio ~0 -> alpha 0.90
         _layer_alpha[n] = 0.90 - 0.55 * ratio
 
     xmin, xmax = np.inf, -np.inf
@@ -483,7 +483,7 @@ def _draw_prism_cross_sections(
     line y=y0 to find x-segments. Each segment becomes a rectangle in
     XZ space: (x_start, z_base) to (x_end, z_top).
 
-    For an x-slice at x=x0, similarly finds y-segments → YZ rectangles.
+    For an x-slice at x=x0, similarly finds y-segments -> YZ rectangles.
 
     Returns True if at least one patch was drawn.
     """
@@ -664,7 +664,7 @@ def _draw_overlay_xy(
         labeled.add(legend_key)
         hw = port.width / 2
 
-        if port.normal_axis == 0:  # x-normal → vertical line
+        if port.normal_axis == 0:  # x-normal -> vertical line
             ax.plot(
                 [cx, cx],
                 [cy - hw, cy + hw],
@@ -681,7 +681,7 @@ def _draw_overlay_xy(
                 arrowprops=dict(arrowstyle="->", color=color, lw=1.5),
                 zorder=96,
             )
-        else:  # y-normal → horizontal line
+        else:  # y-normal -> horizontal line
             ax.plot(
                 [cx - hw, cx + hw],
                 [cy, cy],

--- a/src/gsim/gcloud.py
+++ b/src/gsim/gcloud.py
@@ -86,7 +86,7 @@ class RunResult:
 
     Attributes:
         sim_dir: Root directory (``{job_type}_{job_name}/``).
-        files: Flat mapping of filename → Path inside ``output/``.
+        files: Flat mapping of filename -> Path inside ``output/``.
         job_name: Cloud job identifier.
     """
 
@@ -116,8 +116,8 @@ def register_result_parser(solver: str, parser: Callable[[RunResult], Any]) -> N
 def _extract_solver_from_job(job) -> str | None:
     """Extract the solver name from a Job's ``job_def_name``.
 
-    Handles formats like ``"prod-meep-simulation"`` → ``"meep"``,
-    ``"prod-palace-simulation"`` → ``"palace"``, or plain ``"meep"``.
+    Handles formats like ``"prod-meep-simulation"`` -> ``"meep"``,
+    ``"prod-palace-simulation"`` -> ``"palace"``, or plain ``"meep"``.
     """
     name = getattr(job, "job_def_name", "") or ""
     # Try known solver names in the definition string
@@ -142,7 +142,7 @@ def _get_result_parser(solver: str) -> Callable[[RunResult], Any] | None:
 
 
 def _flatten_results(raw_results: dict) -> dict[str, Path]:
-    """Flatten gdsfactoryplus download results to a filename → Path dict.
+    """Flatten gdsfactoryplus download results to a filename -> Path dict.
 
     The SDK may return directories (extracted archives) or individual files.
     This walks everything and returns a flat mapping.

--- a/src/gsim/meep/models/api.py
+++ b/src/gsim/meep/models/api.py
@@ -36,7 +36,7 @@ class Geometry(BaseModel):
         description=(
             "Y coordinate of the XZ cross-section cut (um). "
             "Only meaningful when solver.is_3d=False and solver.plane='xz'. "
-            "None → resolved to the component bbox Y-center at build time."
+            "None -> resolved to the component bbox Y-center at build time."
         ),
     )
 
@@ -139,8 +139,8 @@ class FiberSource(BaseModel):
     polarization: Literal["TE", "TM"] = Field(
         default="TE",
         description=(
-            "PIC convention. 'TE' → E along waveguide width (Ey, out of XZ "
-            "plane); 'TM' → E in the XZ plane (Ex)."
+            "PIC convention. 'TE' -> E along waveguide width (Ey, out of XZ "
+            "plane); 'TM' -> E in the XZ plane (Ex)."
         ),
     )
 

--- a/src/gsim/meep/models/config.py
+++ b/src/gsim/meep/models/config.py
@@ -345,8 +345,8 @@ class SimConfig(BaseModel):
     plane: Literal["xy", "xz"] = Field(
         default="xy",
         description=(
-            "2D simulation plane when is_3d=False. 'xy' → effective-index "
-            "top-down; 'xz' → vertical cross-section at y=y_cut."
+            "2D simulation plane when is_3d=False. 'xy' -> effective-index "
+            "top-down; 'xz' -> vertical cross-section at y=y_cut."
         ),
     )
     y_cut: float | None = Field(

--- a/src/gsim/meep/script.py
+++ b/src/gsim/meep/script.py
@@ -574,8 +574,8 @@ def _build_fiber_source(config, fiber):
     """Construct a mp.GaussianBeamSource for XZ 2D fiber coupling.
 
     Polarization (PIC convention):
-      - TE → E along waveguide width (Ey, out of XZ plane)
-      - TM → E in the XZ plane (Ex)
+      - TE -> E along waveguide width (Ey, out of XZ plane)
+      - TM -> E in the XZ plane (Ex)
     """
     fdtd = config["fdtd"]
     fcen = fdtd["fcen"]
@@ -592,7 +592,7 @@ def _build_fiber_source(config, fiber):
     src_x_size = _estimate_source_x_size(config)
 
     # beam_x0 is the focus offset *relative to* the source center, not an
-    # absolute position (MEEP docs). Focus sits on the source line → zero.
+    # absolute position (MEEP docs). Focus sits on the source line -> zero.
     src = mp.GaussianBeamSource(
         src=mp.GaussianSource(frequency=fcen, fwidth=fwidth, is_integrated=True),
         center=center,
@@ -754,7 +754,7 @@ def build_monitors(config, sim):
 
     When ``config["fiber_source"]`` is set, also builds a flux monitor
     just in front of (below) the Gaussian beam to measure the launched
-    power, used as normalization reference for fiber→waveguide S-params.
+    power, used as normalization reference for fiber->waveguide S-params.
 
     Returns:
         (port_monitors, fiber_flux) where fiber_flux is None unless a
@@ -990,7 +990,7 @@ def extract_s_params(config, sim, monitors, fiber_flux=None):
 
 
 def _extract_s_params_fiber(config, sim, monitors, fiber_flux):
-    """Extract fiber→waveguide S-parameters for a Gaussian-beam source.
+    """Extract fiber->waveguide S-parameters for a Gaussian-beam source.
 
     Normalization reference is the net flux through ``fiber_flux`` (placed
     just in front of the Gaussian beam): P_fiber(f). For each port i,

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -120,7 +120,7 @@ class Simulation(BaseModel):
         cls,
         v: dict[str, float | Material | dict],
     ) -> dict[str, float | Material]:
-        """Accept float shorthand: ``{"si": 3.47}`` → ``Material(n=3.47)``."""
+        """Accept float shorthand: ``{"si": 3.47}`` -> ``Material(n=3.47)``."""
         out: dict[str, float | Material] = {}
         for name, val in v.items():
             if isinstance(val, (int, float)):
@@ -449,7 +449,7 @@ class Simulation(BaseModel):
         )
 
     def _source_config(self) -> Any:
-        """Translate ModeSource → SourceConfig."""
+        """Translate ModeSource -> SourceConfig."""
         from gsim.meep.models.config import SourceConfig
 
         return SourceConfig(
@@ -458,7 +458,7 @@ class Simulation(BaseModel):
         )
 
     def _stopping_config(self) -> Any:
-        """Translate FDTD stopping fields → StoppingConfig."""
+        """Translate FDTD stopping fields -> StoppingConfig."""
         from gsim.meep.models.config import StoppingConfig
 
         s = self.solver
@@ -474,7 +474,7 @@ class Simulation(BaseModel):
         )
 
     def _domain_config(self) -> Any:
-        """Translate Domain → DomainConfig."""
+        """Translate Domain -> DomainConfig."""
         from gsim.meep.models.config import DomainConfig
 
         return DomainConfig(
@@ -489,13 +489,13 @@ class Simulation(BaseModel):
         )
 
     def _resolution_config(self) -> Any:
-        """Translate FDTD.resolution → ResolutionConfig."""
+        """Translate FDTD.resolution -> ResolutionConfig."""
         from gsim.meep.models.config import ResolutionConfig
 
         return ResolutionConfig(pixels_per_um=self.solver.resolution)
 
     def _accuracy_config(self) -> Any:
-        """Translate FDTD accuracy fields → AccuracyConfig."""
+        """Translate FDTD accuracy fields -> AccuracyConfig."""
         from gsim.meep.models.config import AccuracyConfig
 
         return AccuracyConfig(
@@ -506,7 +506,7 @@ class Simulation(BaseModel):
         )
 
     def _diagnostics_config(self) -> Any:
-        """Translate FDTD diagnostic fields → DiagnosticsConfig."""
+        """Translate FDTD diagnostic fields -> DiagnosticsConfig."""
         from gsim.meep.models.config import DiagnosticsConfig
 
         return DiagnosticsConfig(
@@ -717,7 +717,7 @@ class Simulation(BaseModel):
         fwidth = source_cfg.compute_fwidth(wl_cfg.fcen, wl_cfg.df)
         source_for_config = source_cfg.model_copy(update={"fwidth": fwidth})
 
-        # Translate domain.symmetries → SymmetryEntry for config
+        # Translate domain.symmetries -> SymmetryEntry for config
         symmetry_entries = [
             SymmetryEntry(direction=s.direction, phase=s.phase)
             for s in self.domain.symmetries

--- a/src/gsim/palace/PORTS.md
+++ b/src/gsim/palace/PORTS.md
@@ -160,14 +160,14 @@ If the port only touches one conductor, voltage is undefined - there's no second
 Ground ═══════╡▓▓▓▓▓▓╞═══════ Signal
               ↑     ↑
               └──┬──┘
-           E-field integrated → Voltage
+           E-field integrated -> Voltage
 
 
                 Port touching only signal (WRONG):
 
 Ground ═══════      ▓▓▓▓▓▓═══════ Signal
                     ↑
-                    No reference → Voltage undefined
+                    No reference -> Voltage undefined
 ```
 
 ### Real-World Analogy

--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -178,7 +178,7 @@ def _merge_via_polygons(
     if not shapely_polys:
         return polys
 
-    # Oversize → union → undersize
+    # Oversize -> union -> undersize
     buffered = [buffer(p, offset, join_style="mitre") for p in shapely_polys]
     merged = buffer(unary_union(buffered), -offset, join_style="mitre")
 
@@ -200,7 +200,7 @@ def _merge_via_polygons(
     n_after = len(result)
     if n_before != n_after:
         logger.info(
-            "Via merging: %d polygons → %d (distance=%.1f um)",
+            "Via merging: %d polygons -> %d (distance=%.1f um)",
             n_before,
             n_after,
             merge_distance,
@@ -292,7 +292,7 @@ def add_metals(
             planar_conductors or thickness == 0 or thickness < min_volume_thickness
         )
         if layer_type == "conductor" and is_planar:
-            # Zero/thin-thickness or explicitly planar → 2D PEC surface
+            # Zero/thin-thickness or explicitly planar -> 2D PEC surface
             metal_tags[layer_name]["surfaces_xy"].extend(surfaces)
         elif layer_type == "via":
             # Decide between 3D volume (with conductivity) and 2D PEC fallback

--- a/src/gsim/palace/mesh/gmsh_utils.py
+++ b/src/gsim/palace/mesh/gmsh_utils.py
@@ -37,7 +37,7 @@ class Entity:
 def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
     """Meshwell-style boolean pipeline (minimalistic).
 
-    1. Group entities by dimension (descending: 3 → 0).
+    1. Group entities by dimension (descending: 3 -> 0).
     2. Within each dimension, sort by mesh_order (ascending = higher priority).
     3. For dim=3: fragment all volumes together in one pass (avoids degenerate
        sliver faces from priority cuts on small volumes like vias).
@@ -50,7 +50,7 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
        labelled by the pair of volume names they separate).
 
     Returns:
-        pg_map: mapping from physical-group name → pg tag.
+        pg_map: mapping from physical-group name -> pg tag.
     """
     gmsh.model.occ.synchronize()
 
@@ -204,7 +204,7 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
             if tags:
                 gmsh.model.addPhysicalGroup(3, tags, name=entity.name)
 
-    # 2. Surface → volume ownership map
+    # 2. Surface -> volume ownership map
     vol_entities = [e for e in entities if e.dim == 3 and e.dimtags]
     surf_to_names: dict[int, list[str]] = {}
     for entity in vol_entities:

--- a/src/gsim/palace/mesh/groups.py
+++ b/src/gsim/palace/mesh/groups.py
@@ -37,7 +37,7 @@ def assign_physical_groups(
         port_tags: Port surface tags (may have multiple surfaces for CPW)
         port_info: Port metadata including type info
         entities: Entity list used in run_boolean_pipeline
-        pg_map: name → physical-group tag returned by run_boolean_pipeline
+        pg_map: name -> physical-group tag returned by run_boolean_pipeline
         _stack: Layer stack used to identify via layers
 
     Returns:
@@ -59,7 +59,7 @@ def assign_physical_groups(
         "boundary_surfaces": {},
     }
 
-    # Helper: entity name → (phys_group, surface_tags)
+    # Helper: entity name -> (phys_group, surface_tags)
     entity_by_name: dict[str, gmsh_utils.Entity] = {e.name: e for e in entities}
 
     # Build set of via layer names

--- a/src/gsim/palace/ports/config.py
+++ b/src/gsim/palace/ports/config.py
@@ -374,9 +374,9 @@ def extract_ports(component, stack: LayerStack) -> list[PalacePort]:
             # Compute E-field directions from port orientation.
             # transverse = 90° CCW from the longitudinal direction = [-sin, cos]
             # upper_center = signal_center + transverse * gap_offset
-            #   → E-field in upper gap points toward signal: -transverse direction
+            #   -> E-field in upper gap points toward signal: -transverse direction
             # lower_center = signal_center - transverse * gap_offset
-            #   → E-field in lower gap points toward signal: +transverse direction
+            #   -> E-field in lower gap points toward signal: +transverse direction
             import numpy as np
 
             orientation_rad = np.deg2rad(

--- a/src/gsim/palace/results.py
+++ b/src/gsim/palace/results.py
@@ -608,7 +608,7 @@ def load_fields(
         source: Results dict from ``sim.run_local()`` / ``sim.run()``,
             or a path to the simulation directory.
         excitation: Excitation index (1-based) to load.
-        cycle: ParaView cycle number (``None`` → last available).
+        cycle: ParaView cycle number (``None`` -> last available).
         boundary: If ``True``, load boundary surface fields
             (``driven_boundary/``) instead of volume fields
             (``driven/``).  Boundary data includes ``J_s_real``,

--- a/src/gsim/viz.py
+++ b/src/gsim/viz.py
@@ -45,7 +45,7 @@ def plot_mesh(
     Args:
         msh_path: Path to ``.msh`` file.
         output: Output PNG path (only used when ``interactive=False``).
-        show_groups: Group-name patterns to display (``None`` → all).
+        show_groups: Group-name patterns to display (``None`` -> all).
             Example: ``["metal", "P"]`` to show metal layers and ports.
         interactive: If ``True``, open an interactive 3-D viewer.
             If ``False``, save a static PNG to *output*.
@@ -843,7 +843,7 @@ def plot_cross_section(
 
     # Determine the two in-plane axes (h = horizontal, v = vertical)
     axes = [i for i in range(3) if i != axis_idx]
-    h_idx, v_idx = axes  # e.g. normal="x" → h=y(1), v=z(2)
+    h_idx, v_idx = axes  # e.g. normal="x" -> h=y(1), v=z(2)
 
     h_pts = pts[:, h_idx]
     v_pts = pts[:, v_idx]
@@ -1541,7 +1541,7 @@ def _plot_cross_section_duplicate(
 
     # Determine the two in-plane axes (h = horizontal, v = vertical)
     axes = [i for i in range(3) if i != axis_idx]
-    h_idx, v_idx = axes  # e.g. normal="x" → h=y(1), v=z(2)
+    h_idx, v_idx = axes  # e.g. normal="x" -> h=y(1), v=z(2)
 
     h_pts = pts[:, h_idx]
     v_pts = pts[:, v_idx]

--- a/tests/meep/test_ports.py
+++ b/tests/meep/test_ports.py
@@ -39,7 +39,7 @@ class TestFilterPortsForXZ:
         assert kept == []
 
     def test_partial_overlap_included(self):
-        # Port at y=0.2, width 0.5 → extends from y=-0.05 to y=0.45;
+        # Port at y=0.2, width 0.5 -> extends from y=-0.05 to y=0.45;
         # cut at y=0 falls inside.
         ports = [_port("o1", x=0.0, y=0.2, orientation=180, width=0.5)]
         kept = filter_ports_for_xz(ports, y_cut=0.0)

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -624,7 +624,7 @@ class TestXZBuildConfig:
 
         result = sim.build_config()
 
-        # Straight is centered on y=0 → bbox center is 0.
+        # Straight is centered on y=0 -> bbox center is 0.
         assert result.config.y_cut == pytest.approx(0.0, abs=1e-6)
 
     def test_y_cut_explicit_override(self):

--- a/tests/meep/test_viz_xz.py
+++ b/tests/meep/test_viz_xz.py
@@ -74,7 +74,7 @@ class TestPlot2DXZ:
     def test_default_slice_when_plane_xz(self):
         sim = _xz_sim_for_viz()
         fig, ax = plt.subplots()
-        # Default: plane='xz' → slices='y'.
+        # Default: plane='xz' -> slices='y'.
         result = sim.plot_2d(ax=ax)
         assert result is ax
         plt.close(fig)

--- a/tests/palace/test_results.py
+++ b/tests/palace/test_results.py
@@ -168,7 +168,7 @@ class TestSParams:
         sp = load_sparams(sim_dir)
         fig = sp.plot_interactive()
         names = [trace.name for trace in fig.data]
-        # 3 ports → S11, S21, S31 etc.
+        # 3 ports -> S11, S21, S31 etc.
         assert "S11" in names
         assert "S21" in names
 

--- a/tests/test_gcloud_start.py
+++ b/tests/test_gcloud_start.py
@@ -243,7 +243,7 @@ class TestWaitForResultsSingle:
         mock_sim.download_results.return_value = {"output": output_file}
 
         result = wait_for_results(*["job-1"], verbose="quiet", parent_dir=tmp_path)
-        # Single element list → single result, not a list
+        # Single element list -> single result, not a list
         assert not isinstance(result, list)
 
     def test_empty_raises(self):


### PR DESCRIPTION
## Summary
- Replace all Unicode arrow characters (`→`, U+2192) with ASCII `->` across source and test files
- The `→` character cannot be encoded by the Windows cp1252 codec, causing `UnicodeEncodeError` during installation on Windows

Closes #122

## Test plan
- [x] All pre-commit hooks pass (ruff, codespell, ty, etc.)
- [ ] Verify `pip install` succeeds on Windows