### PR TITLE
fix: reorder pyproject.toml sections to satisfy tombi-format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["build", "setuptools>=61", "uv", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "gsim"
 version = "0.0.16"
@@ -73,6 +69,10 @@ test = [
   "pytest-xdist>=3.6.0",
 ]
 
+[build-system]
+requires = ["build", "setuptools>=61", "uv", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [[tool.bver.file]]
 src = "README.md"
 
@@ -99,6 +99,9 @@ ignore-overloaded-functions = true
 ignore-regex = ["^test_.*"]
 omit-covered-files = true
 verbose = 2
+
+[tool.jupytext]
+formats = "nbs///ipynb,nbs///py:percent"
 
 [tool.mypy]
 mypy_path = ["src"]
@@ -297,9 +300,6 @@ select = ["ALL"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
-
-[tool.jupytext]
-formats = "nbs///ipynb,nbs///py:percent"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary

Fixes the pre-commit `tombi-format` failure that occurred during the merge of #135.

## Root cause

Commit `7d9ef0b` (merge of #135) placed `[tool.jupytext]` at the end of the TOML tool sections and left `[build-system]` before `[project]`. `tombi-format` v0.7.14 requires:
- `[build-system]` after `[project]` and its dependency groups
- `[tool.*]` tables in alphabetical order

## Changes

- Moved `[build-system]` from the top of the file to after the dependency groups
- Moved `[tool.jupytext]` from after `[tool.ruff.lint.pydocstyle]` to between `[tool.interrogate]` and `[tool.mypy]`

## Verification

All 27 pre-commit hooks pass:
```
pre-commit run --all-files  # ✓ All Passed
```