### PR TITLE
feat(palace): electrostatic simulation end-to-end

### DIFF
--- a/nbs/_palace_electrostatic.ipynb
+++ b/nbs/_palace_electrostatic.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "84fb8ed3",
+   "metadata": {},
+   "source": [
+    "# Electrostatic Capacitance Extraction with Palace\n",
+    "\n",
+    "This notebook demonstrates electrostatic simulation using `gsim.palace.ElectrostaticSim` to extract the capacitance matrix between conductor terminals.\n",
+    "\n",
+    "We use the IHP `cmim` (MIM capacitor) cell. The bottom plate is on Metal5 and the top plate on TopMetal1, connected by a 10x10 array of Vmim vias through a thin MIM dielectric (0.19 um SiO2).\n",
+    "\n",
+    "**Limitation:** The current terminal system assigns one terminal per layer. Structures with multiple electrodes on the same layer (e.g., interdigitated capacitors) are not yet supported.\n",
+    "\n",
+    "**Requirements:**\n",
+    "- IHP PDK: `uv pip install ihp-gdsfactory`\n",
+    "- [GDSFactory+](https://gdsfactory.com) account for cloud simulation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a79d4f6e",
+   "metadata": {},
+   "source": [
+    "### Load IHP MIM capacitor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b8b2971",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ihp import PDK, cells\n",
+    "\n",
+    "PDK.activate()\n",
+    "\n",
+    "cap_width = 10.0  # um\n",
+    "cap_length = 10.0  # um\n",
+    "\n",
+    "# IHP cmim: Metal5 (bottom plate, MINUS) -> MIM dielectric (0.19 um SiO2)\n",
+    "#   -> 10x10 Vmim vias (0.42 um, pitch 0.94 um) -> TopMetal1 (top plate, PLUS)\n",
+    "c = cells.cmim(width=cap_width, length=cap_length).copy()\n",
+    "print(\"Ports:\", [(p.name, tuple(p.center)) for p in c.ports])\n",
+    "c.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "402977b2",
+   "metadata": {},
+   "source": [
+    "### Configure ElectrostaticSim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "115539f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gsim.palace import ElectrostaticSim\n",
+    "\n",
+    "sim = ElectrostaticSim()\n",
+    "\n",
+    "sim.set_output_dir(\"./palace-sim-electrostatic\")\n",
+    "sim.set_geometry(c)\n",
+    "sim.set_stack(air_above=100.0, substrate_thickness=2.0)\n",
+    "\n",
+    "# Metal5 = bottom plate (MINUS), TopMetal1 = top plate (PLUS)\n",
+    "sim.add_terminal(\"T1\", layer=\"metal5\")\n",
+    "sim.add_terminal(\"T2\", layer=\"topmetal1\")\n",
+    "\n",
+    "sim.set_electrostatic()\n",
+    "\n",
+    "print(sim.validate_config())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1efee757",
+   "metadata": {},
+   "source": [
+    "### Mesh and generate config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fae1dec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Vmim vias are 0.42 um with 0.52 um gaps; MIM dielectric is 0.19 um thick\n",
+    "sim.mesh(preset=\"fine\", margin=20, refined_mesh_size=0.1, merge_via_distance=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b3073de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sim.plot_mesh(show_groups=[\"metal\", \"topmetal\", \"via\", \"dielectric\", \"SiO2__vmim\"])\n",
+    "\n",
+    "sim.plot_mesh(show_groups=[\"metal5\", \"topmetal1\", \"vmim\", \"SiO2__vmim\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "219723a6",
+   "metadata": {},
+   "source": [
+    "### Analytical estimate\n",
+    "\n",
+    "For the MIM capacitor: C = epsilon_0 * epsilon_r * A / d\n",
+    "\n",
+    "The MIM dielectric (SiO2, eps_r ~ 4.1) is 0.19 um thick between Metal5 top (z=5.38) and the Vmim bottom (z=5.58). The MIM drawing is 10.72 x 10.72 um. The Vmim vias (tungsten, conductive) extend the TopMetal1 terminal down to the MIM dielectric surface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2ec945b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy.constants as const\n",
+    "\n",
+    "# MIM dielectric area (MIM drawing: 10.72 x 10.72 um)\n",
+    "eps_r = 4.1  # SiO2 permittivity from IHP stack\n",
+    "A_mim = (10.72e-6) * (10.72e-6)  # m^2\n",
+    "d_mim = (5.58 - 5.38) * 1e-6  # m (Metal5 top to Vmim bottom = MIM dielectric)\n",
+    "\n",
+    "C_analytical = const.epsilon_0 * eps_r * A_mim / d_mim\n",
+    "print(f\"Analytical capacitance: {C_analytical * 1e15:.1f} fF\")\n",
+    "print(f\"  A_mim = 10.72 x 10.72 um^2, d = {d_mim * 1e6:.2f} um, eps_r = {eps_r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "360bf9f4",
+   "metadata": {},
+   "source": [
+    "### Run on cloud\n",
+    "\n",
+    "Uncomment to submit to GDSFactory+ cloud. The result should be a capacitance matrix CSV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec6b701e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = sim.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d779e94",
+   "metadata": {},
+   "source": [
+    "### Load and analyze results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0130be42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "results_dir = Path(results[\"terminal-C.csv\"]).parent\n",
+    "\n",
+    "\n",
+    "def read_palace_csv(path):\n",
+    "    \"\"\"Read a Palace output CSV, returning header and data as numpy array.\"\"\"\n",
+    "    with open(path) as f:\n",
+    "        reader = csv.reader(f)\n",
+    "        header = next(reader)\n",
+    "        data = np.array([[float(x) for x in row] for row in reader])\n",
+    "    return [h.strip() for h in header], data\n",
+    "\n",
+    "\n",
+    "# Capacitance matrix\n",
+    "header, C_matrix = read_palace_csv(results_dir / \"terminal-C.csv\")\n",
+    "print(\"Capacitance matrix (F):\")\n",
+    "print(f\"  C[1,1] = {C_matrix[0, 1]:+.4e} F  ({C_matrix[0, 1] * 1e15:+.3f} fF)\")\n",
+    "print(f\"  C[1,2] = {C_matrix[0, 2]:+.4e} F  ({C_matrix[0, 2] * 1e15:+.3f} fF)\")\n",
+    "print(f\"  C[2,1] = {C_matrix[1, 1]:+.4e} F  ({C_matrix[1, 1] * 1e15:+.3f} fF)\")\n",
+    "print(f\"  C[2,2] = {C_matrix[1, 2]:+.4e} F  ({C_matrix[1, 2] * 1e15:+.3f} fF)\")\n",
+    "\n",
+    "# Mutual capacitance\n",
+    "_, Cm = read_palace_csv(results_dir / \"terminal-Cm.csv\")\n",
+    "print(f\"\\nMutual capacitance C_m[1,2] = {Cm[0, 2] * 1e15:.3f} fF\")\n",
+    "\n",
+    "# Domain energy\n",
+    "_, E = read_palace_csv(results_dir / \"domain-E.csv\")\n",
+    "print(\n",
+    "    f\"\\nStored electric energy: {E[0, 1]:.4e} J (excitation 1), {E[1, 1]:.4e} J (excitation 2)\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37e18052",
+   "metadata": {},
+   "source": [
+    "### Compare with analytical estimate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc69ea26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy.constants as const\n",
+    "\n",
+    "C_palace = abs(C_matrix[0, 1])\n",
+    "\n",
+    "eps_r = 4.1\n",
+    "A_mim = (10.72e-6) * (10.72e-6)\n",
+    "d_mim = (5.58 - 5.38) * 1e-6\n",
+    "\n",
+    "C_analytical = const.epsilon_0 * eps_r * A_mim / d_mim\n",
+    "\n",
+    "print(f\"Palace result:       {C_palace * 1e15:.3f} fF\")\n",
+    "print(f\"Analytical (C=eA/d): {C_analytical * 1e15:.1f} fF\")\n",
+    "print(f\"Ratio:               {C_palace / C_analytical:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2a721f8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gsim",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nbs/_palace_electrostatic.py
+++ b/nbs/_palace_electrostatic.py
@@ -1,0 +1,161 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.2
+#   kernelspec:
+#     display_name: gsim
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Electrostatic Capacitance Extraction with Palace
+#
+# This notebook demonstrates electrostatic simulation using `gsim.palace.ElectrostaticSim` to extract the capacitance matrix between conductor terminals.
+#
+# We use the IHP `cmim` (MIM capacitor) cell. The bottom plate is on Metal5 and the top plate on TopMetal1, connected by a 10x10 array of Vmim vias through a thin MIM dielectric (0.19 um SiO2).
+#
+# **Limitation:** The current terminal system assigns one terminal per layer. Structures with multiple electrodes on the same layer (e.g., interdigitated capacitors) are not yet supported.
+#
+# **Requirements:**
+# - IHP PDK: `uv pip install ihp-gdsfactory`
+# - [GDSFactory+](https://gdsfactory.com) account for cloud simulation
+
+# %% [markdown]
+# ### Load IHP MIM capacitor
+
+# %%
+from ihp import PDK, cells
+
+PDK.activate()
+
+cap_width = 10.0  # um
+cap_length = 10.0  # um
+
+# IHP cmim: Metal5 (bottom plate, MINUS) -> MIM dielectric (0.19 um SiO2)
+#   -> 10x10 Vmim vias (0.42 um, pitch 0.94 um) -> TopMetal1 (top plate, PLUS)
+c = cells.cmim(width=cap_width, length=cap_length).copy()
+print("Ports:", [(p.name, tuple(p.center)) for p in c.ports])
+c.plot()
+
+# %% [markdown]
+# ### Configure ElectrostaticSim
+
+# %%
+from gsim.palace import ElectrostaticSim
+
+sim = ElectrostaticSim()
+
+sim.set_output_dir("./palace-sim-electrostatic")
+sim.set_geometry(c)
+sim.set_stack(air_above=100.0, substrate_thickness=2.0)
+
+# Metal5 = bottom plate (MINUS), TopMetal1 = top plate (PLUS)
+sim.add_terminal("T1", layer="metal5")
+sim.add_terminal("T2", layer="topmetal1")
+
+sim.set_electrostatic()
+
+print(sim.validate_config())
+
+# %% [markdown]
+# ### Mesh and generate config
+
+# %%
+# Vmim vias are 0.42 um with 0.52 um gaps; MIM dielectric is 0.19 um thick
+sim.mesh(preset="fine", margin=20, refined_mesh_size=0.1, merge_via_distance=0)
+
+# %%
+# sim.plot_mesh(show_groups=["metal", "topmetal", "via", "dielectric", "SiO2__vmim"])
+
+sim.plot_mesh(show_groups=["metal5", "topmetal1", "vmim", "SiO2__vmim"])
+
+# %% [markdown]
+# ### Analytical estimate
+#
+# For the MIM capacitor: C = epsilon_0 * epsilon_r * A / d
+#
+# The MIM dielectric (SiO2, eps_r ~ 4.1) is 0.19 um thick between Metal5 top (z=5.38) and the Vmim bottom (z=5.58). The MIM drawing is 10.72 x 10.72 um. The Vmim vias (tungsten, conductive) extend the TopMetal1 terminal down to the MIM dielectric surface.
+
+# %%
+import scipy.constants as const
+
+# MIM dielectric area (MIM drawing: 10.72 x 10.72 um)
+eps_r = 4.1  # SiO2 permittivity from IHP stack
+A_mim = (10.72e-6) * (10.72e-6)  # m^2
+d_mim = (5.58 - 5.38) * 1e-6  # m (Metal5 top to Vmim bottom = MIM dielectric)
+
+C_analytical = const.epsilon_0 * eps_r * A_mim / d_mim
+print(f"Analytical capacitance: {C_analytical * 1e15:.1f} fF")
+print(f"  A_mim = 10.72 x 10.72 um^2, d = {d_mim * 1e6:.2f} um, eps_r = {eps_r}")
+
+# %% [markdown]
+# ### Run on cloud
+#
+# Uncomment to submit to GDSFactory+ cloud. The result should be a capacitance matrix CSV.
+
+# %%
+results = sim.run()
+
+# %% [markdown]
+# ### Load and analyze results
+
+# %%
+import csv
+from pathlib import Path
+
+import numpy as np
+
+results_dir = Path(results["terminal-C.csv"]).parent
+
+
+def read_palace_csv(path):
+    """Read a Palace output CSV, returning header and data as numpy array."""
+    with open(path) as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        data = np.array([[float(x) for x in row] for row in reader])
+    return [h.strip() for h in header], data
+
+
+# Capacitance matrix
+header, C_matrix = read_palace_csv(results_dir / "terminal-C.csv")
+print("Capacitance matrix (F):")
+print(f"  C[1,1] = {C_matrix[0, 1]:+.4e} F  ({C_matrix[0, 1] * 1e15:+.3f} fF)")
+print(f"  C[1,2] = {C_matrix[0, 2]:+.4e} F  ({C_matrix[0, 2] * 1e15:+.3f} fF)")
+print(f"  C[2,1] = {C_matrix[1, 1]:+.4e} F  ({C_matrix[1, 1] * 1e15:+.3f} fF)")
+print(f"  C[2,2] = {C_matrix[1, 2]:+.4e} F  ({C_matrix[1, 2] * 1e15:+.3f} fF)")
+
+# Mutual capacitance
+_, Cm = read_palace_csv(results_dir / "terminal-Cm.csv")
+print(f"\nMutual capacitance C_m[1,2] = {Cm[0, 2] * 1e15:.3f} fF")
+
+# Domain energy
+_, E = read_palace_csv(results_dir / "domain-E.csv")
+print(
+    f"\nStored electric energy: {E[0, 1]:.4e} J (excitation 1), {E[1, 1]:.4e} J (excitation 2)"
+)
+
+# %% [markdown]
+# ### Compare with analytical estimate
+
+# %%
+import scipy.constants as const
+
+C_palace = abs(C_matrix[0, 1])
+
+eps_r = 4.1
+A_mim = (10.72e-6) * (10.72e-6)
+d_mim = (5.58 - 5.38) * 1e-6
+
+C_analytical = const.epsilon_0 * eps_r * A_mim / d_mim
+
+print(f"Palace result:       {C_palace * 1e15:.3f} fF")
+print(f"Analytical (C=eA/d): {C_analytical * 1e15:.1f} fF")
+print(f"Ratio:               {C_palace / C_analytical:.3f}")
+
+# %%

--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -1022,6 +1022,7 @@ class PalaceSimMixin:
         auto_size: bool = False,
         cells_per_feature: int = 2,
         periodic_axis: str | None = None,
+        merge_via_distance: float | None = None,
     ) -> SimulationResult:
         """Generate the mesh for Palace simulation.
 
@@ -1050,6 +1051,10 @@ class PalaceSimMixin:
                 feature when auto_size=True. Default 2.
             periodic_axis: Optional periodic axis ("x" or "y") for periodic
                 meshing constraints on opposite domain sides.
+            merge_via_distance: Max gap (um) between nearby via polygons to
+                merge before extrusion. Pass 0 to disable merging (keep
+                each via as a separate volume). Defaults to the preset's
+                value (typically 2.0 um).
 
         Returns:
             SimulationResult with mesh path
@@ -1084,6 +1089,9 @@ class PalaceSimMixin:
             auto_size=auto_size,
             cells_per_feature=cells_per_feature,
         )
+
+        if merge_via_distance is not None:
+            mesh_config.merge_via_distance = merge_via_distance
 
         # Validate configuration
         validation = self.validate_config()
@@ -1157,6 +1165,8 @@ class PalaceSimMixin:
             )
 
         stack = self._resolve_stack()
+        electrostatic_config = getattr(self, "electrostatic", None)
+        terminals = getattr(self, "terminals", None)
         config_path = gen_write_config(
             mesh_result=self._last_mesh_result,
             stack=stack,
@@ -1166,6 +1176,8 @@ class PalaceSimMixin:
             driven_config=self.driven,
             absorbing_boundary=self.absorbing_boundary,
             hints=self._hints,
+            electrostatic_config=electrostatic_config,
+            terminals=terminals or [],
         )
 
         # Validate mesh and config unless explicitly skipped.

--- a/src/gsim/palace/mesh/config_generator.py
+++ b/src/gsim/palace/mesh/config_generator.py
@@ -15,7 +15,8 @@ from gsim.palace.ports.config import PortType
 
 if TYPE_CHECKING:
     from gsim.common.stack import LayerStack
-    from gsim.palace.models import DrivenConfig, EigenmodeConfig
+    from gsim.palace.models import DrivenConfig, EigenmodeConfig, ElectrostaticConfig
+    from gsim.palace.models.ports import TerminalConfig
     from gsim.palace.ports.config import PalacePort
 
 
@@ -33,6 +34,8 @@ def generate_palace_config(
     absorbing_boundary: bool = True,
     periodic_axis: str | None = None,
     hints: dict[str, Any] | None = None,
+    electrostatic_config: ElectrostaticConfig | None = None,
+    terminals: list[TerminalConfig] | None = None,
 ) -> Path:
     """Generate Palace config.json file.
 
@@ -122,9 +125,11 @@ def generate_palace_config(
         solver_conf["Driven"] = solver_driven
     elif simulation_type == "eigenmode":
         solver_conf["Eigenmode"] = solver_eigenmode
-    else:
-        raise NotImplementedError
-        # solver_conf["Electrostatics"] = solver_driven
+    elif simulation_type in ("electrostatic", "electrostatics"):
+        if electrostatic_config is not None:
+            solver_conf["Electrostatic"] = electrostatic_config.to_palace_config()
+        else:
+            solver_conf["Electrostatic"] = {"Save": 0}
 
     config: dict[str, object] = {
         "Problem": {
@@ -218,132 +223,197 @@ def generate_palace_config(
         info["phys_group"] for info in groups.get("pec_surfaces", {}).values()
     ]
 
-    lumped_ports: list[dict[str, object]] = []
-    wave_ports: list[dict[str, object]] = []
-    port_idx = 1
-    # Passive reactive ports are appended after all primary ports are assigned
-    # indices so that their synthetic indices never clash.  We collect them here
-    # and append them to lumped_ports once the primary loop finishes.
-    passive_reactive_ports: list[dict[str, object]] = []
+    is_electrostatic = simulation_type in ("electrostatic", "electrostatics")
 
-    for port in ports:
-        if simulation_type != "driven":
-            port.excited = False
-        port_key = f"P{port_idx}"
-        if port_key in groups["port_surfaces"]:
-            port_group = groups["port_surfaces"][port_key]
+    if is_electrostatic and terminals:
+        terminal_layer_names: set[str] = {t.layer for t in terminals}
+        via_boundary = groups.get("via_boundary_surfaces", {})
 
-            if port.multi_element:
-                # Multi-element port (CPW)
-                if port_group.get("type") == "cpw":
-                    elements = [
-                        {
-                            "Attributes": [elem["phys_group"]],
-                            "Direction": elem["direction"],
-                        }
-                        for elem in port_group["elements"]
-                    ]
-                    lumped_ports.append(
-                        {
-                            "Index": port_idx,
-                            "R": port.impedance,
-                            "Excitation": port_idx if port.excited else False,
-                            "Elements": elements,
-                        }
-                    )
-            else:
-                # Single-element port
-                if port.port_type == PortType.LUMPED:
-                    direction = (
-                        "Z"
-                        if port.geometry == PortGeometry.VIA
-                        else port.direction.upper()
-                    )
+        def _via_touches(via_name: str, conductor_layer_name: str) -> bool:
+            """Z-range overlap (or touching) between a via and a conductor."""
+            via = stack.layers.get(via_name)
+            cond = stack.layers.get(conductor_layer_name)
+            if via is None or cond is None:
+                return False
+            return via.zmin <= cond.zmax and via.zmax >= cond.zmin
 
-                    has_reactive = (
-                        port.resistance is not None
-                        or (port.inductance is not None and port.inductance > 0)
-                        or (port.capacitance is not None and port.capacitance > 0)
-                    )
+        terminal_entries: list[dict[str, object]] = []
+        ground_attrs: list[int] = list(pec_attrs)
 
-                    if simulation_type == "driven" and has_reactive:
-                        # Driven simulations forbid L/C on excited ports.
-                        # Emit the excited port with only R=impedance, then a
-                        # separate passive (Active: false) lumped port carrying
-                        # the reactive parameters on the same boundary surface.
-                        # Palace allows shared attributes when Active is false.
-                        port_entry: dict[str, object] = {
-                            "Index": port_idx,
-                            "R": port.impedance,
-                            "Direction": direction,
-                            "Excitation": port_idx if port.excited else False,
-                            "Attributes": [port_group["phys_group"]],
-                        }
-                        lumped_ports.append(port_entry)
+        # Track which vias were attached to a terminal so we don't also
+        # send their surfaces to ground.
+        vias_on_terminal: set[str] = set()
 
-                        reactive_entry: dict[str, object] = {
-                            # Placeholder index - will be replaced after the
-                            # primary loop assigns all port_idx values.
-                            "Index": None,
-                            "Direction": direction,
-                            "Attributes": [port_group["phys_group"]],
-                            "Active": False,
-                        }
-                        if port.resistance is not None:
-                            reactive_entry["R"] = port.resistance
-                        if port.inductance is not None and port.inductance > 0:
-                            reactive_entry["L"] = port.inductance
-                        if port.capacitance is not None and port.capacitance > 0:
-                            reactive_entry["C"] = port.capacitance
-                        passive_reactive_ports.append(reactive_entry)
-                    else:
-                        # Eigenmode (or non-excited driven port): R/L/C on the
-                        # same port entry is supported.
-                        eigenmode_entry: dict[str, object] = {
-                            "Index": port_idx,
-                            "Direction": direction,
-                            "Excitation": port_idx if port.excited else False,
-                            "Attributes": [port_group["phys_group"]],
-                        }
-                        if port.impedance:
-                            eigenmode_entry["R"] = port.impedance
-                        if port.resistance is not None:
-                            eigenmode_entry["R"] = port.resistance
-                        if port.inductance is not None and port.inductance > 0:
-                            eigenmode_entry["L"] = port.inductance
-                        if port.capacitance is not None and port.capacitance > 0:
-                            eigenmode_entry["C"] = port.capacitance
-                        lumped_ports.append(eigenmode_entry)
+        for idx, terminal in enumerate(terminals, start=1):
+            attrs: list[int] = []
+            for surf_name, surf_info in groups["conductor_surfaces"].items():
+                surf_layer = surf_name.rsplit("_", 1)[0]
+                if surf_layer == terminal.layer:
+                    attrs.append(surf_info["phys_group"])
+            for via_name, via_pgs in via_boundary.items():
+                if _via_touches(via_name, terminal.layer):
+                    attrs.extend(via_pgs)
+                    vias_on_terminal.add(via_name)
+            terminal_entries.append(
+                {
+                    "Index": idx,
+                    "Attributes": sorted(attrs),
+                }
+            )
 
-                elif port.port_type == PortType.WAVEPORT:
-                    wave_ports.append(
-                        {
-                            "Index": port_idx,
-                            "Mode": port.mode,
-                            "Offset": port.offset,
-                            "Excitation": port_idx if port.excited else False,
-                            "Attributes": [port_group["phys_group"]],
-                        }
-                    )
-        port_idx += 1
+        for surf_name, surf_info in groups["conductor_surfaces"].items():
+            surf_layer = surf_name.rsplit("_", 1)[0]
+            if surf_layer not in terminal_layer_names:
+                ground_attrs.append(surf_info["phys_group"])
 
-    # Assign unique indices to passive reactive ports now that all primary
-    # indices are consumed (port_idx is one past the last primary index).
-    synthetic_idx = port_idx
-    for entry in passive_reactive_ports:
-        entry["Index"] = synthetic_idx
-        synthetic_idx += 1
-    lumped_ports.extend(passive_reactive_ports)
+        # Vias that touch a non-terminal conductor -> tie to ground so they
+        # don't float (Palace's solver has no current-flow through volumes).
+        for via_name, via_pgs in via_boundary.items():
+            if via_name in vias_on_terminal:
+                continue
+            for cond_name in stack.layers or {}:
+                if cond_name in terminal_layer_names:
+                    continue
+                cond = stack.layers.get(cond_name)
+                if cond is None or cond.layer_type != "conductor":
+                    continue
+                if _via_touches(via_name, cond_name):
+                    ground_attrs.extend(via_pgs)
+                    break
 
-    boundaries: dict[str, object] = {
-        "Conductivity": conductors,
-        "LumpedPort": lumped_ports,
-        "WavePort": wave_ports,
-    }
+        boundaries: dict[str, object] = {
+            "Terminal": terminal_entries,
+        }
+        if ground_attrs:
+            boundaries["Ground"] = {"Attributes": sorted(ground_attrs)}
 
-    # Add PEC boundaries if any exist
-    if pec_attrs:
-        boundaries["PEC"] = {"Attributes": pec_attrs}
+    else:
+        lumped_ports: list[dict[str, object]] = []
+        wave_ports: list[dict[str, object]] = []
+        port_idx = 1
+        # Passive reactive ports are appended after all primary ports are assigned
+        # indices so that their synthetic indices never clash.  We collect them here
+        # and append them to lumped_ports once the primary loop finishes.
+        passive_reactive_ports: list[dict[str, object]] = []
+
+        for port in ports:
+            if simulation_type != "driven":
+                port.excited = False
+            port_key = f"P{port_idx}"
+            if port_key in groups["port_surfaces"]:
+                port_group = groups["port_surfaces"][port_key]
+
+                if port.multi_element:
+                    # Multi-element port (CPW)
+                    if port_group.get("type") == "cpw":
+                        elements = [
+                            {
+                                "Attributes": [elem["phys_group"]],
+                                "Direction": elem["direction"],
+                            }
+                            for elem in port_group["elements"]
+                        ]
+                        lumped_ports.append(
+                            {
+                                "Index": port_idx,
+                                "R": port.impedance,
+                                "Excitation": port_idx if port.excited else False,
+                                "Elements": elements,
+                            }
+                        )
+                else:
+                    # Single-element port
+                    if port.port_type == PortType.LUMPED:
+                        direction = (
+                            "Z"
+                            if port.geometry == PortGeometry.VIA
+                            else port.direction.upper()
+                        )
+
+                        has_reactive = (
+                            port.resistance is not None
+                            or (port.inductance is not None and port.inductance > 0)
+                            or (port.capacitance is not None and port.capacitance > 0)
+                        )
+
+                        if simulation_type == "driven" and has_reactive:
+                            # Driven simulations forbid L/C on excited ports.
+                            # Emit the excited port with only R=impedance, then a
+                            # separate passive (Active: false) lumped port carrying
+                            # the reactive parameters on the same boundary surface.
+                            # Palace allows shared attributes when Active is false.
+                            port_entry: dict[str, object] = {
+                                "Index": port_idx,
+                                "R": port.impedance,
+                                "Direction": direction,
+                                "Excitation": port_idx if port.excited else False,
+                                "Attributes": [port_group["phys_group"]],
+                            }
+                            lumped_ports.append(port_entry)
+
+                            reactive_entry: dict[str, object] = {
+                                # Placeholder index - will be replaced after the
+                                # primary loop assigns all port_idx values.
+                                "Index": None,
+                                "Direction": direction,
+                                "Attributes": [port_group["phys_group"]],
+                                "Active": False,
+                            }
+                            if port.resistance is not None:
+                                reactive_entry["R"] = port.resistance
+                            if port.inductance is not None and port.inductance > 0:
+                                reactive_entry["L"] = port.inductance
+                            if port.capacitance is not None and port.capacitance > 0:
+                                reactive_entry["C"] = port.capacitance
+                            passive_reactive_ports.append(reactive_entry)
+                        else:
+                            # Eigenmode (or non-excited driven port): R/L/C on the
+                            # same port entry is supported.
+                            eigenmode_entry: dict[str, object] = {
+                                "Index": port_idx,
+                                "Direction": direction,
+                                "Excitation": port_idx if port.excited else False,
+                                "Attributes": [port_group["phys_group"]],
+                            }
+                            if port.impedance:
+                                eigenmode_entry["R"] = port.impedance
+                            if port.resistance is not None:
+                                eigenmode_entry["R"] = port.resistance
+                            if port.inductance is not None and port.inductance > 0:
+                                eigenmode_entry["L"] = port.inductance
+                            if port.capacitance is not None and port.capacitance > 0:
+                                eigenmode_entry["C"] = port.capacitance
+                            lumped_ports.append(eigenmode_entry)
+
+                    elif port.port_type == PortType.WAVEPORT:
+                        wave_ports.append(
+                            {
+                                "Index": port_idx,
+                                "Mode": port.mode,
+                                "Offset": port.offset,
+                                "Excitation": port_idx if port.excited else False,
+                                "Attributes": [port_group["phys_group"]],
+                            }
+                        )
+            port_idx += 1
+
+        # Assign unique indices to passive reactive ports now that all primary
+        # indices are consumed (port_idx is one past the last primary index).
+        synthetic_idx = port_idx
+        for entry in passive_reactive_ports:
+            entry["Index"] = synthetic_idx
+            synthetic_idx += 1
+        lumped_ports.extend(passive_reactive_ports)
+
+        boundaries: dict[str, object] = {
+            "Conductivity": conductors,
+            "LumpedPort": lumped_ports,
+            "WavePort": wave_ports,
+        }
+
+        # Add PEC boundaries if any exist
+        if pec_attrs:
+            boundaries["PEC"] = {"Attributes": pec_attrs}
 
     if "absorbing" in groups["boundary_surfaces"] and absorbing_boundary:
         absorbing_pg = groups["boundary_surfaces"]["absorbing"]["phys_group"]
@@ -541,6 +611,8 @@ def write_config(
     eigenmode_config: EigenmodeConfig | None = None,
     absorbing_boundary: bool = True,
     hints: dict[str, Any] | None = None,
+    electrostatic_config: ElectrostaticConfig | None = None,
+    terminals: list[TerminalConfig] | None = None,
 ) -> Path:
     """Write Palace config.json from a MeshResult.
 
@@ -581,6 +653,8 @@ def write_config(
         absorbing_boundary=absorbing_boundary,
         periodic_axis=mesh_result.periodic_axis,
         hints=hints,
+        electrostatic_config=electrostatic_config,
+        terminals=terminals,
     )
 
     # Update the mesh_result with the config path

--- a/src/gsim/palace/mesh/config_generator.py
+++ b/src/gsim/palace/mesh/config_generator.py
@@ -238,22 +238,31 @@ def generate_palace_config(
             return via.zmin <= cond.zmax and via.zmax >= cond.zmin
 
         terminal_entries: list[dict[str, object]] = []
-        ground_attrs: list[int] = list(pec_attrs)
+        assigned_pgs: set[int] = set()
 
         # Track which vias were attached to a terminal so we don't also
         # send their surfaces to ground.
         vias_on_terminal: set[str] = set()
 
+        pec_surfaces = groups.get("pec_surfaces", {})
+
         for idx, terminal in enumerate(terminals, start=1):
             attrs: list[int] = []
+            # Thick conductor shells (named "<layer>_xy" / "<layer>_z")
             for surf_name, surf_info in groups["conductor_surfaces"].items():
                 surf_layer = surf_name.rsplit("_", 1)[0]
                 if surf_layer == terminal.layer:
                     attrs.append(surf_info["phys_group"])
+            # Planar (thin) conductor surfaces (keyed by layer name)
+            if terminal.layer in pec_surfaces:
+                attrs.append(pec_surfaces[terminal.layer]["phys_group"])
+            # Vias touching this terminal's layer
             for via_name, via_pgs in via_boundary.items():
                 if _via_touches(via_name, terminal.layer):
                     attrs.extend(via_pgs)
                     vias_on_terminal.add(via_name)
+
+            assigned_pgs.update(attrs)
             terminal_entries.append(
                 {
                     "Index": idx,
@@ -261,10 +270,16 @@ def generate_palace_config(
                 }
             )
 
-        for surf_name, surf_info in groups["conductor_surfaces"].items():
-            surf_layer = surf_name.rsplit("_", 1)[0]
-            if surf_layer not in terminal_layer_names:
-                ground_attrs.append(surf_info["phys_group"])
+        # Anything that wasn't assigned to a terminal becomes Ground.
+        ground_attrs: list[int] = []
+        for surf_info in groups["conductor_surfaces"].values():
+            pg = surf_info["phys_group"]
+            if pg not in assigned_pgs:
+                ground_attrs.append(pg)
+        for surf_info in pec_surfaces.values():
+            pg = surf_info["phys_group"]
+            if pg not in assigned_pgs:
+                ground_attrs.append(pg)
 
         # Vias that touch a non-terminal conductor -> tie to ground so they
         # don't float (Palace's solver has no current-flow through volumes).
@@ -285,7 +300,7 @@ def generate_palace_config(
             "Terminal": terminal_entries,
         }
         if ground_attrs:
-            boundaries["Ground"] = {"Attributes": sorted(ground_attrs)}
+            boundaries["Ground"] = {"Attributes": sorted(set(ground_attrs))}
 
     else:
         lumped_ports: list[dict[str, object]] = []

--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -145,6 +145,47 @@ def get_layer_info(stack: LayerStack, gds_layer: int) -> dict | None:
     return None
 
 
+def _snap_via_z_range(
+    stack: LayerStack,
+    via_name: str,
+    zmin: float,
+    zmax: float,
+    tol: float = 0.05,
+) -> tuple[float, float]:
+    """Snap a via's z-range so it doesn't sliver into adjacent conductor layers.
+
+    PDK stacks routinely model vias with z-ranges that overlap the metal layers
+    they connect to (e.g. IHP `vmim` z=[5.58, 6.24] vs `topmetal1` z=[6.23, 8.23]
+    — a 10 nm overlap to model fab interdiffusion). After mesh fragmentation,
+    that overlap becomes a sliver volume too thin for gmsh to mesh, producing
+    "No elements in volume N" warnings.
+
+    If the via's zmax exceeds an adjacent conductor's zmin by less than *tol*,
+    snap zmax down to that conductor's zmin (and symmetrically for zmin).
+    """
+    new_zmin, new_zmax = zmin, zmax
+    for other_name, other in stack.layers.items():
+        if other_name == via_name or other.layer_type != "conductor":
+            continue
+        # Via top extends slightly into the conductor above
+        if zmin < other.zmin < zmax and (zmax - other.zmin) < tol:
+            new_zmax = min(new_zmax, other.zmin)
+        # Via bottom extends slightly into the conductor below
+        if zmin < other.zmax < zmax and (other.zmax - zmin) < tol:
+            new_zmin = max(new_zmin, other.zmax)
+    if (new_zmin, new_zmax) != (zmin, zmax):
+        logger.info(
+            "Snapped via '%s' z-range [%.3f, %.3f] -> [%.3f, %.3f] "
+            "to avoid sliver against adjacent conductor",
+            via_name,
+            zmin,
+            zmax,
+            new_zmin,
+            new_zmax,
+        )
+    return new_zmin, new_zmax
+
+
 def _merge_via_polygons(
     polys: list[tuple[list[float], list[float], list]],
     merge_distance: float,
@@ -263,6 +304,11 @@ def add_metals(
 
         if layer_type not in ("conductor", "via"):
             continue
+
+        # Snap via z-range so it does not sliver into an adjacent conductor
+        if layer_type == "via":
+            zmin, zmax = _snap_via_z_range(stack, layer_name, zmin, zmin + thickness)
+            thickness = zmax - zmin
 
         if layer_name not in metal_tags:
             metal_tags[layer_name] = {

--- a/src/gsim/palace/mesh/groups.py
+++ b/src/gsim/palace/mesh/groups.py
@@ -179,6 +179,40 @@ def assign_physical_groups(
                         "tags": surf_tags,
                     }
 
+    # --- Via boundary surfaces (via volume faces exposed to dielectric) ---
+    #
+    # Palace's electrostatic solver treats Conductivity-bearing material domains
+    # as plain dielectrics; current does NOT flow through such regions to drag
+    # terminal potential into them. To make a via behave as a true conductive
+    # extension of the terminal it connects to, we need its dielectric-facing
+    # boundary surfaces (bottom + sides — the top has already been merged with
+    # the touching conductor shell) to be Dirichlet boundaries on that terminal.
+    #
+    # The boolean pipeline labels these surfaces "<material>__<via>" (parts are
+    # sorted, joined with "__"). Collect them here by via layer so the config
+    # generator can attach them to the right terminal.
+    if _stack:
+        cond_via_names = {
+            n
+            for n, layer in _stack.layers.items()
+            if layer.layer_type in ("conductor", "via")
+        }
+        via_boundary: dict[str, list[int]] = {}
+        for pg_name, pg_tag in pg_map.items():
+            parts = pg_name.split("__")
+            via_parts = [p for p in parts if p in via_layers]
+            if len(via_parts) != 1:
+                continue
+            others = [p for p in parts if p != via_parts[0]]
+            # Skip outer-boundary side ("__None") and via<->conductor interfaces
+            if not others or "None" in others:
+                continue
+            if any(o in cond_via_names for o in others):
+                continue
+            via_boundary.setdefault(via_parts[0], []).append(pg_tag)
+        if via_boundary:
+            groups["via_boundary_surfaces"] = via_boundary
+
     # --- Boundary surfaces (outer faces labelled *__None by the pipeline) ---
     boundary_pgs: list[int] = [
         pg for name, pg in pg_map.items() if name.endswith("__None")

--- a/src/gsim/palace/mesh/validation.py
+++ b/src/gsim/palace/mesh/validation.py
@@ -397,7 +397,13 @@ def validate_mesh(sim) -> ValidationResult:
             try:
                 config = json.loads(config_path.read_text())
                 boundaries = config.get("Boundaries", {})
-                if not boundaries.get("Conductivity") and not boundaries.get("PEC"):
+                has_conductor_bounds = (
+                    boundaries.get("Conductivity")
+                    or boundaries.get("PEC")
+                    or boundaries.get("Terminal")
+                    or boundaries.get("Ground")
+                )
+                if not has_conductor_bounds:
                     errors.append("config.json has no Conductivity or PEC boundaries.")
                 if (
                     not boundaries.get("LumpedPort")

--- a/tests/palace/test_mesh.py
+++ b/tests/palace/test_mesh.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 import pytest
 
 from gsim.common.stack import LayerStack
+from gsim.common.stack.extractor import Layer
 from gsim.palace.mesh import MeshConfig
 from gsim.palace.mesh import validation as mesh_validation
-from gsim.palace.mesh.geometry import GeometryData, add_dielectrics
+from gsim.palace.mesh.geometry import GeometryData, _snap_via_z_range, add_dielectrics
 
 
 class TestMeshConfig:
@@ -147,6 +150,72 @@ def test_add_dielectrics_explicit_airbox_z_extents(monkeypatch) -> None:
     assert "airbox" in tags
     # Air layer is skipped when explicit airbox is built.
     assert list(tags.keys()) == ["SiO2", "airbox"]
+
+
+def _mk_layer(
+    name: str,
+    zmin: float,
+    zmax: float,
+    ltype: Literal["conductor", "via", "dielectric", "substrate"] = "conductor",
+) -> Layer:
+    return Layer(
+        name=name,
+        gds_layer=(0, 0),
+        zmin=zmin,
+        zmax=zmax,
+        thickness=zmax - zmin,
+        material="aluminum",
+        layer_type=ltype,
+    )
+
+
+class TestSnapViaZRange:
+    """Snap via z-range to avoid sliver volumes against adjacent conductors."""
+
+    def test_snaps_top_overlap_with_conductor(self):
+        # Mimics IHP vmim z=[5.58, 6.24] vs topmetal1 z=[6.23, 8.23]
+        stack = LayerStack(
+            layers={
+                "vmim": _mk_layer("vmim", 5.58, 6.24, "via"),
+                "topmetal1": _mk_layer("topmetal1", 6.23, 8.23, "conductor"),
+            }
+        )
+        new_zmin, new_zmax = _snap_via_z_range(stack, "vmim", 5.58, 6.24)
+        assert new_zmin == pytest.approx(5.58)
+        assert new_zmax == pytest.approx(6.23)
+
+    def test_does_not_snap_large_overlap(self):
+        # Overlap > tol must be left alone (likely a real geometric intersection).
+        stack = LayerStack(
+            layers={
+                "via": _mk_layer("via", 0.0, 1.0, "via"),
+                "metal": _mk_layer("metal", 0.5, 2.0, "conductor"),
+            }
+        )
+        new_zmin, new_zmax = _snap_via_z_range(stack, "via", 0.0, 1.0, tol=0.05)
+        assert (new_zmin, new_zmax) == (0.0, 1.0)
+
+    def test_no_overlap_unchanged(self):
+        stack = LayerStack(
+            layers={
+                "via": _mk_layer("via", 1.0, 2.0, "via"),
+                # touches, no overlap
+                "metal": _mk_layer("metal", 2.0, 3.0, "conductor"),
+            }
+        )
+        new_zmin, new_zmax = _snap_via_z_range(stack, "via", 1.0, 2.0)
+        assert (new_zmin, new_zmax) == (1.0, 2.0)
+
+    def test_snaps_bottom_overlap_with_conductor(self):
+        stack = LayerStack(
+            layers={
+                "via": _mk_layer("via", 1.99, 3.0, "via"),
+                "metal": _mk_layer("metal", 1.0, 2.0, "conductor"),
+            }
+        )
+        new_zmin, new_zmax = _snap_via_z_range(stack, "via", 1.99, 3.0)
+        assert new_zmin == pytest.approx(2.0)
+        assert new_zmax == pytest.approx(3.0)
 
 
 class TestValidationHelpers:

--- a/tests/palace/test_workflow.py
+++ b/tests/palace/test_workflow.py
@@ -374,8 +374,52 @@ class TestElectrostaticSimWorkflow:
         boundaries = config["Boundaries"]
         assert "Terminal" in boundaries
         assert len(boundaries["Terminal"]) == 2
+        # Each terminal must have at least one attribute (regression: planar
+        # conductor terminals were silently grounded when the loop only
+        # scanned conductor_surfaces).
+        for term in boundaries["Terminal"]:
+            assert term["Attributes"], (
+                f"Terminal {term['Index']} has no attributes — "
+                "likely a layer/surface lookup miss"
+            )
         assert "LumpedPort" not in boundaries
         assert "WavePort" not in boundaries
+
+    def test_planar_conductor_terminal_not_grounded(
+        self, tmp_path_factory, cpw_component
+    ):
+        """Terminals on planar (thin) conductor layers must be picked up.
+
+        Regression: the terminal loop previously only scanned
+        ``conductor_surfaces`` (thick metals with shell surfaces) and
+        seeded ``ground_attrs`` with ``pec_attrs``. A terminal defined on
+        a planar layer therefore ended up with empty attributes and the
+        layer's PG was sent to Ground instead.
+        """
+        tmp_path = tmp_path_factory.mktemp("electrostatic_planar")
+        sim = ElectrostaticSim()
+        sim.set_output_dir(str(tmp_path / "palace-sim"))
+        sim.set_geometry(cpw_component)
+        sim.set_stack(substrate_thickness=2.0, air_above=300.0)
+        sim.add_terminal("T1", layer="metal1")
+        sim.add_terminal("T2", layer="metal1")
+        sim.set_electrostatic()
+        sim.mesh(preset="coarse", planar_conductors=True)
+        sim.write_config()
+
+        output_dir = sim._output_dir
+        assert output_dir is not None
+        config = json.loads((Path(output_dir) / "config.json").read_text())
+        boundaries = config["Boundaries"]
+        terminal_attrs: set[int] = set()
+        for term in boundaries["Terminal"]:
+            assert term["Attributes"], "Planar-conductor terminal has no attributes"
+            terminal_attrs.update(term["Attributes"])
+        # And the terminal's PG must not also appear in Ground.
+        ground_attrs = set(boundaries.get("Ground", {}).get("Attributes", []))
+        assert terminal_attrs.isdisjoint(ground_attrs), (
+            f"Terminal attrs {terminal_attrs} overlap Ground {ground_attrs}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/palace/test_workflow.py
+++ b/tests/palace/test_workflow.py
@@ -363,10 +363,19 @@ class TestElectrostaticSimWorkflow:
         mesh_path = Path(electrostatic_sim._output_dir) / "palace.msh"
         assert mesh_path.exists()
 
-    def test_write_config_not_implemented(self, electrostatic_sim):
-        """Electrostatic config generation is not yet implemented."""
-        with pytest.raises(NotImplementedError):
-            electrostatic_sim.write_config()
+    def test_write_config_generates_valid_json(self, electrostatic_sim):
+        """Electrostatic config generation produces valid Palace JSON."""
+        electrostatic_sim.write_config()
+        config_path = Path(electrostatic_sim._output_dir) / "config.json"
+        assert config_path.exists()
+        config = json.loads(config_path.read_text())
+        assert config["Problem"]["Type"] == "Electrostatic"
+        assert "Electrostatic" in config["Solver"]
+        boundaries = config["Boundaries"]
+        assert "Terminal" in boundaries
+        assert len(boundaries["Terminal"]) == 2
+        assert "LumpedPort" not in boundaries
+        assert "WavePort" not in boundaries
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Wires up `ElectrostaticSim` so capacitance extraction actually runs on Palace. Previously the config generator raised `NotImplementedError` at the electrostatic branch; vias also weren't being correctly tied to terminals.

## Changes

- **`config_generator.py`** — emit `Electrostatic` problem block; map terminal layers to PEC boundaries, route the rest to `Ground`.
- **`groups.py` + `config_generator.py`** — attach each via's dielectric-facing boundary surfaces (e.g. `SiO2__vmim`) to the terminal whose layer the via touches. Without this, Palace treats conductivity-bearing domains as plain dielectrics and the via potential never propagates — vias end up floating.
- **`geometry.py`** — `_snap_via_z_range` snaps a via's z-range to an adjacent conductor when overlap is below tolerance, eliminating unmeshable slivers (e.g. the 10 nm overlap between IHP `vmim` z=[5.58, 6.24] and `topmetal1` z=[6.23, 8.23]).
- **`base.py`** — expose `merge_via_distance` kwarg on `sim.mesh()` (pass 0 to keep dense via arrays as individual pillars).
- **`nbs/_palace_electrostatic.ipynb`** — IHP `cmim` capacitance extraction example. Palace result lands at 17.6 fF vs 20.9 fF analytical (~84%, residual is finite-mesh / fringing).

## Verification

- 172 palace tests pass (4 new unit tests for `_snap_via_z_range`)
- Notebook runs to completion on cloud