### PR TITLE
fix: force utf-8 on write_text so Windows cp1252 doesn't break output

### DIFF
--- a/src/gsim/common/stack/extractor.py
+++ b/src/gsim/common/stack/extractor.py
@@ -317,7 +317,7 @@ class LayerStack(BaseModel):
         if path:
             path = Path(path)
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(yaml_str)
+            path.write_text(yaml_str, encoding="utf-8")
             logger.info("Stack written to: %s", path)
 
         return yaml_str

--- a/src/gsim/meep/models/config.py
+++ b/src/gsim/meep/models/config.py
@@ -412,5 +412,5 @@ class SimConfig(BaseModel):
         data = self.model_dump(by_alias=True)
         if self._hints:
             data.update(self._hints)
-        path.write_text(json.dumps(data, indent=2))
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
         return path

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -812,7 +812,7 @@ class Simulation(BaseModel):
         # Write runner script
         script_path = output_dir / "run_meep.py"
         script_content = generate_meep_script(config_filename="sim_config.json")
-        script_path.write_text(script_content)
+        script_path.write_text(script_content, encoding="utf-8")
 
         logger.info("Config written to %s", output_dir)
         return output_dir


### PR DESCRIPTION
## Summary
- Three `Path.write_text(...)` call sites were missing `encoding=`, defaulting to the host codec — cp1252 on Windows — and raising `UnicodeEncodeError` when the payload contained non-cp1252 chars. This is what causes the runtime failure reported for `sim.run()` → `upload()` → `write_config()`.
- Fixed sites:
  - `src/gsim/meep/simulation.py:815` — generated `run_meep.py`
  - `src/gsim/meep/models/config.py:415` — `sim_config.json`
  - `src/gsim/common/stack/extractor.py:320` — stack YAML (uses `allow_unicode=True`, so this was the most exposed)
- Runtime counterpart to the install-time cp1252 cleanup in #123 and #125: those scrubbed the source chars, this makes the output codec independent of the host locale so a future edit can't silently reintroduce the bug.