### PR TITLE
ci: add Windows and macOS to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,18 @@ on:
       - main
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     permissions:
       contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
-      - name: Install system dependencies
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libglu1-mesa libegl1 libgl1 libxrender1 libxcursor1 libxft2 libxinerama1
       - name: Install UV
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
## Summary
- Adds a cross-platform CI matrix (`ubuntu-latest`, `windows-latest`, `macos-latest`) to the `test` job
- Linux system dependencies are now conditional (`if: runner.os == 'Linux'`)
- Coverage job stays on Ubuntu only (no change)

## Test plan
- [ ] Verify all three OS jobs pass in CI