### PR TITLE
ci: add Claude Code PR review workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,27 @@
+name: Claude Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+    - name: Run Claude Code Review
+      uses: anthropics/claude-code-action@v1
+      with:
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        prompt: |
+          Review this pull request for correctness bugs, security issues, and
+          adherence to the conventions in CLAUDE.md (keep modules < ~500 lines,
+          conventional commits, simple over clever). Leave inline comments on
+          specific lines where useful and a short summary. Be concise.
+        claude_args: "--max-turns 5"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,33 @@
+name: Claude Code
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+    - name: Run Claude Code
+      uses: anthropics/claude-code-action@v1
+      with:
+        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Adds Claude Code AI review to this repo. The Claude GitHub App and `ANTHROPIC_API_KEY` org secret are already configured, so these two workflow files are the only repo-side setup needed.

- **`claude-review.yml`** — automated review on every PR (`opened`/`synchronize`); prompt references `CLAUDE.md` conventions, posts inline comments + summary.
- **`claude.yml`** — interactive `@claude` bot; runs only when someone mentions `@claude` in a comment, review, or issue.

Both use the single `anthropics/claude-code-action@v1` action — the trigger determines the mode. Note: this adds Claude alongside the existing Gemini and Copilot reviewers, so every PR will now have three bots. If that's too noisy, `claude-review.yml` can be gated behind a `claude-review` label.