### PR TITLE
Relax gdsfactory version pin to >=9,<10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-  "gdsfactory~=9.39",
+  "gdsfactory>=9.39",
   "gdsfactoryplus>=1.6.4",
   "gmsh",
   "meshio>=5.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-  "gdsfactory>=9.39",
+  "gdsfactory>=9,<10",
   "gdsfactoryplus>=1.6.4",
   "gmsh",
   "meshio>=5.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
   "gdsfactory>=9,<10",
-  "gdsfactoryplus>=1.6.4",
+  "gdsfactoryplus>=1.6.4,<2",
   "gmsh",
   "meshio>=5.0.0",
   "nbformat>=4.2.0",


### PR DESCRIPTION
## Summary
- Change `gdsfactory~=9.39` to `gdsfactory>=9,<10` in pyproject.toml
- Allows picking up new gdsfactory minor releases without pinning, while staying on the 9.x series

## Test plan
- [ ] Verify CI passes with the relaxed constraint