### PR TITLE
Palace driven simulation for spiral inductor with guard ring

### DIFF
--- a/nbs/palace_inductor.ipynb
+++ b/nbs/palace_inductor.ipynb
@@ -1,0 +1,2113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "87779b57",
+   "metadata": {},
+   "source": [
+    "# Running Palace Simulations\n",
+    "\n",
+    "[Palace](https://awslabs.github.io/palace/) is an open-source 3D electromagnetic simulator supporting eigenmode, driven (S-parameter), and electrostatic simulations. This notebook demonstrates using the `gsim.palace` API to run a driven simulation on a spiral inductor with Metal1 guard ring.\n",
+    "\n",
+    "**Requirements:**\n",
+    "- IHP PDK: `uv pip install ihp-gdsfactory`\n",
+    "- gsim with Palace backend\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23b2aff6",
+   "metadata": {},
+   "source": [
+    "### Build inductor + guard ring\n",
+    "\n",
+    "**Known PDK limitation:** `gf.components.inductor` accepts a `turns` parameter but does not use it in geometry construction. The spiral is always single-turn regardless of the value passed.\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "52509b1f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzAAAAJoCAYAAAC5ogQ1AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAMTgAADE4Bf3eMIwAAXMhJREFUeJztvc2x5DiShYtsGyVmBJiSIWYzVqtRozV5LE1Kjbe6NptXMlQL0C1GvEVOVDFZIEGCAP3g4PvMjmV6Mu+NQ5AR+HF48Nv7/X4nAAAAAACAAfhbtAEAAAAAAICzMIEBAAAAAIBhYAIDAAAAAADDwAQGAAAAAACGgQkMAAAAAAAMAxMYAAAAAAAYBiYwAAAAAAAwDP9W+g/fvn17wgcAAAAAAEAqPaaSDAwAAAAAAAxDlwnMsiw9fm01Sn7wkgcvefCyj5IfvOTBSx687KPkBy958JIHL/v08PPtXcjRsIUMAAAAAACegi1kAAAAAABgA1vIHgYvefCSBy/7KPnBSx685MHLPkp+8JIHL3nwsg9byAAAAAAAwBq2kAEAAAAAgA1MYAAAAAAAYBiogXkYvOTBSx687KPkBy958JIHL/so+cFLHrzkwcs+1MAAAAAAAIA11MAAAAAAAIANbCF7GLzkwUsevOyj5AcvefCSBy/7KPnBSx685MHLPmwhAwArfv/ncYoYALT56T8YIwBAe0pbyJjATMLri4EiaPHrT9///M9/5zMGYET+8a/v/crffw82ArDht5/pV0anNIH5t4d8gACub+jX19v23Fz5ZF7+89+//TEIAoCx+Lx/f/2JTMxoOPebLNhOwrtASumylmWp+rleUvIT5eX19f7hz4+Xdbw9/mT8aZean1//Wws/62uk0j4Kcav75fd/ftf7nf74e6Sf6Pu3dcz9y/3yxP2Sex9z/45z/277Tqf7d/v/nhJjzbZ+SrCFbBJeX96rLa7n5kYu88LKLcCY8H4eF+d+0/ncZqIwPeFrlGfl9fUmJn40PhrsKPgjJia+Fn/ev//41/uPWrbf//mW8Uc8ZwyTUErRpElTV25eXpmUqku75M5txGvk7OVo29jsbYMXvIzupeX7261tVL3c6TfV26X1mMClXUbzU5yf9JjAID193tDbN7ZDvP43BT/EP8atal6IiYl14141McR94m3fGe2nZbz9dzSmSlADMwmvL989oc7nNjrskQeYB97v4+Dcbzqf20wUpifUwMzK6+tNTNw1puaFmHiumJoYYoUYJqGUokmrdM56D9t2P1vvY9GvP/qx19dbxkvra/1apYtVz2m2Y0fbxqK9cSzmWPTrc+y5Y6WaGFXfMx3bjgmc3tefMYGCF6djT79+cX5yZQKDxtXnDb0e7LvE639T8DN7TM0LMTExNTHa8bbvjPbTMt7+OxpTJaiBmYTXl++eUOdzGw32wAPABz4PdHHuN53PbSYK05M+NTDLsvT4tdUo+VHx8vp6/+Dl9fX+y/FZ42VZZPx8rpGCn9L98nTNC/dvPub+5X5RuV9qamK4f7l/796/UaiM71LS8pJSHz9kYCbh9eW7IuF8bqPASisA7MHngx7O/abzuc1ESAYGdFFaOSH2iPm2MWJi4qOYbycjjojBGzIwk/D68l2RcD43dVhZBYCz8Hmhg3O/6XxuM0ENTNLyo+Ll9cWe2r2YPdj5eHu/RGdeuH/zMfcv94vq/XImE8P9y/179/6NQmV8l5KWl5SogYEbvL58VyScz00VVlIBoBY+P+Jx7jedz20mqIGBH1BaOSEeM47OvBATE48dUxND/EQM5pQeFJMqHj6zfcpmtJT8RHl5ZR7s5NIuuXMb8RqN4KX0hO2Z2ybaA17wMpqX3OcJbfOMlzv9pnq7tB4TuLTLaH6K85MeExikp+0b2il+ffk+UVgpPpq8KPgjJiYeL859rij5c423fWi0n54xGlMlqIGZhNeX755Q53NTgT3rANALPl+ex7nfdD63mShMT6iBmY3X15uY+FJMzQsxMXHPmJoY4h4xmFNK0aSKtI/D3js3L69MStWlXXLnNuI1UvSiVPOi1jZ4wQte2krt80apbaiBOe+l9ZjApV1G81Ocn/SYwCA9bd/QTvHriz3TPWJqXoiJiZ+OqYl5Jt72odF+esZoTJWgBmYSXl++e0Kdzy0K9qQDQBR8/vTHud90PreZKExP+tTAzPAE0Fqivby+/rwheOJxPp79icd7gwel+yUl7t+9ePb7dy/mfhnjflmWhZqYTMz9e/3+fZro8d0aJS8p9fFDBmYSXl++KxLO5/Y0rHwCgAp8HvXDud90PreZCMnAgD4KKyfEWjHfNkZMTKwUk4khrolhDsjATMLry3dFwvncnoKVTgBQhc+n9jj3m87nNhPUwCQtP9Fe1isV7KnNx2p7wnvHZzMvSveLmh/uX/2Y+2WM+yXnh0wM9+9eTA1MHiUvKVEDAzd4ffmuSDifW29Y2QSAUeDzqh3O/abzuc0ENTCQRWHlhDg2puaFmJh4pJhMDPGZGCah9KCYVPHwGYcngLp5eWUe7OTSLrlzG/EaPeml5onXSu2i5gcveMHLc35qPr9Gb5vWXu70m+rt0npM4NIuo/kpzk96TGCQnj5v6O0b2yFe/5uCH/X4qPNX8EdMTExcinOfY0r+1ONt3xntp2W8/Xc0pkpQAzMJry/fPaHO59Ya9pADgAt8ntXj3G86n9tMFKYn1MDMyuvrTTxZTM0LMTGxU0xNDHEuhkkopWhSRdrHYe+dm5dXJqXq0i65cxvxGvX00mLPuFK7qPnBC17wEuenV02MUttQA3PeS+sxgUu7jOanOD/pMYFBevq8obdvbId4/W8KftRial6IiYndY2pirsXbvjPaT8t4++9oTJWgBmYSXl++e0Kdz+0u7BEHgFng8+48zv2m87nNRGF60qcGZoYngNai4uX1pfcEZpXY5YnHrWte1O4XNT8qscv92zrmfsnHSvfLXT+ta2K4f/Xj3P0Shcr4LiUtLyn18UMGZhJeX74rEs7nVgsrkQAwK3z+lXHuN53PbSZCMjCgi9LKCXGfmG8bIyYmnjnm28mIwR8yMJPw+vJdkXA+t6uw8ggA8B0+D/dx7jedz20mmmZg1nvYtvvZeh+Lfn23Y6+v83tqt3tM1/F2j/A6rn296Ncf9fXOZl6Uzi/69Xm9514v+vV5vWdfL/r1UzqXiRm1fVVeL/r1c6+X+zvH7h+LeP0jyMBMwuvLd0XC+dzOwkojAEAePh//inO/6XxuM0ENDPzAlZUU4jFial6IiYmJ92NqYuaMwZzSg2JSxcNnFoMngLp5eWUe7OTSLrlzG/Ea1Xjp9QRq9XZR84MXvOBF38/Vz0ultmnt5U6/qd4urccELu0ymp/i/KTHBAbpafuGdopfX75PFD6KjzpjBX/ExMTEanHuc1PJ31Pxtg+N9tMzRmOqBDUwk/D68t0T6nxue7CnGwCgDj4/vftN53ObicL0hBqY2Xh9vYkHj6l5ISYmJq6PqYmZIwZzSimaVJH2cdh75+bllUmpurRL7txGvEZnvDxZ86LcLmp+8IIXvIznp/R5qtQ21MCc99J6TODSLqP5Kc5PekxgkJ62b2in+PU1xx5mal6IiYmJ28az1sRs+9BoPz1jNKZKUAMzCa8v3z2hzuf2gT3bAAB9mPHz1bnfdD63mShMT/o8yHJZlktP0+yNkp8oL6+v4xsBdPn1p+9/rjvXv/8eaAgAwAw+Z72ImMAw1tynxk/IBAb0cF6RcD63GVcGAQAimOnz1rnfdD63mShNYPgWsknZZmRGjx2ZqTMFAIhm79vJ3InuvxkPQA1kYCbBeUXC8dyYvAAAxDDD569jv/nB+dxmIiQDo7TvLiUtP9Fe1isVy7KEr5R84k+7KKy8RF8j1c4zul22KPnBSx685MHLPgp+FDMxPdolur9uEa/bJToTo3DvflDyklIfP2RgJsF5RcLp3FQnLwAAs+H8eezUb25xPreZoAYGsiisnLSMHXDuLAEARkMxE9OD6P6b8QBUUXpQTKp4+IzDE0DdvOQe7OTSLq0fWhXRLnsPqXS5Ru5+8IIXvPj5+Xg5eojwqO1yp99UvEatzk3pGrl4qfVTnJ/0mMAgPX3e0NFPxO0Rj/7UXYXOESGE0L7cPqdzfadLPPqYAH1XCWpgJsF5T+jI58a2MQCAMXD6vB653yzhfG4zUZieUAMzK9F7VNnz6tUZAgC441oTE91/Mx6AKnpsIXPYe+fmhRoYrWt0djuCyzVy94MXvODFz8+el4jtZNTAnPdCDYyWl1o/xflJjwkM0hM1MDpy20uNEEKzafTPcWpgkLpKUAMzCc57Qkc6N7aNAQB4MPLn+Uj95lWcz20mCtOTPjUwMzwBtBYVL6+v4yfYjha3pNc1qunsVO6XlLS8pKTlBy958JIHL/so+Sl5ebImpme7RPffd+JlWWRqYEa6d5+mhx8yMJPgvCIxwrmNvFIHAAD7jPj5PkK/WYvzuc1ESAYGdFFaOekRKzJi5wYAAOcY9dvJovvrGccD0A4yMJPgvCKhfG5MXgAA5mCkz3vlfvMuzuc2E9TAJC0/Kl6ogdmn1TVq0Zmp3C8paXlJScsPXvLgJQ9e9lHyc9VLz0wMNTD5mBqYPEpeUqIGBm7gvCKheG4jrcQBAEA7Rvj8V+w3W+F8bjNBDQz8gNLKSY9YgRE6LwAA6MMoNTHR/fUM4wHoSI8HWTo8AdTNS+7BTi7t0vqhVXe8tH64mcs1cveDF7zgxc/PXS8t+4PW7XKn31S/RlEPslRvl9H8FOcnPSYwSE/bN7RTHPVhtdXoT2ZGCCHUVqr9wlEf6hajMVWCGphJcN4TqnBubBsDAIAciv2DQr/ZC+dzm4nC9IQamNmI3pPquOdVsXMCAAANVGtiovtrx/EAPMiVLWTrPWzb/Wy9j0W//ujHXl9vGS+tr/U6Xfy076PtAartq3Qs+vU5xrXmGNf6qWOl7WRPetmOCZyu9WdMoODF6djTr1+cn1yZwKBxFb0H1bEGRnVvM0IIIU2p9BvUwCB1laAGZhKc94RGnBvbxgAAoAaF/oMxAahTmJ5QAzMb0XtSHfa8KnQ+AAAwJio1MdH9tcN4AALpsYVsu78tWkp+orzkUqou7dI6XXzk5en0v8s1cveDF7zgxc9Pby9X+pPWXu70m+rXKGoLmXq7jOanOD/pMYFBeoreg+pQA6OydxkhhJCHovoVamCQukpQAzMJzntCnzg3to0BAEAPIvoXxgSgTmF60qcGZlmWHr+2GiU/0V7We0SXZQnfo/qJP+2isOd1e40iJy/R98saJS8pafnBSx685MHLPkp+nvJypiamh5fo/rpFvG6X6BqYGe/ds/TwQwZmEpxXJHqeG5kXAAB4gif7G8YEoE5IBgb0UVg5aRn3gMkLAAA8RdS3k0X33yOMB0APMjCT4Lwi0ePcmLwAAEAET/Q/jAlAHWpgkpafaC/UwJRRmrxE3y9rlLykpOUHL3nwkgcv+yj5ifLyVCYmur+mBqYfSl5SogYGbuC8ItHy3JQmLwAAMC89+yPGBKAONTCQRWHlpGXcAiYvAACggnomRjWGSejxIEuHJ4C6eck92MmlXVo8tEr1IZUu18jdD17wghc/PypeevRPd/pNlXbZ8xL1IEv1dhnNT3F+0mMCg/T0eUNv39gO8d0PK9XJC0IIIZRS+34q13e6xFETGNRWJaiBmQTnPaF3zo1tYwAAMAIt+yvGBKBOYXpCDcysRO9RVdjzyuQFAABGoVdNTHT/rTAegAHpsYXMYe+dmxdqYH7UUTrepV2cvaj5wQte8OLnR9VLi+1k1MDMc78oiBoYVC1qYP4UNS8IIYRG1t1+jBoYpK4S1MBMgvOe0CvnxrYxAABw4E5/xpgA1ClMT/rUwMzwBNBaVLy8vo6fYDtafIazH/Yq1yglvByh5AcvefCSBy/7KPlR99KqJia6/74TL8siUwOjfr9E0sMPGZhJcF6ROHNuZF4AAMCRmv5t9jEB6BOSgQFdlFZOesQ5mLwAAIArtZmY6P5aYWcGjAsZmElwXpE4OjcmLwAAMANX+rtZxwQwDtTAJC0/Kl5mqIGpnbyoXKOU8HKEkh+85MFLHrzso+RnNC8zZmKogcmj5CUlamDgBs4rErlzI/MCAAAzcqb/m21MAONBDQz8gNLKSY84JSYvAAAwL2czMdH9NTUwcIseD7J0eAKom5fcg51c2mV9bi0eUunSLs5e1PzgBS948fMzupej/vDOwx7V2yXqQZbq7TKan+L8pMcEBulp+4Z2ij9/bzF5QQghhFy01y/m+lDXGI2pEtTATILzntDX1zv9+tP3v7NtDAAA4E9y26r//nuyHhO4nttMFKYn1MDMRvSe1B4xkxcAAIA8uZqYX3/S6L97xmBOjy1kDnvv3Ly41sD02Dbm0C7uXtT84AUvePHz4+alVX+p3i7UwGh5qfVTnJ/0mMAgPUXvQe0RU/OCEEIInVeu31Toz3vGaEyVoAZmEtz2hPJVyQAAANdx7z/dxjuzUpieXKuBWT9Jc/tUzd7Hol/f5dh6j+g6/vy/XLz+Hbl4zd7vv/J6pdc/+vCNbl+OXTsW/foce+5Y9Otz7Llj0a/PseNje8+J6dFfb+M1LcYLR6+n2PYjH4t4/SPIwEyCy4rEbN+mAgAA0BrnL8BxGe/MTtMMDPgQ/e0gNbF72hsAAOApzmRiUtLo/6/EMAdkYCZh9BWJo8nL6OcGAADwJOt+021xkDGBByEZmCt72J5AyU+0l6M9p9vjT8bbPa7r46XJS2uir9EavOyj5AcvefCSBy/7KPlx9/LpP69mYo7666fjoxqbp3G/X+7Qww8ZmEkYdUXizMrQqOcGAAAQQa7fdMnEMCbwgBoYyKKwclKKn868AAAAzEZtJkY1hkno8SDLxeAJoG5ecg92Um6XKw+pbP3QKuV2wYumH7zgBS9+fpy9HPWbpf5XvV2iHmSp3i6j+SnOT3pMYJCePm/o6CfinomPPjxz/z/qwwohhBAaUbm+cx3n+mGF8cGZmDGBh0pQAzMJo+wJrdmDO8q5AQAAKHCm3xy1JoYxgQeF6Qk1MLMSvUf1bs0Le14BAADus9e/jloTA5PQYwuZw947Ny/qNTBXal7OnNuI1wgv4/rBC17w4ufH2cuVfvNO/xzRLtTAaHmp9VOcn/SYwCA9KdfAXK152cbsd0UIIYTOq1QDs41HqolhTOChEtTATILqntAWe2xVzw0AAECRmn5zlJoYxgQeFKYnfWpgZngCaC0qXl5fx0+wVa956bnnVeUapYSXI5T84CUPXvLgZR8lP7N4OdvfKtbELMsiUwMzy/1SQw8/ZGAmQW1FouVKjtq5AQAAKHOn31TPxDAm8CAkAwO6RH87SOvMi8rKCwAAwEjU9reKmZhcDN6QgZkElRWJHis3KucGAAAwAi36TdVMDGMCD6iBSVp+VLxE1MCMknlRuUYp4eUIJT94yYOXPHjZR8nPLF5GzsRQA5NHyUtK1MDADaJXJHqu1ESfGwAAwEi07DfVMjGMCTygBgZ+wK3mRWXlBQAAYCRa9b8KmZhcDOb0eJClwxNA3bzkHuz0hJezT/C946X1Q6u4X/S9qPnBC17w4ufH2cudfnPPy9n+vne7RD3I0vl+ifBTnJ/0mMAgPT31BNx1fPRh1vL1oj6sEEIIoRF11IfeiXP9fsT4I7p90X2VoAZmEp7eE/rknlj2uwIAAJynZ78ZXRPDmMCDwvSEGpjZcKt5Yc8rAADAdXr1xyo1MWBOjy1kDnvv3Lw8VQNTuweWGhi8jOwHL3jBi58fZy89amC2eqImhhoYfS+1forzkx4TGKQnp5qXbcx+V4QQQui8etXAbGOFmhg0pkpQAzMJvfeERu55Zb8rAADAeZ7sN58eHzAm8KAwPelTAzPDE0Brifay3iOae4JtVM3Lp10U9rxGX6M1eNlHyQ9e8uAlD172UfLj7qW2v73aX/esiVm3S3QNjPv9cocefsjATEKvFYnobxtJidUWAACAK0T0m0+NFxgTeBCSgQF9VDIvrWIAAAC4zlP99VPfTgZzQAZmElqvSChkXj6w2gIAAHCeyH6z9/iBMYEH1MAkLT/RXlrUwPTIvFADkwcv+yj5wUsevOTByz5Kfty9RPXXLTMx1MDkUfKSEjUwcINWKxJKmZcPrLYAAACcR6Hf7DWeUDg3uA81MJBFJfPSKgYAAIDrRPXfvWpiYA4uTWDWKaBtOqj3sejXdzv228/ffoj/539/+eHn1vGyLOnXn77/fTt5+fyOz2rHOq59vdzrr1dT1rFq+3Ls3LHo1+fYc8eiX59jzx2Lfn2OXTv2dH+9jnOTmF9/SqdfP/d6pfPlWN2xiNc/pPSkyyTwNE50X58n09Y80Tb3JN0rP9873v4bQgghhPaV6zsj49w4o/b3MSbwUAlqYCahdk+oYs3LFva7AgAAnEex32w13lA8N7gONTCQZfSaF/a8AgAA3Ce6/25dEwOT0GML2bIs4aknVT9RXnIp1SMvR9vG1NqldbqY+0Xfi5ofvOAFL35+nL3c6Td7t8uV8UfOS9QWMuf7JcJPcX7SYwKD9HSlBka95mUbs98VIYQQOi+1GphtfKcmhjGBh0pQAzMJZ/eEjlDzsoX9rgAAAOcZod+sHY+McG5QpjA96VMDc+lr0B5AyY+Kl9wTbEeqeem551XlGqWElyOU/OAlD17y4GUfJT+zeInuv+/UxCzLIlMDM8v9UkMPP2RgJqG0IjFi5uUDqy0AAADnGanfvDo+GencYJ+QDAzoMvq3jfHtIwAAAPeJ7q97fzsZeEMGZhL2ViRGzrx8YLUFAADgPCP2m2fHKyOeG/wVamCSlh8VL2Re9lG5Rinh5QglP3jJg5c8eNlHyc8sXqL779aZmChmuV9qoAYGqtmuSDhkXj6w2gIAAHCekfvN0vhl5HODP6EGBn7ALfOisvICAAAwEtH9tWsmBh6ix4MsHZ4A6ubl82CnK0+4HaVdWj+0ivtF34uaH7zgBS9+fpy93Ok3VdplbzwT9SBLlXZR81Lrpzg/6TGBQXp6fb0PJy9XnpCrFkd9WCGEEEIj6qgPHSnOjWsYE3ioBDUwk+BU87KF/a4AAADnceo3ncc3M1OYnlADMwPONS/seQUAALhOdH/duyYGzOmxhcxh752Tl71tYy7tQg3MfF7U/OAFL3jx8+PsxaEGZutlu51s9Gvk4qXWT3F+0mMCg7SUe0Mr7WG9G7PfFSGEEDovlxqYbRw5gUFtVYIamAn4/Z/vP7aPOe4LddrLCwAA0BvXftN9vDMThelJnxqYGZ4AWku0l/Ue0mVZZPawftpFoQYm+hqtwcs+Sn7wkgcvefCyj5Ifdy/R/XWLeN0u0TWx7vfLHXr4IQMzAe4rEq4rSQAAAD1w7TfdxzszEZKBAX0UVk5axgAAAHCd6P6b8QDUQAZmAtxXJFxXkgAAAHrg2m+6j3dmghqYpOUn2gs1MGWir9EavOyj5AcvefCSBy/7KPlx9xLdX1MD0w8lLylRAwOVuK9IuK4kAQAA9MC133Qf78wENTCQRWHlpGUMAAAA14nuvxkPQBU9HmTp8ARQJy97D3ZyaZftQ61GvEZ4GdsPXvCCFz8/zl7u9JvK7RL5IEvldolWjZ/i/KTHBAZpaf2GVnpibqu49QQGIYQQclau73SIIycwqK1KUAMzAe57Ql338gIAAPTAtd90H+/MRGF6Qg3MrETvUWXPKwAAQDzR/TfjAaiixxYyh713Tl6ogdG/RngZ2w9e8IIXPz/OXqiB0b9GLl5q/RTnJz0mMEhL1MAghBBC6CNqYJC6SlADMwHue0Jd9/ICAAD0wLXfdB/vzERhenKtBmb9JM3tUzV7H4t+fYdja0pPsF3Hy7Lsxtsn8q7j7e8/+3o1r78+lvs7xzSPRb8+x547Fv36HHvuWPTrc+zasaf765bjhe3r5c4vF3Ps+rGI1z+CDMwEuK9IuK4kAQAA9MC133Qf78xE0wwMjE/0t4Pw7SMAAADxRPfXjAfgDmRgJsB9RcJ1JQkAAKAHrv2m+3hnJkIyMFf2sD2Bkh8VL3f2uCrGLVG5Rinh5QglP3jJg5c8eNlHyc8sXqL77zvxUQ3M08xyv9TQww8ZmAlwX5FwXUkCAADogWu/6T7emQlqYOAHlFZOesQAAABQJrq/ZjwAt+jxIMvF4AmgTl72Huzk0i7bh1mNeI3wMrYfvOAFL35+nL3c6TeV2yXyQZbK7RKtGj/F+UmPCQzSUu4NrfDE3FZx6wkMQggh5KyjPnTkOHICg9qqBDUwE+C+J9R1Ly8AAEAPXPtN9/HOTBSmJ+nfHvIBImw/tBxigNl5L9EOxuPbEu0AIBaF/pvxAFTTYwuZw947Jy/UwOhfI7yM7SfSy3v58e9rL+tjs8fLsvylrWa8X5S9qPlx9kINjP41cvFS66c4P+kxgUFaogYGIU9FDsIdRPuhWUUNDFIXExhk/4ZmAoNm1FE2gfh8zCQGzSjXftN9vDOTQiYwDqkrJy/rN/T6Q2tZFpmVk0+71Pw8W8jm86Lm52kvR4Pumdul1svTk5hR2mV2P85ecn3nE/1163jdLq+vN1vIBL3U+gmZwCAtua9IuK4kIZQTmZc+MZkYNJNc+0338c5MYgKDqIFByEQMsmlfhFqIGhikrhI8B2YC3L8X3fX77AHWvJc/v/p3/ffcMchztv34imVwx7XfdB/vzERhelKe4qSKWZPD3jsnL9TA6F8jvIztp7eXs5mB7dcoR0vNy5V2nKldoj2o+nH2Qg2M/jVy8VLrpzg/6TGBQVpyT6myhQw562zNC9ufaE+Ezsq133Qf78ykEn9LMCXbJ9aOHgM4st3OtN3axLan63xb0h/b7Pbac/v/AJyJ7r8ZD0AVZGD85b4i4bqShOYWmQLaF6Fecu033cc7MykkA7MsS49fW42Sn2gv65WKZVnCV0o+8addFFZeoq/RGrzso+SntZc7mRfndrnD1ktkJka5XaJR8uPuJbq/bhGv2yU6E+N+v9yhix8yMP5yX5FwXUlCc4rMAO2NUG+59pvu452ZFJKBAX0UVk5axgAOUPPyPNTEwOxE99+MB6CKHhkYh69vc/KytyLh0i58jfJ8XtT8tPDSKhPg1i5PeXkyEzNSu8zsx9nLnX5TuV34GmU9L7V+ivOTHhMYpKW958CkpPE97ndj11Q4mkcqzyeZXVwHNIvuPAdGOWYLmY+YwCD7NzQTGDSyqMHQEtcDzSDXftN9vDOTSlADMynRe1TZ8wqQqHkRhJoYmI3o/pvxAFTRIwPjsPfOyQs1MPrXCC9j+6na37vk/1465t4uKl56ZmJGbpeZ/Dh7oQZG/xq5eKn1U5yf9JjAIC1RA4OQlqi1GENcJ+QqamCQupjAIPs3NBMYNJKosRhLXC/kKNd+0328M5NKdKmBmeIJoJWoeCk9wXa0uCUq1yglvByh5OeslydqXkZslyeo9dKjJsahXXqh5GcWL9H99514WRaZGphZ7pcauvghA+Mv9xUJ15Uk5CVW8scW1w85ybXfdB/vzKSQDAzoorRy0iMGUIRvGxsfvp0M3IjurxkPwC3IwPjLfUXCdSUJeYiVey9xPZGDXPtN9/HOTGqagVnvYdvuZ+t9LPr1HY6tuVIDs91juo4/vyMXb39/bc3NmddfH8v9nWOax6Jfv/ex95LSL+nPeP33dbz9f0/7fOJY9Ou3OvZLWv7IsOxdz+3/i/DJtebY2WNP99ctxwvb18udXy7m2PVjEa9/CBkYf7mvSLiuJKGxxUq9t7i+aGS59pvu452Z1DQDA+MTvSeVPa8wA9S8+ENNDIxOdH/NeABu0SMDsxg8AdTJy96KhEu7tF5JcmkXZy9qftZeolfmVdslWr281FzvGdrFwY+zlzv9pnK7RGZglNslWjV+ivOTHhMYpKXcG1rhibmtYtdUOBpPPLl9TnHd0Wg66kNHjtlC5iMmMMj+Dc0EBikoOvOCuP4InZVrv+k+3plJJaiBmYzoPanseQVHqHkBamJgNKL7a8YDcIseGRiHvXdOXqiB0b9GeBnXz3v504vCyrtKu8zq5UwmZlkWmUyM0jVS8+PshRoY/Wvk4qXWT3F+0mMCg7REDQxCfUTtA7pzvbkvUJSogUHqYgKD7N/QTGBQhKh5QEfi/kDKcu033cc7M6lElxqYS0/SfAAlP9FeSk+wjYq3T+it/X0tiL5Ga/CyT6SfbS3L9onskTUvStdpZi9HNTHr+yW6JkbpGqWk5cfdS3R/3SJet0t0DYz7/XKHLn7IwPjLfUXCdSUJaYqVdXRF3C9IUa79pvt4ZyaFZGBAH4WVk5YxwBPwbWNwFb6dDNSJ7r8ZD0AVZGD85b4i4bqShLTESjq6I+4fpCTXftN9vDOTQjIwU+y9qyTaCzUwZaKv0Rq87POkn1Lm5VPToJB5UbpOePmTdYZlr2Zq+/+eILpdtij5cfcS3V9TA9MPJS8pUQODKuW+IuG6koQ0xMo5ainuJ6Qg137Tfbwzk0IyMKCPwspJyxigB9S8QGuoiQE1ovtvxgNQRY8MjMMTQJ287K1IuLRL65Ukl3Zx9vKEnysr5Uptg5cxvKhkYpTaRc2Ps5c7/aZyu0RmYJTbJVo1forzkx4TGKSl9Rta6Ym5rWLXVDiKE09SR0+I+wxFKdd3OsRsIfMRExhk/4ZmAoNaSmVlHM0h7jcUIdd+0328M5NKUAMzKdF7VNnzCopQ8wJPQ00MRBPdfzMegCp6ZGAc9t45eaEGRv8a4SXez52VcKW2wcuYXqIyMUrtoubH2Qs1MPrXyMVLrZ/i/KTHBAZpiRoYhI5FLQJSEPchekrUwCB1MYFB9m9oJjDojqhBQErifkRPyLXfdB/vzKQSXWpgpngCaCUqXkpPsB0tbonKNUoJL0e08NOq5kWpbfCSZxQvT9fEKLVLSlp+ZvES3X/fiZdlkamBmeV+qaGLHzIw/nJfkXBdSUJ9xUo3Uhb3J+op137Tfbwzk0IyMKCL0spJjxjgDHzbGKjDt5NBb6L7a8YDcAsyMP5yX5FwXUlC7fVeWNlGY+nK/co9i87Ktd90H+/MpJAMzBR77ypR8UINzD4q1yglvBxR66dH5kWpbfCSZ1QvVzIxvb08gZKfWbxE99/UwLRHyUtK1MCgSrmvSLiuJKH2+qxQk3lBo+lMJoZ7F52Va7/pPt6ZSSEZGNBFaeWkRwxwBmpeYDTOZmIAzhLdXzMegFv0yMA4PAHUycveioRLu7ReSXJpF2cvtX6OMi+5eMS2wYuvlx73r1K7qPlx9nKn31Rul8gMjHK7RKuqvy7NT3pMYJCWcm9ohSfmtopdU+GovUoDPLbgIGVx/6JWOupDR47ZQuYjJjDI/g3NBAadVakGhgEgUhb3L2ol137Tfbwzk0pQAzMZ0XtS2fMKClBDACPD/QstiO6vGQ/ALa5kYNZ72Lb72Xofi379kY+dqYFR8Fn7e9YrSarnxLE21/rusffy13j9c+tYqZ0cjkW/vsOx0v26d/9yrTm2/fvr6215rdfjnWgvbseefv3i/OTKBAaNKWpgEPouagjQyOL+Ra1EDQxSFxMYZP+GZgKDzooaAjSyuH9RK7n2m+7jnZlUoksNzDLDE0ArifZSeoJtVPxpF4U9r9HXaA1e9rnjp3UNgVLb4CWPk5eW969Su6Sk5cfdS3R/3SJet0t0DYz7/XKHLn7IwPjLfUXCdSUJtVev58Ag9IS4f1Erufab7uOdmRSSgQF9FFZOWsYANfDtTTAy3L/Qguj+m/EAVEEGxl/uKxKuK0movaghQCOL+xe1kmu/6T7emUkhGZgp9t5VEu2FGpgy0ddoDV72oQYmD17yOHmhBuYZ3L1E99fUwPRDyUtK1MCgSrmvSLiuJKH2ooYAjSzuX9RKrv2m+3hnJoVkYEAfhZWTljFADdQQwMhw/0ILovtvxgNQRY8MzPYpm9FS8hPhZW9FwqVdWq8kubSLs5daP71qCJTaBi++Xnrcv0rtoubH2cudflO5XSIzMMrtEq2q/ro0P+kxgUFaWr+hlZ6Y2yp2TYWj9uJJ5mhkcf+iVsr1nQ4xW8h8xAQG2b+hmcCgs6KGAI0s7l/USq79pvt4ZyaVoAZmUqL3qLLnFRSghgBGhvsXWhDdfzMegCp6ZGAc9t45eaEGRv8a4eUZP9TA4EVB1MCM4cfZCzUw+tfIxUutn+L8pMcEBmmJGhiEvosaAjSyuH9RK1EDg9TFBAbZv6GZwKCzooYAjSzuX9RKrv2m+3hnJpXoUgMzxRNAK1HxUnqC7WhxS1SuUUp4OaKFn1Y1BEptg5c8jl5a3L9K7ZKSlp9ZvET333fiZVlkamBmuV9q6OKHDIy/3FckXFeSUHv1qoFB6Alx/6JWcu033cc7MykkAwO6KK2c9IgBzrBduebbnGAkuH+hBdH9NeMBuAUZGH+5r0i4riSh9qKGAI0s7l/USq79pvt4ZyaFZGCm2HtXiYoXamD2UblGKeHlCGpg8uAlj6MXamD6MouX6P6bGpj2KHlJiRoYVCn3FQnXlSTUXtQQoJHF/YtaybXfdB/vzKSQDAzoorRy0iMGOAM1BDAy3L/Qguj+mvEA3KJHBsbhCaBOXvZWJFzapfVKkku7OHup9dOrhkCpbfDi66XH/avULmp+nL3c6TeV2yUyA6PcLtGq6q9L85MeExikpdwbWuGJua1i11Q4ai+eZI5GFvcvaqWjPnTkmC1kPmICg+zf0Exg0FlRQ4BGFvcvaiXXftN9vDOTSlADMxnRe1LZ8woKUEMAI8P9Cy2I7q8ZD8AtemRgHPbeOXmhBkb/GuHlGT/UwOBFQdTAjOHH2Qs1MPrXyMVLrZ/i/KTHBAZpiRoYhL6LGgI0srh/UStRA4PUxQQG2b+hmcCgs6KGAI0s7l/USq79pvt4ZyaV6FIDM8UTQCuJ9lJ6gm1U/GkXhT2v0ddoDV72ueOndQ2BUtvgJY+Tl5b3r1K7pKTlx91LdH/dIl63S3QNjPv9cocufsjA+Mt9RcJ1JQm1V68aGISeEPcvaiXXftN9vDOTQjIwoI/CyknLGKAGvr0JRob7F1oQ3X8zHoAqyMD4y31FwnUlCbUXNQRoZHH/olZy7TfdxzszqWkGZr2Hbbufrfex6Nd3OJbSfg3Mdk/rOt7uMT3ac3pUY3P29e68vmrbcyx/LOr1PyvXn2O5lWwFn07Hol/f4diH3P2r5lO1DTn2J9H9dYvXP/r90e3rdizi9Q8hA+Mv9xUJ15Uk1F7UEKCRxf2LWsm133Qf78ykphkY8CF6jyp7XkEBaghgZLh/oQXR/TfjAaiiRwZmMXgCqJOXvRUJl3ZpvZLk0i7OXmr99KohUGobvPh66XH/KrWLmh9nL3f6TeV2iczAKLdLtKr669L8pMcEBmlp/YZWemJuq9g1FY7aiyeZo5HF/YtaKdd3OsRsIfMRExhk/4ZmAoPOihoCNLK4f1Erufab7uOdmVSCGphJid6jyp5XUIAaAhgZ7l9oQXT/zXgAquiRgXHYe+fkhRoY/WuEl2f8UAODFwVRAzOGH2cv1MDoXyMXL7V+ivOTHhMYpCVqYBD6LmoI0Mji/kWtRA0MUhcTGGT/hmYCg86KGgI0srh/USu59pvu452ZVKJLDcylJ2k+gJIfFS+lJ9iOFrdE5RqlhJcjWvhpVUOg1DZ4yePopcX9q9QuKWn5mcVLdP99J16WRaYGZpb7pYYufsjA+Mt9RcJ1JQm1V68aGISeEPcvaiXXftN9vDOTQjIwoIvSykmPGOAM25Vrvs0JRoL7F1oQ3V8zHoBbkIHxl/uKhOtKEmovagjQyOL+Ra3k2m+6j3dmUkgGZoq9d5WoeKEGZh+Va5QSXo6gBiYPXvI4eqEGpi+zeInuv6mBaY+Sl5SogUGVcl+RcF1JQu1FDQEaWdy/qJVc+0338c5MCsnAgC5KKyc9YoAzUEMAI8P9Cy2I7q8ZD8AtemRgHJ4A6uRlb0XCpV1aryS5tIuzl1o/vWoIlNoGL75eety/Su2i5sfZy51+U7ldIjMwyu0Srar+ujQ/6TGBQVrKvaEVnpjbKnZNhaP24knmaGRx/6JWOupDR47ZQuYjJjDI/g3NBAadFTUEaGRx/6JWcu033cc7M6kENTCTEb0nlT2voAA1BDAy3L/Qguj+mvEA3KJHBsZh752TF2pg9K8RXp7xQw0MXhREDcwYfpy9UAOjf41cvNT6Kc5PekxgkJaogUHou6ghQCOL+xe1EjUwSF1MYJD9G5oJDDoragjQyOL+Ra3k2m+6j3dmUokuNTBTPAG0kmgvpSfYRsWfdlHY8xp9jdbgZZ87flrXECi1DV7yOHlpef8qtUtKWn7cvUT31y3idbtE18C43y936OKHDIy/3FckXFeSUHv1qoFB6Alx/6JWcu033cc7MykkAwP6KKyctIwBauDbm2BkuH+hBdH9N+MBqIIMjL/cVyRcV5JQe1FDgEYW9y9qJdd+0328M5NCMjBT7L2rJNoLNTBloq/RGrzsQw1MHrzkcfJCDcwzuHuJ7q+pgemHkpeUqIFBlXJfkXBdSULtRQ0BGlncv6iVXPtN9/HOTArJwIA+CisnLWOAGqghgJHh/oUWRPffjAegih4ZGIcngDp52VuRcGmX1itJLu3i7KXWT68aAqW2wYuvlx73r1K7qPlx9nKn31Rul8gMjHK7RKuqvy7NT3pMYJCW1m9opSfmtopdU+Govc4M8NiGgxTFvYtaKtd3OsRsIfMRExhk/4ZmAoPO6mwNAQNBpKRS5mUvRmhPrv2m+3hnJpWgBmZSoveosucVIvi2pPRefoy3x3P/DyCK9/LjfblmHa//H8AVovtvxgNQw6UJzPpr0LZfidb7WPTrOxxb89vP33449j//+8sPx9fxsizpt5+/ZePP78jF699/5fVqXn99LPd3jmkei3j9X9Lyx+TkcywXr/9fhE+3Y9GvP+Kx7X1Yul9VziH69Tl27djT/XXL8cL29XLnl4s5dv1YxOsfwhYyf1EDg9BfdXa7DdtyUIS4P1FPUQOD1FWcnzCB8Zf7G5oJDKoVNTFIUdS8oN5y7TfdxzszqcTfEkxJ9B5V9ryCAtTEgBrUvMDTRPffjAegih4ZmMXg+6edvPAcGP1rhJdYP3czMUptg5dxvURkXpTaRc2PsxeeA6N/jVy81Popzk96TGCQlqiBQagsag5QpLj/0JOiBgapiwkMsn9DM4FBrURNDIoQNS/oabn2m+7jnZlUoksNzKWvQXsAJT8qXl5f7x+8RO9ZVdrzqnKNUsLLET381NbEKLUNXvKoeomueVFql5S0/MziJbr/vhMvyyJTAzPL/VJDFz9kYPzlviLhupKE4kQmBj0hMi8oSq79pvt4ZyaFZGBAF6WVkx4xQAv4djLoTXTmBSC6v2Y8ALcgA+Mv9xUJ15UkFC8yMaiHyLygaLn2m+7jnZkUkoGZYu9dJSpeqIHZR+UapYSXI57wczYT80taZDIxStcJL3/lvXy/X1LSyLyotMsHJT+zeInuv6mBaY+Sl5SogUGVcl+RcF1JQjoiE4NaiMwLUpFrv+k+3plJIRkY0EVp5aRHDNADamLgLtS8gBrR/TXjAbhFjwyMwxNAnbzsrUi4tEvrlSSXdnH2EuVnb6X840UhE6N0nfDy4/2wd79s/98s7aLux9nLnX5TuV0iMzDK7RKtGj/F+UmPCQzSUu4NrfDE3FaxayocaYonpqMr4n5BijrqQ0eO2ULmIyYwyP4NzQQGPS1qYtAZUfOCVOXab7qPd2ZSCWpgJiN6Typ7XsEBamKgBDUvoE50f814AG7RIwPjsPfOyQs1MPrXCC9j+jlb0/DkCrtCu8zupZR52btf3NtlND/OXqiB0b9GLl5q/RTnJz0mMEhL1MAg1E/UOKCa68z9gCJFDQxSFxMYZP+GZgKDokVNDDq6ztS8IDW59pvu452ZVKJLDcwUTwCtJNpL6Qm2UfGnXRT2vEZfozV42UfJzy9pkamJUWqXmbxcqXn5JfX1cgWla5SSlh93L9H9dYt43S7RNTDu98sduvghA+Mv9xUJ15UkNJ7IxMwpMi9oNLn2m+7jnZkUkoEBfRRWTlrGAArw7WTzwbeNwehE99+MB6AKMjD+cl+RcF1JQuOKTMwcIvOCRpVrv+k+3plJIRmYKfbeVRLthRqYMtHXaA1e9lHys/USmYlRbpdIWnu5k3lxbpe7KPlx9xLdX1MD0w8lLylRA4Mq5b4i4bqShMYXmRhPkXlBo8u133Qf78ykkAwM6KOwctIyBlCEmhg/qHkBN6L7b8YDUEWPDIzDE0CdvOytSLi0S+uVJJd2cfai5qfk5clMzEjtMpqXVpkXt3Zx9ePs5U6/qdwukRkY5XaJVo2f4vykxwQGaWn9hlZ6Ym6r2DUVjrzEE9rHFtcPOSnXdzrEbCHzERMYZP+GZgKDRhE1MWOKmhfkJtd+0328M5NKUAMzKdF7VNnzCjNCTcx4UPMC7kT334wHoIoeGRiHvXdOXqiB0b9GeBnbz1UvPTMxI7eLmpdemZfR22UWP85eqIHRv0YuXmr9FOcnPSYwSEvUwCCkp9lrKt7Lj1I7/9mvD/IWNTBIXUxgkP0bmgkMGlWz1sTkzid37qXJTW9/1LwgV7n2m+7jnZlU4lINzPpJmtunavY+Fv36DsfWlJ5gu46XZdmNt0/kXcfb33/29Wpef30s93eOaR6Lfv3oY7+k5Y9al2VZfqihWMfr/6d2DnvH3suPWh//tuSPr3/Pt+XPmpKnff+S/vS5PraO1/+vl5dRj0W/PseuHXu6v245Xti+Xu78cjHHrh+LeP1DyMD4y31FwnUlCc0jt0xMKcNyJgNT+veevsm8IHe59pvu452Z1DQDA+MT/e0gfPsIwF+Z/dvJFM6JbxuD2YjurxkPwC3IwPjLfUXCdSUJzSeXTMzZDMy6xiUyA0PmBc0m137Tfbwzk0IyMJf2sD2Akh8VL3f2uCrGLVG5Rinh5QglP628tMjEjNIun0zGU9mMPS8RmZdRrlEESn5m8RLdf9+Jj2pgnmaW+6WGLn7IwPjLfUXCdSUJzavRMzGj1MCQeUGzyrXfdB/vzKSQDAzoorRy0iMGcGD0mpjct4xtz+HoW8jWx7d/bwU1LzA70f014wG4RY8MzGLwBFAnL3srEi7t0nolyaVdnL2o+enlpSYTM0O73PUSnXlRbRcFKflx9nKn31Rul8gMjHK7RKvGT3F+0mMCg7SUe0MrPDG3VeyaCkcoJZ4IT3si1F5HfejIMVvIfMQEBtm/oZnAIHeNXhOjoujMC0Iqcu033cc7M6nEt/+bpOzy7du3o8MwAL//853+89+/pX/8653+/ntKv/385zV9fb2Hj1P68ZwAHDlbi6FQE5PzqeprCzUvMAO5vlOhP78b//pT+mO889N/MC4YmcL0pDzFSRWzJoe9d05eqIHRv0Z4GdvPU17OZA5ytR5Px58/P14+z3uJ8vPxopJ5mfHeHdGPsxdqYPSvkYuXWj/F+UmPCQzSEjUwCPlIeXvT0cMqcxMYJSl7Q6i1qIFB6irBFrIJWG8hc0ypbtPIAO5stzk9GffcCrZ+jajzA5gB137TfbwzE4XpSXmKkypmTQ6pKycv6xWJ9UrFsiwyKyefdqn5ebaQzedFzU+El72MQW8vR5mKdZbls52t9ADLM8d6XqOIzMvs9+4ofpy95PrOJ/rr1vG6XV5fb7aQCXqp9VOcn/SYwCAtuadU2UKGZlVETcnRhKRU63L0+6NrZBCaSa79pvt4ZyYxgUHUwCBkrKcH4WczMFeOqZ0HQu6iBgapqwQ1MBPgvifUdS8vwFkUvqL4w1EtySg+Adxx7TfdxzszUZielKc4qWLW5LD3zskLNTD61wgvY/uZycuVLMrWi2INjOM1GtWLmh9nL9TA6F8jFy+1forzkx4TGKQl95QqW8gQek6lGpizP1v6XQihfnLtN93HOzOpxN8STMnr620VA8Dz3N2GxTYugHii+2/GA1BFjwyMQ+rKycveioRLu7CFbD4van5m8nLlW8b2tpCVvt1sxHbBi58fZy93+k3ldmELmZ6XWj/F+UmPCQzS0l4NTEoae1jvxq6pcIQUdaeORelbyBCaWXdqYJRjtpD5iAkMsn9DM4FB6DlRA4PQ+HLtN93HOzOpBDUwkxK9R5U9rwDjQw0MwPhE99+MB6CKHhkYh713Tl6ogdG/RngZ289MXqiBwcssfpy9UAOjf41cvNT6Kc5PekxgkJaogUEItRI1MAiNL2pgkLqYwCD7NzQTGISeEzUwCI0v137Tfbwzk0p0qYFZlqXHr61GyY+Kl9fX+wcv0XtWlfa8qlyjlPByhJKfWb2UalhKXp6sgZn1GpVQ8pKSlp9ZvET333fiZVlkamBmuV9q6OKHDIy/3FckXFeSEFLUlRqY3M/m/t8TNTAIoT/l2m+6j3dmUkgGBnRRWjnpEQNAf7aZk6uZlLs/DwD3ie6vGQ/ALcjA+Mt9RcJ1JQkhRVEDg9D4cu033cc7MykkAzPF3rtKVLxQA7OPyjVKCS9HKPmZ1Qs1MHXgZR8lP7N4ie6/qYFpj5KXlKiBQZVyX5FwXUlCSFHUwCA0vlz7TffxzkwKycCALkorJz1iAOgPNTAA4xPdXzMegFtcycCsn6S5fapm72PRrz/ysb0VCTWftb9nvZKkek4ca3OtORZ/bFu3sncs93vWx5dl2a2BUTpfjl0/Fv36HCsfe329La/1erwT7cXt2NOvX5yfXJnAoDGVm8AoPDG3VeyaCkdIUUdbva4W8V/5WYRQOx31oSPHbCHzERMYZP+GZgKD0HOiBgah8eXab7qPd2ZSCWpgJiN6Typ7XgHGhxoYgPGJ7q8ZD8AtemRgtvvboqXkJ8LLmRqYaN3x0nolyaVdnL2o+ZnJy5XnwBzVwJR+12jtghc/P85e7vSbyu0SmYFRbpdo1fgpzk96TGCQlqiBQQi1EjUwCI0vamCQupjAIPs3NBMYhJ4TNTAIjS/XftN9vDOTSnSpgVlmeAJoJdFeSk+wjYo/7aKw5zX6Gq3Byz5KfmbzcraGZc9LRA3MbNfoLEpeUtLy4+4lur9uEa/bJboGxv1+uUMXP2Rg/LVekXBclXBdSUJIUVdqYI5+tvS7EEL95NhvfsY4ZGA8FJKBAU3+89+/pZRS+v2fb4mVk5YxADzP3cwJ3z4GEE90/90i/v2f3//tM84Bf779X5Zl/z9842YYnc8bO6Xvb+5//Ot7/NN/eFzb19c7/fazx7kAqPNevv+5nny8l+/x58+jn839v9zvBIB+OPWb68nLZ3yTks8YZ1YK05NEDczDRHj56T++pb///v3v//jXWzITQw1MHrzso+RnNi/UwNwDL/so+XH3Et1ft868fCYvf/89ZvLifr/cgRoYVK3PftftHlGHfaKOe3kRUhU1MAiNL4d+c28843BuiBoY2PBZlVDNxNTGAPA81MAAjE90/90q88KWscnokYFxeAKom5ftioRaJuZOu7RebeF+0fei5mcmL1eeA7P1EvkcmJmu0ahe1Pw4e7nTb0a3S2n8EpWBiW4XVS+1forzkx4TGKSnzxt6+8Ta7YdA5BN0a2PSxQg9p6OJxtUtZFd+FiHUTrm+c4T4aPKSG+egccUEBr1T2n9Dq2ViWp4bQqi9qIFBaHyN2G+eHa+MeG7orypBDcykfPaUutTEAMDzUAMDMD7R/ffdmhfGA5PSIwPjsPfOzUtuRWLtJToTQw0MXkb2M5MXamDwMosfZy8j1cAcjU9yXqiB0fJS66c4P+kxgUF62tsb6lATQ7oYoedEDQxC42uUGpgzNS/bmDGBh5jAoHdK59/Q0ZmYnueGELovamAQGl8j9Ju145ERzg2VVaJLDcwUTwCtRMXL6+v9g5fRa2JaonKNUsLLEUp+ZvVSqmEpeXmyBmbWa1RCyUtKWn5m8RLdf9+peVmWRaYGZpb7pYYufsjAzKGrKxIjZWJYbUHoOV2pgcn9bO7/PVEDgxD6U8r95t3xh/K5ofMKycCALmdXQsjEAMAe28zJ1UzK3Z8HgPtE99d3v22M8cDkkIGZQ7UrEiNkYlhtQeg5UQOD0PhS7DdbjTcUzw1dV0gGZoq9d5WoeNmrgdnGo2RiWqJyjVLCyxFKfmb1Qg1MHXjZR8nPLF6i++87mRdqYPIoeUmJGhh0Q3dXJJQzMay2IPScqIFBaHwp9ZutxxdK54bqFZKBAV1qV0pmzMQAQB5qYADGJ7q/bl3zwnhgMnpkYByeAOrmJbciUeOlVybmTru0Xm3hftH3ouZnJi9XamC2XiJrYGa6RqN6UfPj7OVOv9nKS4vxRM5LVAbG+X6J8FOcn/SYwCA9tXgi7ufvuQ+dlr//aky6GKHndDTRuFrEf+VnEULtdNSHPhEfTV5avx4aU0xg0Dul9m9opZoYPqwQek7UwCA0viL7zd7jB8YEHipBDcxktNrDqloTAwD9oQYGYHzcal4YD0xGjwyMw947Ny+tamC2arWSQg0MXkb2M5MXamDwMosfZy8RNTA9Mi/UwOh7qfVTnJ/0mMAgPfXc0xpdE0O6GKHnRA0MQuPr6RqYJ2teGBN4iAkMeqfU/w0dWRPDhxVCz4kaGITG15P95tPjA8YEHipxqQZm/STN7VM1ex+Lfn2XY+s9ouv48/9y8fp35OKUztXEnH29mtffO1+OaR+Lfn2OXT+W0o81K8uy7NawbH9u/fPrY9ufVzpfjl0/Fv36HDt3bK9/3safn6vpr8/WvNS+/vb1lNrX7VjE6x9CBmYOPbUiEZGJYbUFoed0pQbm6GdLvwsh1E9P9JtROzMYE3ioaQYGfOj1bSNR304GAM9z99vD+PYxgHhG/7YxxgOTQgZmDj29IvHkygurLQg9J2pgEBpfPfvN6OfEMSbwUEgG5tIetgdQ8hPt5WjP6fb4nfhqJma7x7X29VsQfY3W4GUfJT+zeTn7HJc9LxHPgZntGp1FyUtKWn7cvdT2t0f99dOZl20NTCTu98sduvghAzOHolYknliJYbUFoedEDQxC46tHvxmdeel5buh5hWRgQJ/ee1CfrokBgOehBgZgfEaveWE8MCk9MjCLwRNA3bzkViSe9FJambnjpfVqC/eLvhc1PzN5uVIDs/USWQMz0zUa1YuaH2cvd/rNrZfIzEuuXaIyMM73S4Sf4vykxwQG6enzhu79xNujOPch1+L3ky5G6DkdTTSubiG78rMIoXbK9Z018dHkJWq8wZjAQ0xg0DslnTd0j5UalXNDaAZRA4PQ+GrRb6rUvPQ4NxSvEtTATMrTe1J718QAwPNQAwMwPqPXvDAemJQeGRiHvXduXqJrYLZquXJDDcx8XtT8zOSFGhi8zOLH2cudflMp80INjL6XWj/F+UmPCQzSk0INzDZuVRNDuhih50QNDELjq7YGRrHmZRszJvAQExj0Tkn3Dd1iJUf13BByFDUwCI2vmn5TKfPS+tyQnkp0qYGZ4gmglah4eX0dP8F2tJqYlqhco5TwcoSSn1m9lGpYSl6erIGZ9RqVUPKSkpafWbyMXPOyLItMDcws90sNXfyQgZlD6isSd1Z21M8NISddqYHJ/Wzu/z1RA4MQ+lNX+s1RMi8154Z0FZKBAV2ivx1kpEwMAOTZZk6uZlLu/jwA3GfkzMuZGMwhAzOHRlmRqFnpGeXcEHIQNTAIja8z/eZomZcr54b0FZKBmWLvXSUqXlRqYLZxbSamJSrXKCW8HKHkZ1Yv1MDUgZd9lPzM4mXkzAs1MHmUvKREDQy6odFWJK6s/Ix2bgiNLGpgEBpfR/3mqJmXM+eGxlFIBgZ0UVo5OYoVMjEAkIcaGIDxGTnzciYGc8jAzKFRVyTOrASNem4IjShqYBAaX7l+c/TMy9G5ofEUkoGZYu9dJSpeVGtgtvHZTExLVK5RSng5QsnPrF6ogakDL/so+ZnFy8iZF2pg8ih5SYkaGHRDo69IHK0MjX5uCI0kamAQGl/rftMl85I7NzSuQjIwoIvSysmVOCITAwB5qIEBGJ+RMy9nYjCnRwZmWZbwmZuqnygvuRWJEdslt1LUerVlxHaZzYuan5m8XKmB2XqJrIGZ6RqN6kXNj7OX19e7OvOi3i5RGRj1dhnNT3F+0mMCg/S0fUOPHLuluxEaSUcTjatF/Fd+FiHUTle2ZY8eozFV4tv/TVJ2+fbt29FhGITX1zv99rPPtTxKewNAP97L9z/X277ey/f48+fRz+b+X+53AkAf3PtPt/HOrBSmJ4kamMmI3pPauyYGAPpDDQzAmDjXvFADMxk9tpA57L1z8+JSA7NVj+1kDu3i7kXNz0xeqIHByyx+3Ly06i/V24UaGC0vtX6K85MeExikp+g9qNTEIOQhamAQGk8z1bxQA+MhJjDonZL3G/rOt6kghK6J58AgNJae+PZOJTmf20wq0aUGZoongFYS7aX0BNuo+NMuCjUx0ddoDV72UfIzm5ezNSx7XiJqYGa7RmdR8pKSlh8HLz1qXu721y3jdbtE18A43C+96OKHDMwccl6RYDsZQs/pSg3M0c+WfhdC6J6ubBtzkvO5zaSQDAzoo7By0jL+wLeTATzH3cwJ3z4G0IcrX5Uc3X/z7WNQBRmYOeS8IpE7NzIxCPURNTAIaetM/zfbmACNp6YZmPUetu1+tt7Hol/f5dheDcx2T+s63u4xPdpzelRjc/b17rz+51gpE6N2XWY9Fv36HLt+LKUfMyfLslTVwKyPbX9e6Xw5dv1Y9OvPfOwo87L9uej+usXrH72e0nVxOBbx+oeQgZlDzisSR+dGJgahtqIGBiFNXenvZh0ToHHUNAMDPkTvUX1qzys1MQD9oAYGQIMrNS9bovtvamCgih4ZmMXgCaBuXnIrEi7tcma15crKlEu7OHtR8zOTlys1MFsvkTUwM12jUb2o+RnFS81OgztZCvV2icrAqLfLaH6K85MeExikp88bevvGdojPflixnQyh+zqaaFzdQnblZxFCf1Vtv5brO11itpB5iAkMeqfk/Ya+cm5MYhC6J2pgENLQnf6MMQFSVwlqYCYleo9q1J5XamIA2kENDEAMd2petkT339TAQBU9MjAOe+/cvMxeA7PV0cqVS7s4e1HzM5MXamDwMosfVS8tdhJQAzPP/aIgamBQtaiB+avYTobQdVEDg1CcWvVb1MAgdTGBQe+UvN/Qd86NSQxC10QNDEIxatlfMSZA6irRpQbm0pM0H0DJj4qX19f5J+SOENeiXhOjcr+kpOUlJS0/s3op1bCUvDxZAzPrNSqh5CUlLT9KXlrWvGyJ7r/vxMuyyNTAKN0vSl5S6uSHDMwccl6RaHFuZGIQOqcrNTC5n839vydqYBAaVT36J8YESF0hGRjQRWnlpEdci3omBkCJbebkaibl7s8DzAKZl/oYzCEDM4ecVyRanhuZGISORQ0MQs+oZ3/EmACpKyQDM8Xeu0pUvFADk0ctE6Nyv6Sk5SUlLT+zeqEGpg687KPkJ9JLz8zLluj+mxqY9ih5SYkaGHRDzisSPc6NTAxCeVEDg1BfPdH/MCZA6grJwIAuSisnPeJWqGViAJSgBgagD2Re2sVgTo8MjMMTQN285FYkXNql9WpL6yceR7WLsxc1PzN5uVIDs/USWQMz0zUa1Yuan6e9HPU3rb3c6TfVr1FUBka9XUbzU5yf9JjAID1t39BOce8Pq+hJDEJKOppoXC3iv/KzCDnr6X7mqA91i9GYYgKD3il5v6GfODcmMQh9FzUwCLVVRP/CmACpqwQ1MJMRvSd11D2v1MQA/Ak1MABteLLmZUt0fz3qeABE6JGBcdh75+aFGpg2Xp5eKXO5Ru5+ZvJCDQxeZvHT28uV/oQamPNeqIHR8lLrpzg/6TGBQXqK3oM6cg3MVmwnQzOLGhiE7iu6H6EGBqmLCQx6p+T9ho44t+jOB6EoUQOD0D0p9B+MCZC6SnSpgZniCaCVRHtZ7xHNPcE2Kv60i8Ke1zPX6KmamOj7ZY2Sl5S0/Mzm5WwNy56XiBqY2a7RWZS8pKTlp4eX2pqXHl6i++sW8bpdomtg3O/dO3TxQwZmDjmvSESem8JKGkJP6koNzNHPln4XQm5S6i8YEyB1hWRgQB+FlZOWcRR8OxnMzN3MCd8+BrMQ+W1jJaL7b5fxADwMGZg55LwioXBuSitrCPUUNTAIXZNi/6DQb3Ju6EghGZgp9t5VEu2FGpgyNdeoVyYm+n5Zo+QlJS0/s3mhBuYeeNlHyU8LL60yL9TAUANzBSUvKVEDg27IeUVC6dwUV9oQailqYBA6J+X+QKnf5NxQTiEZGNBHYeWkZawCNTEwE9TAAORRrnnZEt1/u44HoDM9MjAOTwB185JbkXBpl9arLS3apdXKm8s1cvczk5crNTBbL5E1MDNdo1G9qPmp9dIj89K6Xe70m+rXKCoDo94uo/kpzk96TGCQnj5v6O0b2yFWTRcrbx9AqFZHE42rW8iu/CxCI2iUz/1c3+kSq44J0DUxgUHvlLzf0MrnNkpnhtBZUQODUF4jfd4r95ucG0qJGhjYIXqP6ix7XqmJAWeogQH4zkg1L1ui++9ZxgPQlksTmPXXoG2/Eq33sejXdzv228/ffoj/539/+eHn1vGyLOm3n79l48/vyMW1r1fz+rlzVDlWmsSo+Iw4Fv36HLt+LKWU3suPx94/Ht79ufXPr49tf17pfDl2/Vj06z997GjyouRz79jT/XXL8ULu9XJ/59j9YxGvfwhbyOYQNTDxGml7AUJ7ogYGoT816uc6NTBIXcX5CROYOeT8hh7p3Ebt7BD6iBoYhL5r5M/zkfpNzm1Olfhb6sClFNADKPlR8fL6On6C7WhxS3peo6s1MSr3S0paXlLS8jOrl1INS8nLkzUws16jEkpeUtLyc+Tl6ZqXnu0S3X/fiZdlkamBGeXejaCLHzIwc8h5RWLEcxt55Q7NrSvPgcn9bO7/PfEcGIRayeHze8R+k3ObSyEZGNBFaeWkRzwKfDsZjMw2c3I1k3L35wGiGPnbxrZE99eMB+AWZGDmkPOKxMjn5rCSh+YSNTBoVjl9Xo/cb858bjMpJAMzxd67SlS8UAOzz5PX6OpXLEei5CUlLT+zeqEGpg687KPkZ+0lOvNCDUw+pgYmj5KXlKiBQTfkvCLhcG5OK3vIW9TAoNnk+Pns0G/OeG4zKSQDA7oorZz0iEeFmhgYCWpgYBaiMy89ie6vGQ/ALXpkYJZlCZ+5qfqJ8pJbkXBpl9arLZHtorzSp3S/qPmZycuVGpitl8gamJmu0ahe1PwofR63bpc7/abSNcp5icrAqLfLaH6K85MeExikp+0b2il2SxcrdZoIbXU00bhaxH/lZxF6Uu6fw0d9qFuMxhQTGPROyfsN7Xhu7p0nGlfUwCB3zfD569hvznBuM6kENTCTEb0nlT2v56AmBpShBgZcca552RLdXzMegFv0yMA47L1z80INjP41yklpJVCpXdT8zOSFGhi8uPpR+rzt3S7UwOhfIxcvtX6K85MeExikp+g9qNTA1Eu5U0XziRoY5KjZPmepgUHqKvHt/yYpu3z75pk6nQ1Sq2Pz60/f/1xva/j774GGYFr+v//93if813+/f/i3//rv9x9/Hv1s7v/lfifAU/D56sdvPzN2HZ3C9KQ8xUkVsyaH1JWbl8+KxHplYlmW8JWRT/xpl5qfb72StL5GKu2TUn6F8MnXV7pf1PzcuX9bx73v33WmZHt8m0W5cvy9cL843i/qfo4yLwrt0ev+3fadTvfv9v89Jcaabf2UYAvZJIp6Q3NubTXbNgekpys1MEc/W/pdCPXWzJ+nzv2m87nNpBJ8C9mkvL7exAPGe99OpuKPeK748+1hUT9PTFwbH33bmII/4voYJoEMzBx6Ga9IOJ/bnmZeOUSx4jkwaHTx+endbzqf20wKycAsy9Lj11aj5Cfay3qlYlmW8JWST/xpFwU/62uk4CcXR2RilO4XNT+z3b/bzMnec1z2Vkb3fp77xfN+UfIzauaF+/f6/fI00eO7NUpeUurkhwzMHHoZr0g4n1tJrCSip0UNDBpVfF7+Ked+0/ncZlJIBgb0UVg5Ib4fUxNDHBlTA0M8Sjxq5oX4egyT0CMD4/D1bW5eXpkVCZd2yZ3biNfojpcnVhaV2kXNz0xertTAbL1E1sDMdI1G9dLLT+3no1LbtPZyp99Ub5fWYwKXdhnNT3F+0mMCg/T0eUNv39gO8frfFPxExdHPiSGeIx71OTDEc8ajPOfl6Xjbd0b7aRlv/x2NqRJMYCaR8xva+dyuij3eqLeogUGjiM/DfTn3m87nNpNKUAMzKa+vN7FhTE0M8ZMxNTDEqjE1L/PGMAk9MjAOe+/cvLwyKxIu7ZI7txGvUUsvPVYeldpFzc9MXqiBwYu6n1aff0ptQw3MeS+txwQu7TKan+L8pMcEBunp84bevrEd4vW/KfhRiamJIe4RUwNDrBxT83Iu3vad0X5axtt/R2OqBBOYSeT8hnY+t7tiDzhqLWpgkKr4vDsv537T+dxmUokuNTBTPAG0EhUvry+9JzCrxE5PPG5ZE6N2v6j5UYmfvH9LNSyl+/fJGhjul3ys9Hl3x0+PmpdRnjg/c5y7X6JQGd+lpOUlpU5+yMDMoZfxioTzubUSK5Oola7UwOR+Nvf/nqiBQb7i8+26nPtN53ObSSEZGNBFaeWE+LmYbycjbhlvMyefeMveyujez6ucH/E4Md82RrwXgzlkYObQy3hFwvncWouVSnRX1MAgFfF5Vi/nftP53GZS0wzMeg/bdj9b72PRr+927PV1fk/tdo/pOt7uEV7Hta8X/frOr1fKxDx9fr3Pl9dr/3rr+NtyXLOwff3t69VkXtzb1+X1er9+bebFpX1VXi/69XOvl/s7x+4fi3j9Q8jAzKGX8YqE87n1EiuXqFbUwKBo8fl1X879pvO5zaSmGRgYnysrKcS+MTUxxHdiamCIo2JqXojPxmBOjwzMYvAEUDcvr8yKhEu75M5txGsU4eXKSqZSu6j5mcnLlRqYrZfIGpiZrtGoXkp+ns68KLVNay93+k31dmk9JnBpl9H8FOcnPSYwSE/bN7RT/PryfaLwE3FuUKDkj1grfi/7xz+TkJrj6wmM0vkSa8RHkxcFf6PF2z402k/PGI2pEkxgJpHzG9r53J4Se8rRWVEDg54Wn0/t5dxvOp/bTCpBDcxkvL7exMR/iamJIb4SUwND/FRMzQtxbQzm9MjAOOy9c/PyyqxIuLRL7txGvEYKXo5WOpXaRc3PTF6ogcHLU36iMy9KbUMNzHkvrccELu0ymp/i/KTHBAbpafuGdopfX9RstIypiSE+iqmBIX4ipualb7ztQ6P99IzRmCrBBGYSOb+hnc8tStErn0hX1MCg3uLzp7+c+03nc5tJJbrUwFx6kuYDKPmJ9vL6ev/x9+0TbLfHn4zXT+SN9nP2CcDO8Qg1Mdy/cffviDUw3C9jfN5R85KPuX+v379PEz2+W6PkJaVOfsjAzKGX8YqE87lFi5VQtNWVGpijny39LjSf+Lx5Ts79pvO5zaSQDIwyy7L8oKP/44zCygmxfjxCJoY4Lr6bOeHbx4g/MZkX4lYxTMJMGZjctyBs/20dq32Lwx29jFcknM9NRayMoo/2amByyv3s+s+9n917TWplPMXny/Ny7jedz20mhWRg1LIXHz8lX9vMy9VMTO7/5n7f2s/TbbVeqWBPbT5W2xOuECtmYrh/4+7foxqYb8ufeq/+/cP637Y//1///f7h515f7/Re/b7c8bP+uV80P+/IvJyLuX+v379PozT2VfKSEjUwXVTKuFzJwpR+/szfe+llvCLhfG5qYqUU7dWtHH072TZe/7mXlTnrAY0rPk/i5NxvOp/bTArJwIzCXgZEbebaA4WVE+LxYsVMDHFcXFvD8mHv57dcPU6sH5N5Ie4VwyT0yMCo1Y7k6lzOZltaZ2A+sUIGRuk63fGSO7coL0rt0tOLwsqpattEq7eXKzUwWy+1NTC536HWLng5r6PPj9nb5ikvd/pN9XZpPSZwaZfR/BTnJz0mMMo6asQZtpBt39gO8frfFPzMEucGIUr+iPvE6wnE+nhu8rH9+e0EZv373svx65/5/cT68dHkRcHfLPG274z20zLe/jsaUyWmmsCcmSjcmViUMj0KExhHOZ+buhQyMehZXamB2fvZUg3M0WuiccXnhY6c+03nc5tJJaargVl/E1iuBuboWM3vV+X19SYmvh1TEzN33KsGZh2/l+/fPtbDP/FzMTUvxE/FMAk9MjAOe+96vU5U27wyKxJK14kamLG9RKysjtI2bl5KNTBHXvZqZY6yN1f+L9dI08uVz4fZ2ibKy51+U71dWo8JXNplND/F+UmPCcysUrth1vq8obdvbId4/W8KfmaNqYmZI96rgUnpfA1M7nipBoZ4zJiaF81423dG+2kZb/8djakSTGAaaoQJjKOcz200scfdX0fPa7n6DWJXnv2CxhOfB7py7jedz20mlehSA6NW+/GUnzOvo9I2r6/4JzCrxgtPPM7GZ+6XJ2tiuH/z8ZP3b6mGpXT/1tbQcL/o3y+1NS98/nL/3r1/o1AZ36Wk5SWlTn7IwMyhl/GKhPO5jSpWXn21VwOz/vPoZ3P/r7auBWmK97++nPtN53ObSSEZGNBFaeWE2Dfm28m8423m5BNv2VsZ3ft5lfMjro/5tjFilRi8+fZ/WZb9//DtW9MXVEtrKdGzbV5f7/Tbz22vpQrO5zY6R4MZGJP38ueEY/33XHz0s6XfBePB+30cnPtN53ObicL0JE1RA3NE7rkwPbX3mk/z+mJP7V7MHux8XHO/9MzEcP/m4yfu3/fyXeu/f+L1/8/dv9v/v/3ZHn65X/rfL60yL3z+cv/evV+iUBr7KnlJqY+f6TMwKn56T2ReX74rEs7n5gIrsz6sJxvflr9OPkoZmNz//fw7GZgx4f09Hs79pvO5zURIBgZ0UVo5IZ4npibGK95OPNb/dvTz2//3+nr/sHVM5fyIz8fUvBCrxuBNlwzMUTZBJePx4Wk/e20TkYGJ2r6W446X3LlFeWmNm5eWK7VubdOK3l62dSsp7dexbL1c+dnWzHSNrnDHS4/Mi0vbtKa1lzv9pnq7tB4T3PEShZKXlOr8UAMjhkrbvL609tT+v//9/4S+/jpmD3Y+bnG/tMzEcP/m4yfv32/Ld9Xcv5+f7elvHXO/5OPa+6VX5oXPX+7fu/dLFCrju5S0vKREDYw9T2dgXHA+N1fYMz8uuXqVT/bk7LeQ5b6NbPs7QRfev+Pj3G86n9tMlDIwj09gIIbPG3r7xnaIU0p//JuCH+JzcW4QBABjsJd5Ufl8IT6Ot31ntJ+WMRMYD5pOYNZ72Lb72Xofi3790Y+ppFgB1vz60/c/P9vJAGAMPpOXv/8ebAQgw28/f5MZf7kce/r1ycAAgDSfTAwAjAXbxgCgF0xgAAAAAABgGHgODAAAAAAA2NBlArPe26aAkh+85MFLHrzso+QHL3nwkgcv+yj5wUsevOTByz49/LCFDAAAAAAAZGALGQAAAAAA2MAWsofBSx685MHLPkp+8JIHL3nwso+SH7zkwUsevOzDFjIAAAAAALCGLWQAAAAAAGADExgAAAAAABgGamAeBi958JIHL/so+cFLHrzkwcs+Sn7wkgcvefCyDzUwAAAAAABgDTUwAAAAAABgA1vIHgYvefCSBy/7KPnBSx685MHLPkp+8JIHL3nwsk/IFjIAAAAAAAAV2EIGAAAAAADDwAQGAAAAAACGgQkMAAAAAAAMAxMYAAAAAAAYBiYwAAAAAAAwDExgAAAAAABgGJjAAAAAAADAMPz/CR3yA682f6wAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 800x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import gdsfactory as gf\n",
+    "from ihp import PDK\n",
+    "\n",
+    "PDK.activate()\n",
+    "\n",
+    "c = gf.components.inductor(\n",
+    "    width=2,\n",
+    "    space=2.1,\n",
+    "    diameter=50,\n",
+    "    turns=1,\n",
+    "    layer_metal=\"TopMetal2drawing\",\n",
+    "    layer_inductor=\"INDdrawing\",\n",
+    "    layer_metal_pin=\"TopMetal2drawing\",\n",
+    "    layers_no_fill=(\"NoMetFillerdrawing\",),\n",
+    ").copy()\n",
+    "\n",
+    "# Define guard ring dimensions based on the inductor's bounding box\n",
+    "bbox = c.bbox()\n",
+    "xmin, ymin = bbox.left, bbox.bottom\n",
+    "xmax, ymax = bbox.right, bbox.top\n",
+    "\n",
+    "margin_outer = 0.0\n",
+    "margin_inner = -15.0\n",
+    "\n",
+    "ol, oright = xmin - margin_outer, xmax + margin_outer\n",
+    "ob, ot = ymin - margin_outer, ymax + margin_outer\n",
+    "il, ir = xmin - margin_inner, xmax + margin_inner\n",
+    "ib, it = ymin - margin_inner, ymax + margin_inner\n",
+    "\n",
+    "w_v = il - ol  # Width vertical walls\n",
+    "h_h = ot - it  # Height horizontal walls\n",
+    "over = 0.5  # Overlap for Gmsh to fuse the pieces\n",
+    "\n",
+    "# Left wall\n",
+    "c.add_ref(\n",
+    "    gf.components.rectangle(\n",
+    "        size=(w_v + over, ot - ob), layer=\"Metal1drawing\", centered=True\n",
+    "    )\n",
+    ").move((ol + w_v / 2 + over / 2, (ot + ob) / 2))\n",
+    "# Right wall\n",
+    "c.add_ref(\n",
+    "    gf.components.rectangle(\n",
+    "        size=(w_v + over, ot - ob), layer=\"Metal1drawing\", centered=True\n",
+    "    )\n",
+    ").move((oright - w_v / 2 - over / 2, (ot + ob) / 2))\n",
+    "# Top wall\n",
+    "c.add_ref(\n",
+    "    gf.components.rectangle(\n",
+    "        size=(oright - ol, h_h + over), layer=\"Metal1drawing\", centered=True\n",
+    "    )\n",
+    ").move(((oright + ol) / 2, ot - h_h / 2 - over / 2))\n",
+    "# Bottom wall\n",
+    "c.add_ref(\n",
+    "    gf.components.rectangle(\n",
+    "        size=(oright - ol, h_h + over), layer=\"Metal1drawing\", centered=True\n",
+    "    )\n",
+    ").move(((oright + ol) / 2, ob + h_h / 2 + over / 2))\n",
+    "\n",
+    "cc = c.copy()\n",
+    "\n",
+    "c.draw_ports()\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0a49a2e",
+   "metadata": {},
+   "source": [
+    "### Configure and run simulation with DrivenSim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "57e3ef84",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation: PASSED\n"
+     ]
+    }
+   ],
+   "source": [
+    "from gsim.palace import DrivenSim\n",
+    "\n",
+    "# Create simulation object\n",
+    "sim = DrivenSim()\n",
+    "\n",
+    "# Set output directory\n",
+    "sim.set_output_dir(\"./palace-sim-inductor-guardring\")\n",
+    "\n",
+    "# Set the component geometry\n",
+    "sim.set_geometry(cc)\n",
+    "\n",
+    "# Configure layer stack from active PDK\n",
+    "sim.set_stack(substrate_thickness=180.0, air_above=200.0, include_substrate=True)\n",
+    "\n",
+    "# Configure ports\n",
+    "sim.add_port(\n",
+    "    \"P1\", from_layer=\"metal1\", to_layer=\"topmetal2\", geometry=\"via\", excited=True\n",
+    ")\n",
+    "sim.add_port(\n",
+    "    \"P2\", from_layer=\"metal1\", to_layer=\"topmetal2\", geometry=\"via\", excited=True\n",
+    ")\n",
+    "\n",
+    "# Configure driven simulation (frequency sweep for S-parameters)\n",
+    "sim.set_driven(fmin=10e9, fmax=200e9, num_points=50)\n",
+    "\n",
+    "# Validate configuration\n",
+    "print(sim.validate_config())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "eca89cc6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Small conductor feature detected (2.100 um) may be under-resolved by refined_mesh_size=5.000 um. Pass auto_size=True to scale the mesh down.\n",
+      "Warning : 4 ill-shaped tets are still in the mesh\n",
+      "Warning : ------------------------------\n",
+      "Warning : Mesh generation error summary\n",
+      "Warning :     1 warning\n",
+      "Warning :     0 errors\n",
+      "Warning : Check the full log for details\n",
+      "Warning : ------------------------------\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Mesh Summary\n",
+       "========================================\n",
+       "Dimensions: 262.6 x 262.6 x 396.3 µm\n",
+       "Nodes:      9,709\n",
+       "Elements:   73,407\n",
+       "Tetrahedra: 55,159\n",
+       "Edge length: 0.40 - 185.69 µm\n",
+       "Quality:    0.521 (min: 0.001)\n",
+       "SICN:       0.561 (all valid)\n",
+       "----------------------------------------\n",
+       "Volumes (4):\n",
+       "  - silicon [1]\n",
+       "  - SiO2 [2]\n",
+       "  - passive [3]\n",
+       "  - air [4]\n",
+       "Surfaces (13):\n",
+       "  - metal1_xy [5]\n",
+       "  - metal1_z [6]\n",
+       "  - topmetal2_xy [7]\n",
+       "  - topmetal2_z [8]\n",
+       "  - P1 [9]\n",
+       "  - P2 [10]\n",
+       "  - silicon__None [11]\n",
+       "  - SiO2__silicon [12]\n",
+       "  - SiO2__None [13]\n",
+       "  - SiO2__passive [14]\n",
+       "  - passive__None [15]\n",
+       "  - air__passive [16]\n",
+       "  - air__None [17]\n",
+       "----------------------------------------\n",
+       "Mesh:   palace-sim-inductor-guardring/palace.msh"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Generate mesh (presets: \"coarse\", \"default\", \"fine\")\n",
+    "sim.mesh(preset=\"default\", margin=50, refined_mesh_size=1.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "6a4d41a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cf3dbeddc0da4a9b91c7754b741c7420",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Widget(value='<iframe src=\"http://localhost:43827/index.html?ui=P_0x7224083a7fb0_0&reconnect=auto\" class=\"pyvi…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sim.plot_mesh(show_groups=[\"metal\", \"P\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a7d5293",
+   "metadata": {},
+   "source": [
+    "### Run simulation on cloud"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "11649b59",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  palace-ab3528dd  completed  2m 42s\n",
+      "Extracting results.tar.gz...\n",
+      "Downloaded 11 files to /home/delfina/projects/gsim/nbs/IHP_components/sim-data-palace-ab3528dd\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run simulation on GDSFactory+ cloud\n",
+    "results = sim.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "9fb30d82",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Port mapping: Port 1: P1, Port 2: P2\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "mode": "lines",
+         "name": "S11",
+         "type": "scatter",
+         "visible": true,
+         "x": {
+          "bdata": "AAAAAAAAJEDqJFtdTsErQOokW11OwTFAiDa2jfWhNUD9yGO8nII5QHJbEetDYz1A83bfjPWhQEAuQDYkSZJCQP3IY7ycgkRAOJK6U/ByRkByWxHrQ2NIQK0kaIKXU0pA5+2+GetDTEC2duyxPjROQPifoSRJElBAlgRN8HIKUUAzafi7nAJSQNDNo4fG+lJAOJK6U/DyU0DV9mUfGutUQHJbEetD41VAD8C8tm3bVkCtJGiCl9NXQBTpfk7By1hAvW4RGOvDWUBDke7nFLxaQOD1mbM+tFtAfVpFf2isXEAav/BKkqRdQLgjnBa8nF5AVYhH4uWUX0B5dvnWh0ZgQMgoz7ycwmBAFtukorE+YUBljXqIxrphQLM/UG7bNmJAAvIlVPCyYkBRpPs5BS9jQJ9W0R8aq2NA7ginBS8nZEA9u3zrQ6NkQIttUtFYH2VA2h8ot22bZUAo0v2cghdmQHeE04KXk2ZAxjapaKwPZ0AU6X5OwYtnQGObVDTWB2hAsU0qGuuDaEAAAAAAAABpQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "MTAgNPGyN8D/f+9i3gc1wFT8eWIdCjPAu1euRaNxMcBq+vbc0RswwFxF6yEX6y3ADEaT7TbmK8CSuKr5hhkqwAD0/QYxeijAVH8a3EwAJ8A5g/ab5qUlwGxvNFpnZiTAGkisLzQ+I8CnZgRybSoiwLF+Yd7BKCHABVvlsU43IMCy9BXkEKkewFE0XnNT/hzAbti+nExsG8DPGU6qQvEZwIQrzLnLixjA4nkUZ8I6F8CQIepOPf0VwKazz+yI0hTA0/9QiCO6E8CaCvgPu7MSwPBKBecsvxHAg2sl04fcEMBege1kEAwQwIMps9qQnA7AQqTfsfRHDcAl0/hHkxwMwOUrwB6UHQvAWifjlj9PCsDxn77VVrcJwIG9W92JXQnA9xopThJMCcAkUWW3dZAJwDvqel9mPArAHRqzm5pmC8ClpNclLSsNwLm9+beKqg/A9ZgCK3iCEcC1IRbngqcTwDVplZeDPRbAfnsLcWsaGcCBqIetod8bwNZET+vEAR7Aq7uH4MwFH8Ci/+BMl9MewA==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "mode": "lines",
+         "name": "S21",
+         "type": "scatter",
+         "visible": true,
+         "x": {
+          "bdata": "AAAAAAAAJEDqJFtdTsErQOokW11OwTFAiDa2jfWhNUD9yGO8nII5QHJbEetDYz1A83bfjPWhQEAuQDYkSZJCQP3IY7ycgkRAOJK6U/ByRkByWxHrQ2NIQK0kaIKXU0pA5+2+GetDTEC2duyxPjROQPifoSRJElBAlgRN8HIKUUAzafi7nAJSQNDNo4fG+lJAOJK6U/DyU0DV9mUfGutUQHJbEetD41VAD8C8tm3bVkCtJGiCl9NXQBTpfk7By1hAvW4RGOvDWUBDke7nFLxaQOD1mbM+tFtAfVpFf2isXEAav/BKkqRdQLgjnBa8nF5AVYhH4uWUX0B5dvnWh0ZgQMgoz7ycwmBAFtukorE+YUBljXqIxrphQLM/UG7bNmJAAvIlVPCyYkBRpPs5BS9jQJ9W0R8aq2NA7ginBS8nZEA9u3zrQ6NkQIttUtFYH2VA2h8ot22bZUAo0v2cghdmQHeE04KXk2ZAxjapaKwPZ0AU6X5OwYtnQGObVDTWB2hAsU0qGuuDaEAAAAAAAABpQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "ghBdxwpVvL/cDdZswHXCv5vTKcaKEce/hoI2ceb9y7+3tVVYE6bQvyL1PWrXhtO/Q5vMhv+n1r+nUmlshg7av1b/oo40vt2/mG8Hsw7d4L/grC6GeQLjvyw/T3WbUOW/gI/G4qjI57+hB7iqzWvqv/c4zmsrO+2/tv0r9ekb8L/DicYyYLHxv2fjMBljXvO/habPS0Qj9b8+sPHVMwD3v0KhZuY19fi/D8IxlBYC+7+tUMNdWyb9v4M5+QwyYf+/i5s+VK7YAMD2YC8RjQoCwBO8FMUFRQPAENMm3IqGBMDU/LPgH80FwIgrKY1HFgfAYKFfq/FeCMCb64KEaqMJwCR3xuZO3wrAktI1rIkNDMBcxCNwYigNwCP8bu2oKQ7AjUB1Tg0LD8BYFabhusYPwBOmEwwnLBDAzvwixR1fEMCWfmA21X0QwHuPBD9JjRDA0wzmjcaWEMDBy7DdIKgQwMj+APt30hDAC76Hdv8mEcDRa5qJK7IRwJaTNooPdxLAv5m5AGhtE8A8oKqOmIMUwA==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "mode": "lines",
+         "name": "S12",
+         "type": "scatter",
+         "visible": "legendonly",
+         "x": {
+          "bdata": "AAAAAAAAJEDqJFtdTsErQOokW11OwTFAiDa2jfWhNUD9yGO8nII5QHJbEetDYz1A83bfjPWhQEAuQDYkSZJCQP3IY7ycgkRAOJK6U/ByRkByWxHrQ2NIQK0kaIKXU0pA5+2+GetDTEC2duyxPjROQPifoSRJElBAlgRN8HIKUUAzafi7nAJSQNDNo4fG+lJAOJK6U/DyU0DV9mUfGutUQHJbEetD41VAD8C8tm3bVkCtJGiCl9NXQBTpfk7By1hAvW4RGOvDWUBDke7nFLxaQOD1mbM+tFtAfVpFf2isXEAav/BKkqRdQLgjnBa8nF5AVYhH4uWUX0B5dvnWh0ZgQMgoz7ycwmBAFtukorE+YUBljXqIxrphQLM/UG7bNmJAAvIlVPCyYkBRpPs5BS9jQJ9W0R8aq2NA7ginBS8nZEA9u3zrQ6NkQIttUtFYH2VA2h8ot22bZUAo0v2cghdmQHeE04KXk2ZAxjapaKwPZ0AU6X5OwYtnQGObVDTWB2hAsU0qGuuDaEAAAAAAAABpQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "qCxdxwpVvL/cDdZswHXCv5vTKcaKEce/hoI2ceb9y7+3tVVYE6bQvyL1PWrXhtO/Q5vMhv+n1r+nUmlshg7av1b/oo40vt2/mG8Hsw7d4L/grC6GeQLjvyw/T3WbUOW/gI/G4qjI57+hB7iqzWvqv/c4zmsrO+2/tv0r9ekb8L/DicYyYLHxv2fjMBljXvO/habPS0Qj9b8+sPHVMwD3v0KhZuY19fi/D8IxlBYC+7+tUMNdWyb9v4M5+QwyYf+/i5s+VK7YAMD2YC8RjQoCwBO8FMUFRQPAENMm3IqGBMDU/LPgH80FwIgrKY1HFgfAYKFfq/FeCMCb64KEaqMJwCR3xuZO3wrAktI1rIkNDMBcxCNwYigNwCP8bu2oKQ7AjUB1Tg0LD8BYFabhusYPwBOmEwwnLBDAzvwixR1fEMCWfmA21X0QwHuPBD9JjRDA0wzmjcaWEMDBy7DdIKgQwMj+APt30hDAC76Hdv8mEcDRa5qJK7IRwJaTNooPdxLAv5m5AGhtE8A8oKqOmIMUwA==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "mode": "lines",
+         "name": "S22",
+         "type": "scatter",
+         "visible": "legendonly",
+         "x": {
+          "bdata": "AAAAAAAAJEDqJFtdTsErQOokW11OwTFAiDa2jfWhNUD9yGO8nII5QHJbEetDYz1A83bfjPWhQEAuQDYkSZJCQP3IY7ycgkRAOJK6U/ByRkByWxHrQ2NIQK0kaIKXU0pA5+2+GetDTEC2duyxPjROQPifoSRJElBAlgRN8HIKUUAzafi7nAJSQNDNo4fG+lJAOJK6U/DyU0DV9mUfGutUQHJbEetD41VAD8C8tm3bVkCtJGiCl9NXQBTpfk7By1hAvW4RGOvDWUBDke7nFLxaQOD1mbM+tFtAfVpFf2isXEAav/BKkqRdQLgjnBa8nF5AVYhH4uWUX0B5dvnWh0ZgQMgoz7ycwmBAFtukorE+YUBljXqIxrphQLM/UG7bNmJAAvIlVPCyYkBRpPs5BS9jQJ9W0R8aq2NA7ginBS8nZEA9u3zrQ6NkQIttUtFYH2VA2h8ot22bZUAo0v2cghdmQHeE04KXk2ZAxjapaKwPZ0AU6X5OwYtnQGObVDTWB2hAsU0qGuuDaEAAAAAAAABpQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "CZlDo/GyN8CNEWMc3Ac1wPSOX6UbCjPA2rhuq6RxMcAM+6V+1hswwB5zEB0l6y3AsaOnqUfmK8CHA/XfmBkqwDWiiflCeijAS6lLJV4AJ8Dl1PrV9qUlwClK0lh2ZiTAzH687kE+I8CtO1MIeioiwBe/GnTNKCHAgaq1eVk3IMDE1pRIJakewHn3JiJn/hzAibKuC2BsG8CDsTJNVvEZwCFOSwHgixjAp/68wNc6F8AzxEgmVP0VwPYWea2h0hTAQXLmoD66E8Cel0H22LMSwPEGUh1OvxHA6PU+76zcEMBJzA8ZOgwQwA33pCfvnA7AUZKlBmBIDcAwwYNeDh0MwNTc0n0iHgvAhXDC2+VPCsCjMWIaG7gJwLKUmUh0XgnADBiW4i1NCcBLK+yA0ZEJwA2O2DAXPgrAvQ6jpb1oC8Bvx4vP6y0NwEjHQDEgrg/AgIWLi9iEEcCLLV3es6oTwFkKKRvSQRbAhI3TISwgGcClvS6LC+cbwM81VZ+vCh7AZF0xqowPH8D2r2OwRN0ewA==",
+          "dtype": "f8"
+         }
+        }
+       ],
+       "layout": {
+        "height": 350,
+        "legend": {
+         "bgcolor": "rgba(245,245,245,0.9)",
+         "bordercolor": "#888",
+         "borderwidth": 1,
+         "entrywidth": 70,
+         "entrywidthmode": "pixels",
+         "groupclick": "toggleitem",
+         "itemclick": "toggle",
+         "itemdoubleclick": "toggleothers",
+         "itemsizing": "constant",
+         "x": 1.02,
+         "xanchor": "left",
+         "y": 1,
+         "yanchor": "top"
+        },
+        "margin": {
+         "b": 40,
+         "l": 60,
+         "r": 140,
+         "t": 40
+        },
+        "modebar": {
+         "orientation": "v"
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "width": 650,
+        "xaxis": {
+         "title": {
+          "text": "Frequency (GHz)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "|S| (dB)"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results.plot_interactive()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c62eda66",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Port mapping: Port 1: P1, Port 2: P2\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "mode": "lines",
+         "name": "S11",
+         "type": "scatter",
+         "visible": true,
+         "x": {
+          "bdata": "AAAAAAAAJEDqJFtdTsErQOokW11OwTFAiDa2jfWhNUD9yGO8nII5QHJbEetDYz1A83bfjPWhQEAuQDYkSZJCQP3IY7ycgkRAOJK6U/ByRkByWxHrQ2NIQK0kaIKXU0pA5+2+GetDTEC2duyxPjROQPifoSRJElBAlgRN8HIKUUAzafi7nAJSQNDNo4fG+lJAOJK6U/DyU0DV9mUfGutUQHJbEetD41VAD8C8tm3bVkCtJGiCl9NXQBTpfk7By1hAvW4RGOvDWUBDke7nFLxaQOD1mbM+tFtAfVpFf2isXEAav/BKkqRdQLgjnBa8nF5AVYhH4uWUX0B5dvnWh0ZgQMgoz7ycwmBAFtukorE+YUBljXqIxrphQLM/UG7bNmJAAvIlVPCyYkBRpPs5BS9jQJ9W0R8aq2NA7ginBS8nZEA9u3zrQ6NkQIttUtFYH2VA2h8ot22bZUAo0v2cghdmQHeE04KXk2ZAxjapaKwPZ0AU6X5OwYtnQGObVDTWB2hAsU0qGuuDaEAAAAAAAABpQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "SlH3JNsgU0Cu6/hwf8RSQKo/QBbMWlJA/Fu6luLrUUCxbkuWBXlRQDyWm6qIAlFA22x+YLeIUEDGQecy4QtQQB/PiKaaGE9ALeAehWcUTkD+3r0deAtNQOsmHMz9/UtAT0SBLhHsSkCxE+Upt9VJQFs7OjTlukhACIa6toSbR0CeRC6VdXdGQAI7b/qPTkVA2kz3i6UgRECAm/8ggu1CQAkAkBLstEFALL0HM6R2QEBlMdXrymQ+QHP5y5jIzztASWJscJstOUBVmkArjH02QFw+dj3PvjNA1KX1XoHwMEAXwGR0RyMsQGfKxSEwQiZAVOTF4To7IEDJNPZaOhcUQLy/8d0/gv0/yGQU2S3Q9r/PGuHMIy0TwKtVKdJKiCDAd/BT2RexJ8DXtpWunBAvwFoTCUgIUTPAqQBvCkwsN8BeP75xqww7wOSddEsr2T7A6S5/bXkzQcAclgQ0GrlCwAppDjdGzUPAbZQ2qdM2RMBuisPH7chDwAYzzof3ikLAu8IBT7LWQMA7oYNI4nA+wA==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "mode": "lines",
+         "name": "S21",
+         "type": "scatter",
+         "visible": true,
+         "x": {
+          "bdata": "AAAAAAAAJEDqJFtdTsErQOokW11OwTFAiDa2jfWhNUD9yGO8nII5QHJbEetDYz1A83bfjPWhQEAuQDYkSZJCQP3IY7ycgkRAOJK6U/ByRkByWxHrQ2NIQK0kaIKXU0pA5+2+GetDTEC2duyxPjROQPifoSRJElBAlgRN8HIKUUAzafi7nAJSQNDNo4fG+lJAOJK6U/DyU0DV9mUfGutUQHJbEetD41VAD8C8tm3bVkCtJGiCl9NXQBTpfk7By1hAvW4RGOvDWUBDke7nFLxaQOD1mbM+tFtAfVpFf2isXEAav/BKkqRdQLgjnBa8nF5AVYhH4uWUX0B5dvnWh0ZgQMgoz7ycwmBAFtukorE+YUBljXqIxrphQLM/UG7bNmJAAvIlVPCyYkBRpPs5BS9jQJ9W0R8aq2NA7ginBS8nZEA9u3zrQ6NkQIttUtFYH2VA2h8ot22bZUAo0v2cghdmQHeE04KXk2ZAxjapaKwPZ0AU6X5OwYtnQGObVDTWB2hAsU0qGuuDaEAAAAAAAABpQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "oT8+SemaF8AHXlrcHi0gwDo2hQT6fyTAUf5x6NTNKMB/QXBgWBstwFh8sKmctTDAqico4ZrfMsAFYJWpTww1wICZNZFOPDfAIRUKUSRwOcA77UuuXKg7wMfaMKyE5T3AJ69cqRUUQMBJgbgHcThBwNeMdZAeYELAh28aHmqLQ8Dfu5LAobpEwFa3WmUW7kXAeu7HtBwmR8AQ1TcuDmNIwMz42ZBKpUnAw8CxozntSsAhS1x1TTtMwO4bYjMFkE3AcETBwfDrTsDPgSuj2idQwN/5pnQJ3lDAUDsFDvaYUcCQLJ1lJ1lSwFqG9Po/H1PA8Yk6HAXsU8B45sj0Z8BUwK6DBLOQnVXAISIuAOyEVsB8NGXKOnhXwFK2dN6jeVjAltRIzMWLWcAs6pe5xbFawNqTNatU71vAIvkUCaBIXcAUQnPUG8JewAKXQoYHMGDAnBsyYeUSYcC8v3zdQgpiwPJU/1gDFWPAZ7i1EMovZMA6C7o+7VRlwE3wgzMkfWbABF1Vly9fZUB5t6UapUZkQA==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "mode": "lines",
+         "name": "S12",
+         "type": "scatter",
+         "visible": "legendonly",
+         "x": {
+          "bdata": "AAAAAAAAJEDqJFtdTsErQOokW11OwTFAiDa2jfWhNUD9yGO8nII5QHJbEetDYz1A83bfjPWhQEAuQDYkSZJCQP3IY7ycgkRAOJK6U/ByRkByWxHrQ2NIQK0kaIKXU0pA5+2+GetDTEC2duyxPjROQPifoSRJElBAlgRN8HIKUUAzafi7nAJSQNDNo4fG+lJAOJK6U/DyU0DV9mUfGutUQHJbEetD41VAD8C8tm3bVkCtJGiCl9NXQBTpfk7By1hAvW4RGOvDWUBDke7nFLxaQOD1mbM+tFtAfVpFf2isXEAav/BKkqRdQLgjnBa8nF5AVYhH4uWUX0B5dvnWh0ZgQMgoz7ycwmBAFtukorE+YUBljXqIxrphQLM/UG7bNmJAAvIlVPCyYkBRpPs5BS9jQJ9W0R8aq2NA7ginBS8nZEA9u3zrQ6NkQIttUtFYH2VA2h8ot22bZUAo0v2cghdmQHeE04KXk2ZAxjapaKwPZ0AU6X5OwYtnQGObVDTWB2hAsU0qGuuDaEAAAAAAAABpQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "oT8+SemaF8AHXlrcHi0gwDo2hQT6fyTAUf5x6NTNKMB/QXBgWBstwFh8sKmctTDAqico4ZrfMsAFYJWpTww1wICZNZFOPDfAIRUKUSRwOcA77UuuXKg7wMfaMKyE5T3AJ69cqRUUQMBJgbgHcThBwNeMdZAeYELAh28aHmqLQ8Dfu5LAobpEwFa3WmUW7kXAeu7HtBwmR8AQ1TcuDmNIwMz42ZBKpUnAw8CxozntSsAhS1x1TTtMwO4bYjMFkE3AcETBwfDrTsDPgSuj2idQwN/5pnQJ3lDAUDsFDvaYUcCQLJ1lJ1lSwFqG9Po/H1PA8Yk6HAXsU8B45sj0Z8BUwK6DBLOQnVXAISIuAOyEVsB8NGXKOnhXwFK2dN6jeVjAltRIzMWLWcAs6pe5xbFawNqTNatU71vAIvkUCaBIXcAUQnPUG8JewAKXQoYHMGDAnBsyYeUSYcC8v3zdQgpiwPJU/1gDFWPAZ7i1EMovZMA6C7o+7VRlwE3wgzMkfWbABF1Vly9fZUB5t6UapUZkQA==",
+          "dtype": "f8"
+         }
+        },
+        {
+         "mode": "lines",
+         "name": "S22",
+         "type": "scatter",
+         "visible": "legendonly",
+         "x": {
+          "bdata": "AAAAAAAAJEDqJFtdTsErQOokW11OwTFAiDa2jfWhNUD9yGO8nII5QHJbEetDYz1A83bfjPWhQEAuQDYkSZJCQP3IY7ycgkRAOJK6U/ByRkByWxHrQ2NIQK0kaIKXU0pA5+2+GetDTEC2duyxPjROQPifoSRJElBAlgRN8HIKUUAzafi7nAJSQNDNo4fG+lJAOJK6U/DyU0DV9mUfGutUQHJbEetD41VAD8C8tm3bVkCtJGiCl9NXQBTpfk7By1hAvW4RGOvDWUBDke7nFLxaQOD1mbM+tFtAfVpFf2isXEAav/BKkqRdQLgjnBa8nF5AVYhH4uWUX0B5dvnWh0ZgQMgoz7ycwmBAFtukorE+YUBljXqIxrphQLM/UG7bNmJAAvIlVPCyYkBRpPs5BS9jQJ9W0R8aq2NA7ginBS8nZEA9u3zrQ6NkQIttUtFYH2VA2h8ot22bZUAo0v2cghdmQHeE04KXk2ZAxjapaKwPZ0AU6X5OwYtnQGObVDTWB2hAsU0qGuuDaEAAAAAAAABpQA==",
+          "dtype": "f8"
+         },
+         "y": {
+          "bdata": "AAlqyL0gU0AUfWCITcRSQAIm1oSBWlJAEvcCEIXrUUBRcIbZmnhRQEP1m08UAlFAVEZJJDuIUEDuYu6fXQtQQIdR44eEF09AUCkCaUETTkCVT0uoQApNQHfrPIKz/EtA2DNLlLLqSkBeofDRQtRJQDZtFcZZuUhANA8b8OCZR0DWOQlIuHVGQNX9PAm4TEVAnrHk5LEeREAGTnq4cetCQLvJad29skFAN89KIFd0QEAWisfQ8F8+QGcmtiesyjtA7t5mFDooOUCy3HwL43c2QIE2bizbuDNAXl/axz7qMEAG2T8YHRYsQFaxgk5XNCZAXiR48KgsIEDYZqe0i/gTQOcS5+DoAP0/8+6Ne6RY97+RjtF0L1ETwDjJMMddmyDAl3b2pFHFJ8DakZ0TGyYvwDS+YtZ6XDPAOdMnFoU4N8C5VPJrvxk7wExh7a8t5z7A2JH+Uvg6QcAUyxb7E8FCwHYAfO6i1UPAfRSjk1M/RMC/NFOcGNFDwOswEz4skkLADyjK5XLcQMBOsO5QZnk+wA==",
+          "dtype": "f8"
+         }
+        }
+       ],
+       "layout": {
+        "height": 350,
+        "legend": {
+         "bgcolor": "rgba(245,245,245,0.9)",
+         "bordercolor": "#888",
+         "borderwidth": 1,
+         "entrywidth": 70,
+         "entrywidthmode": "pixels",
+         "groupclick": "toggleitem",
+         "itemclick": "toggle",
+         "itemdoubleclick": "toggleothers",
+         "itemsizing": "constant",
+         "x": 1.02,
+         "xanchor": "left",
+         "y": 1,
+         "yanchor": "top"
+        },
+        "margin": {
+         "b": 40,
+         "l": 60,
+         "r": 140,
+         "t": 40
+        },
+        "modebar": {
+         "orientation": "v"
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermap": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermap"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "width": 650,
+        "xaxis": {
+         "title": {
+          "text": "Frequency (GHz)"
+         }
+        },
+        "yaxis": {
+         "title": {
+          "text": "Phase (deg)"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "results.plot_interactive(phase=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Overview
This notebook demonstrates a driven EM simulation of a spiral inductor 
using `gsim.palace` with the IHP PDK. The inductor includes 
a Metal1 guard ring. It follows the same conventions as the existing 
example notebooks in the repository.

## What this adds
- Driven simulation setup for a spiral inductor with guard ring
- S-parameter extraction

## Work in progress
This is an initial contribution. Planned next steps:
- Fit equivalent RLC circuit models to simulation results
- Optimize inductor geometry for high Q factor

## Notes
Feedback welcome, especially on simulation setup and port configuration.