### PR TITLE
feat(mesh): decimate_tolerance, verbosity, and stale tag fix

### DIFF
--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -1026,7 +1026,7 @@ class PalaceSimMixin:
         show_gui: bool = False,
         model_name: str = "palace",
         verbose: bool = True,
-        gmsh_verbosity: int = 0,
+        verbosity: int = 0,
         auto_size: bool = False,
         cells_per_feature: int = 2,
         periodic_axis: str | None = None,
@@ -1052,7 +1052,7 @@ class PalaceSimMixin:
             show_gui: Show gmsh GUI during meshing
             model_name: Base name for output files
             verbose: Print progress messages
-            gmsh_verbosity: Gmsh OCC verbosity level (0=silent, 1-99=increasing)
+            verbosity: Gmsh OCC verbosity level (0=silent, 1-99=increasing)
             auto_size: If True, scale refined_mesh_size down to the smallest
                 conductor feature / cells_per_feature. Off by default so presets
                 use their literal refined_mesh_size.
@@ -1123,7 +1123,7 @@ class PalaceSimMixin:
             write_config=False,
             periodic_axis=periodic_axis,
             decimate_tolerance=decimate_tolerance,
-            gmsh_verbosity=gmsh_verbosity,
+            gmsh_verbosity=verbosity,
         )
 
         # Post-mesh summary: nodes, tets, refined / max sizes (in um).

--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -826,6 +826,8 @@ class PalaceSimMixin:
         verbose: bool,
         write_config: bool = True,
         periodic_axis: str | None = None,
+        decimate_tolerance: float | None = None,
+        gmsh_verbosity: int = 0,
     ) -> SimulationResult:
         """Internal mesh generation."""
         from gsim.palace.mesh.generator import generate_mesh
@@ -873,7 +875,8 @@ class PalaceSimMixin:
             absorbing_boundary=self.absorbing_boundary,
             periodic_axis=periodic_axis,
             merge_via_distance=mesh_config.merge_via_distance,
-            verbosity=3,
+            decimate_tolerance=decimate_tolerance,
+            verbosity=gmsh_verbosity,
         )
 
         # Store mesh_result for deferred config generation
@@ -915,6 +918,7 @@ class PalaceSimMixin:
         show_gui: bool = True,
         auto_size: bool = False,
         cells_per_feature: int = 2,
+        decimate_tolerance: float | None = None,
     ) -> None:
         """Preview the mesh without running simulation.
 
@@ -935,6 +939,8 @@ class PalaceSimMixin:
                 conductor feature / cells_per_feature. Off by default.
             cells_per_feature: Target cells across the smallest conductor
                 feature when auto_size=True. Default 2.
+            decimate_tolerance: Relative tolerance for polygon decimation
+                (None = no decimation; typical 0.001-0.01).
 
         Example:
             >>> sim.preview(preset="fine", planar_conductors=True, show_gui=True)
@@ -998,6 +1004,7 @@ class PalaceSimMixin:
                 pec_blocks=self._pec_blocks or None,
                 absorbing_boundary=self.absorbing_boundary,
                 merge_via_distance=mesh_config.merge_via_distance,
+                decimate_tolerance=decimate_tolerance,
             )
 
     # -------------------------------------------------------------------------
@@ -1019,9 +1026,11 @@ class PalaceSimMixin:
         show_gui: bool = False,
         model_name: str = "palace",
         verbose: bool = True,
+        gmsh_verbosity: int = 0,
         auto_size: bool = False,
         cells_per_feature: int = 2,
         periodic_axis: str | None = None,
+        decimate_tolerance: float | None = None,
     ) -> SimulationResult:
         """Generate the mesh for Palace simulation.
 
@@ -1043,6 +1052,7 @@ class PalaceSimMixin:
             show_gui: Show gmsh GUI during meshing
             model_name: Base name for output files
             verbose: Print progress messages
+            gmsh_verbosity: Gmsh OCC verbosity level (0=silent, 1-99=increasing)
             auto_size: If True, scale refined_mesh_size down to the smallest
                 conductor feature / cells_per_feature. Off by default so presets
                 use their literal refined_mesh_size.
