### PR TITLE
fix(palace): correct metal_tags typing to satisfy ty

### DIFF
--- a/src/gsim/palace/mesh/geometry.py
+++ b/src/gsim/palace/mesh/geometry.py
@@ -367,7 +367,7 @@ def add_metals(
         conductors.
     """
     # layer_name -> {"volumes": [], "surfaces_xy": [], "surfaces_z": []}
-    metal_tags = {}
+    metal_tags: dict[str, dict[str, list]] = {}
     # Detect shaped-dielectric layers once (replaces thickness heuristic)
     shaped_dielectric_names = _detect_shaped_dielectric_layers(geometry, stack)
 
@@ -623,7 +623,10 @@ def add_metals(
 
     # Store shaped-dielectric layer names for downstream classification.
     # Uses a reserved key that is skipped by consumers iterating per-layer.
-    metal_tags["__shaped_dielectrics__"] = shaped_dielectric_names  # type: ignore[assignment]
+    # TODO: smuggling a set[str] into metal_tags under a reserved key forces a
+    # type-ignore here. Cleaner to return shaped_dielectric_names separately and
+    # update the consumer in classify_* (see metal_tags.get("__shaped_dielectrics__")).
+    metal_tags["__shaped_dielectrics__"] = shaped_dielectric_names  # ty: ignore[invalid-assignment]
 
     return metal_tags
 


### PR DESCRIPTION
## What

The CI **Pre-commit** job has been failing on recent `main` merges (#144, #145) at the `ty` hook — 10 diagnostics in `src/gsim/palace/mesh/geometry.py`.

`metal_tags` was untyped, so `ty` widened its value type to include the `set[str]` stashed under the reserved `__shaped_dielectrics__` key. That made every `metal_tags[layer_name][...]` access fail as non-subscriptable.

## Fix

- Annotate `metal_tags: dict[str, dict[str, list]]` to pin the value type, eliminating the 10 cascading errors.
- Fix the suppression on the lone heterogeneous assignment: the old `# type: ignore[assignment]` used a mypy code `ty` does not honor; switched to `# ty: ignore[invalid-assignment]`.
- Added a TODO flagging the underlying smell (smuggling a set into the tag dict) for a later cleanup that returns it separately.

It passed locally before because the cached pre-commit `ty` env was looser than CI's pinned version; the type ambiguity was real either way.

`uv run pre-commit run ty --all-files` now passes.