### PR TITLE
Add cdaunt, flaport, and das-dias to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @nikosavola @vvahidd
+* @joamatab @nikosavola @vvahidd @cdaunt @flaport @das-dias


### PR DESCRIPTION
## Summary
- Add @cdaunt, @flaport, and @das-dias as code owners for the repository

## Test plan
- [x] Verify CODEOWNERS syntax is correct