@@ -1050,6 +1060,9 @@ class PalaceSimMixin:
                 feature when auto_size=True. Default 2.
             periodic_axis: Optional periodic axis ("x" or "y") for periodic
                 meshing constraints on opposite domain sides.
+            decimate_tolerance: Relative tolerance for polygon decimation
+                (None = no decimation; typical 0.001-0.01). Reduces vertex
+                count on curved geometry before meshing.
 
         Returns:
             SimulationResult with mesh path
@@ -1109,6 +1122,8 @@ class PalaceSimMixin:
             verbose=verbose,
             write_config=False,
             periodic_axis=periodic_axis,
+            decimate_tolerance=decimate_tolerance,
+            gmsh_verbosity=gmsh_verbosity,
         )
 
         # Post-mesh summary: nodes, tets, refined / max sizes (in um).

--- a/src/gsim/palace/mesh/generator.py
+++ b/src/gsim/palace/mesh/generator.py
@@ -202,6 +202,7 @@ def generate_mesh(
     absorbing_boundary: bool = True,
     periodic_axis: str | None = None,
     merge_via_distance: float = 2.0,
+    decimate_tolerance: float | None = None,
     verbosity: int = 3,
 ) -> MeshResult:
     """Generate mesh for Palace EM simulation.
@@ -232,6 +233,8 @@ def generate_mesh(
         absorbing_boundary: If True, use absorbing boundary conditions on outer surfaces
         periodic_axis: ("x" or "y") for meshing constraints on opposite domain sides
         merge_via_distance: Max gap between vias to merge (um)
+        decimate_tolerance: Relative tolerance for polygon decimation
+            (None = no decimation; typical 0.001-0.01)
         verbosity: Sets gmsh verbosity level
 
     Returns:
@@ -244,7 +247,7 @@ def generate_mesh(
 
     # Extract geometry
     logger.info("Extracting geometry...")
-    geometry = extract_geometry(component, stack)
+    geometry = extract_geometry(component, stack, decimate_tolerance=decimate_tolerance)
     logger.info("  Polygons: %s", len(geometry.polygons))
     logger.info("  Bbox: %s", geometry.bbox)
 

--- a/src/gsim/palace/mesh/generator.py
+++ b/src/gsim/palace/mesh/generator.py
@@ -203,7 +203,7 @@ def generate_mesh(
     periodic_axis: str | None = None,
     merge_via_distance: float = 2.0,
     decimate_tolerance: float | None = None,
-    verbosity: int = 3,
+    verbosity: int = 0,
 ) -> MeshResult:
     """Generate mesh for Palace EM simulation.
 

--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -36,12 +36,17 @@ class GeometryData:
     layer_bboxes: dict  # layer_num -> (xmin, ymin, xmax, ymax)
 
 
-def extract_geometry(component, stack: LayerStack) -> GeometryData:
+def extract_geometry(
+    component, stack: LayerStack, *, decimate_tolerance: float | None = None
+) -> GeometryData:
     """Extract polygon geometry from a gdsfactory component.
 
     Args:
         component: gdsfactory Component
         stack: LayerStack for layer mapping
+        decimate_tolerance: If set, simplify polygons with Douglas-Peucker
+            using this relative tolerance (passed to ``decimate()``).
+            Typical values: 0.001 (conservative) to 0.01 (aggressive).
 
     Returns:
         GeometryData with polygons and bounding boxes
@@ -52,6 +57,30 @@ def extract_geometry(component, stack: LayerStack) -> GeometryData:
 
     # Get polygons from component
     polygons_by_index = component.get_polygons()
+
+    if decimate_tolerance is not None:
+        from gsim.common.polygon_utils import decimate
+
+        total_before = 0
+        total_after = 0
+        decimated_by_index = {}
+        for layer_index, polys in polygons_by_index.items():
+            total_before += sum(p.num_points_hull() for p in polys)
+            decimated_by_index[layer_index] = decimate(
+                polys, relative_tolerance=decimate_tolerance, verbose=True
+            )
+            total_after += sum(
+                p.num_points_hull() for p in decimated_by_index[layer_index]
+            )
+        if total_before > 0:
+            pct = (total_before - total_after) / total_before * 100
+            logger.info(
+                "Decimation: %d -> %d pts (%.1f%% removed)",
+                total_before,
+                total_after,
+                pct,
+            )
+        polygons_by_index = decimated_by_index
 
     # Build layer_index -> GDS tuple mapping
     layout = component.kcl.layout

--- a/src/gsim/palace/mesh/gmsh_utils.py
+++ b/src/gsim/palace/mesh/gmsh_utils.py
@@ -149,14 +149,53 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
                 tool_dimtags = [dt for prev in processed_in_dim for dt in prev.dimtags]
 
                 if tool_dimtags and entity.dimtags:
-                    cut_result, _ = gmsh.model.occ.cut(
-                        entity.dimtags,
-                        tool_dimtags,
-                        removeObject=True,
-                        removeTool=False,
-                    )
-                    gmsh.model.occ.synchronize()
-                    entity.dimtags = list(set(cut_result))
+                    # occ.cut(object, tool, removeObject=True) destroys all
+                    # object tags — including any that may be shared with
+                    # previously processed entities (from the fragment step).
+                    # Collect object tags so we can prune stale references
+                    # from processed_in_dim afterwards.
+                    object_tag_set = {t for _, t in entity.dimtags}
+                    try:
+                        cut_result, _ = gmsh.model.occ.cut(
+                            entity.dimtags,
+                            tool_dimtags,
+                            removeObject=True,
+                            removeTool=False,
+                        )
+                        gmsh.model.occ.synchronize()
+                        entity.dimtags = list(set(cut_result))
+                    except Exception:
+                        # Stale tags can cause "Unknown entity" errors.
+                        # Filter to only valid dimtags and retry.
+                        valid = []
+                        for dt in entity.dimtags:
+                            try:
+                                gmsh.model.getBoundary([dt], oriented=False)
+                                valid.append(dt)
+                            except Exception:
+                                pass
+                        gmsh.model.occ.synchronize()
+                        if valid:
+                            cut_result, _ = gmsh.model.occ.cut(
+                                valid,
+                                tool_dimtags,
+                                removeObject=True,
+                                removeTool=False,
+                            )
+                            gmsh.model.occ.synchronize()
+                            entity.dimtags = list(set(cut_result))
+                        else:
+                            entity.dimtags = []
+
+                    # Prune stale tags from previously processed entities.
+                    # removeObject=True may have invalidated shared tags.
+                    destroyed = object_tag_set - {t for _, t in entity.dimtags}
+                    if destroyed:
+                        for prev in processed_in_dim:
+                            prev.dimtags = [
+                                dt for dt in prev.dimtags
+                                if dt[1] not in destroyed
+                            ]
 
                 if entity.dimtags:
                     processed_in_dim.append(entity)

--- a/src/gsim/palace/mesh/gmsh_utils.py
+++ b/src/gsim/palace/mesh/gmsh_utils.py
@@ -193,8 +193,7 @@ def run_boolean_pipeline(entities: list[Entity]) -> dict[str, int]:
                     if destroyed:
                         for prev in processed_in_dim:
                             prev.dimtags = [
-                                dt for dt in prev.dimtags
-                                if dt[1] not in destroyed
+                                dt for dt in prev.dimtags if dt[1] not in destroyed
                             ]
 
                 if entity.dimtags:


### PR DESCRIPTION
## Summary
- Add `decimate_tolerance` param for polygon simplification in mesh generation
- Add `verbosity` param to `mesh()` for controlling gmsh OCC output (default 0 = silent)
- Fix stale shared tag handling in boolean pipeline priority cuts
- Rename `gmsh_verbosity` → `verbosity` for cleaner API

## Dependencies
Depends on PR #143 (frequency-dependent materials) — mesh code touches material resolution.