### PR TITLE
docs(palace): compare electrostatic cmim against IHP PDK compact model

### DIFF
--- a/nbs/_palace_electrostatic.ipynb
+++ b/nbs/_palace_electrostatic.ipynb
@@ -2,25 +2,36 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "84fb8ed3",
+   "id": "8b19873e",
    "metadata": {},
    "source": [
     "# Electrostatic Capacitance Extraction with Palace\n",
     "\n",
-    "This notebook demonstrates electrostatic simulation using `gsim.palace.ElectrostaticSim` to extract the capacitance matrix between conductor terminals.\n",
+    "We use `gsim.palace.ElectrostaticSim` to extract the **plate-to-plate (mutual)\n",
+    "capacitance** of the IHP `cmim` (MIM capacitor) cell and compare it against the IHP\n",
+    "PDK compact model. The bottom plate is on Metal5\n",
+    "(terminal `T1` = SPICE `MINUS`), the top plate on TopMetal1 (`T2` = `PLUS`), joined\n",
+    "by a 10x10 array of Vmim vias through a 0.19 um SiO2 MIM dielectric.\n",
     "\n",
-    "We use the IHP `cmim` (MIM capacitor) cell. The bottom plate is on Metal5 and the top plate on TopMetal1, connected by a 10x10 array of Vmim vias through a thin MIM dielectric (0.19 um SiO2).\n",
+    "Palace writes two matrices: `terminal-C.csv` (Maxwell — self-cap on the diagonal,\n",
+    "negative induced charge off-diagonal) and `terminal-Cm.csv` (mutual/\"SPICE\" — its\n",
+    "off-diagonal `Cm[i,j] = -C[i,j]` is the physical two-terminal capacitor). The MIM cap\n",
+    "value is `Cm[1,2]`, which is exactly what the PDK `cap_cmim` model describes.\n",
     "\n",
-    "**Limitation:** The current terminal system assigns one terminal per layer. Structures with multiple electrodes on the same layer (e.g., interdigitated capacitors) are not yet supported.\n",
+    "The IHP `cap_cmim` is a 2-terminal model with an area + perimeter law (plate-to-plate\n",
+    "only; substrate parasitics are left to extraction). See\n",
+    "[`capacitors_mod.lib`](https://github.com/IHP-GmbH/IHP-Open-PDK/blob/main/ihp-sg13g2/libs.tech/ngspice/models/capacitors_mod.lib).\n",
     "\n",
-    "**Requirements:**\n",
-    "- IHP PDK: `uv pip install ihp-gdsfactory`\n",
-    "- [GDSFactory+](https://gdsfactory.com) account for cloud simulation"
+    "**Limitation:** one terminal per layer — multiple electrodes on the same layer (e.g.\n",
+    "interdigitated caps) are not yet supported.\n",
+    "\n",
+    "**Requirements:** IHP PDK (`uv pip install ihp-gdsfactory`) and a\n",
+    "[GDSFactory+](https://gdsfactory.com) account for cloud simulation."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a79d4f6e",
+   "id": "f2d2d762",
    "metadata": {},
    "source": [
     "### Load IHP MIM capacitor"
@@ -28,8 +39,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "0b8b2971",
+   "execution_count": null,
+   "id": "da58a01e",
    "metadata": {},
    "outputs": [
     {
@@ -40,29 +51,14 @@
      ]
     },
     {
-     "ename": "PermissionError",
-     "evalue": "[Errno 13] Permission denied: '/tmp/gdsfactory/layer_properties.lyp'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mPermissionError\u001b[39m                           Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/gsim/.venv/lib/python3.12/site-packages/kfactory/kcell.py:890\u001b[39m, in \u001b[36mProtoTKCell._ipython_display_\u001b[39m\u001b[34m(self)\u001b[39m\n\u001b[32m    885\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_ipython_display_\u001b[39m(\u001b[38;5;28mself\u001b[39m) -> \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m    886\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Display a cell in a Jupyter Cell.\u001b[39;00m\n\u001b[32m    887\u001b[39m \n\u001b[32m    888\u001b[39m \u001b[33;03m    Usage: Pass the kcell variable as an argument in the cell at the end\u001b[39;00m\n\u001b[32m    889\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m890\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mplot\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/gsim/.venv/lib/python3.12/site-packages/gdsfactory/component.py:1199\u001b[39m, in \u001b[36mComponent.plot\u001b[39m\u001b[34m(self, lyrdb, display_type, show_labels, show_ruler, pixel_buffer_options, return_fig)\u001b[39m\n\u001b[32m   1197\u001b[39m     lyp_path = pathlib.Path(layer_views)\n\u001b[32m   1198\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m1199\u001b[39m     \u001b[43mlayer_views\u001b[49m\u001b[43m.\u001b[49m\u001b[43mto_lyp\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath\u001b[49m\u001b[43m=\u001b[49m\u001b[43mlyp_path\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1201\u001b[39m layout_view = lay.LayoutView()\n\u001b[32m   1202\u001b[39m cell_view_index = layout_view.create_layout(\u001b[38;5;28;01mTrue\u001b[39;00m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Desktop/gsim/.venv/lib/python3.12/site-packages/gdsfactory/technology/layer_views.py:1065\u001b[39m, in \u001b[36mLayerViews.to_lyp\u001b[39m\u001b[34m(self, filepath, overwrite)\u001b[39m\n\u001b[32m   1062\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m ls \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m.custom_line_styles.values():\n\u001b[32m   1063\u001b[39m     root.append(ls.to_klayout_xml())\n\u001b[32m-> \u001b[39m\u001b[32m1065\u001b[39m \u001b[43mfilepath\u001b[49m\u001b[43m.\u001b[49m\u001b[43mwrite_bytes\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmake_pretty_xml\u001b[49m\u001b[43m(\u001b[49m\u001b[43mroot\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1066\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m filepath\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/usr/lib/python3.12/pathlib.py:1038\u001b[39m, in \u001b[36mPath.write_bytes\u001b[39m\u001b[34m(self, data)\u001b[39m\n\u001b[32m   1036\u001b[39m \u001b[38;5;66;03m# type-check for the buffer interface before truncating the file\u001b[39;00m\n\u001b[32m   1037\u001b[39m view = \u001b[38;5;28mmemoryview\u001b[39m(data)\n\u001b[32m-> \u001b[39m\u001b[32m1038\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mopen\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmode\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mwb\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mas\u001b[39;00m f:\n\u001b[32m   1039\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m f.write(view)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/usr/lib/python3.12/pathlib.py:1015\u001b[39m, in \u001b[36mPath.open\u001b[39m\u001b[34m(self, mode, buffering, encoding, errors, newline)\u001b[39m\n\u001b[32m   1013\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mb\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m mode:\n\u001b[32m   1014\u001b[39m     encoding = io.text_encoding(encoding)\n\u001b[32m-> \u001b[39m\u001b[32m1015\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mio\u001b[49m\u001b[43m.\u001b[49m\u001b[43mopen\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mbuffering\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mencoding\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43merrors\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnewline\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[31mPermissionError\u001b[39m: [Errno 13] Permission denied: '/tmp/gdsfactory/layer_properties.lyp'"
-     ]
-    },
-    {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzAAAAJoCAYAAAC5ogQ1AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAMTgAADE4Bf3eMIwAAutJJREFUeJzt/b2uJUFyoAlGFvoVRmCp1RxqU69QK7AaoEZgpcG8wVDjKCNVlkSFrXFfYaUFViPApsCWRq/RuGSpbIEPkYtzeO2kH7v+Z+5mER5+P0M68sSNsHALD/txt5/wbz9+/PhxAAAAAAAAAAAA3AB+cTUBAAAAAAAAAAAAvcACBgAAAAAAAACA2wALGAAAAAAAAAAAbgMsYAAAAAAAAAAAuA2wgAEAAAAAAAAA4DbAAgYAAAAAAAAAgNsACxgAAAAAAAAAAG4D/6l1wbdv386hBAAAAAAAAACALw8/GttUEoEBAAAAAAAAAOA2wAIGAAAAAAAAAIDbAAsYAAAAAAAAAABuAyxgAAAAAAAAAAC4DbCAAQAAAAAAAADgNsACBgAAAAAAAACA2wALGAAAAAAAAAAAbgMsYAAAAAAAAAAAuA2wgAEAAAAAAAAA4DbAAgYAAAAAAAAAgNtA+ALm+/fvx50B+hl/+Oe+gPwy/vDPfQH5Zfzhn/vC9+D5/7cfP378qF7w7VsoAUA8/Lj3GhIAAAAAAMAE35j73Boay5PjP51GCXAtfK8zAgAAAAAAwBbwHef77sAC5qsK9GNBMyPg4DN+8A/yg/5Af2I/sJ+rzR9w2H4JIIXsq6SQfQj8I6T64/hxfDvGlQf4jB/8g/ygP9Cf2A/s52rzBz3fAfZNIeMrZF8MtPD/6x9++3a+dQw+4wf/ID/oD/Qn9gP7ufr8AdgbiMB8AXh5JB4vHM/x+DgSeYF/kB/kB/2B/sR+LGs/icDsA0RggJ/w/T6eE/AZP/gH+UF/oD+xH9hPIi9ADojAfAGY9UgQeSDyQOSByMOw/kF+kB/kB/k5SX8QgdkHiMAAb0Dkg8iPhR+InBE5JHJK5Bj7gf284/wB2BuIwHwBGPVI4DnFc4rnFM/psN5BfpAf5Af5OVl/EIHZB4jAAFlY3XMCPuMH/yA/6A/0J/YD+0nkBcgBEZgvAFaPBJ5TPKd4TvGcDusb5Af5QX6Qnwv1xxPYB+b2QAQGeAMiH0R+avxA5IvIF5EvIl+99gL9gf5czX6kX1sF9gYiMF8AeiMweE7xnOI5xXM6rGeQH+QH+UF+LtYf1MDsA0RggCzgOcNztprnDHzGD/5BftAf6M9Z+wF8DSAC8wWg5ZHAc4rnFM8pntNh/YL8ID/ID/KziP4gArMPEIEB3gDPN57/NwVB5IPID5Gfon4kckjkFPt53/kDsDcQgfkCUPJI4DnFc4rnFM/psF5BfpAf5Af5WUx/EIHZB4jAAHnGWNxzAj7jB/8gP+gP9Cf2A/tJ5AXIARGYLwDaI4HnFM8pnlM8p8P6BPlBfpAf5GdR/UEEZh8gAgO8MwSRDyI/RL5e8kDkj8hnCkR+ifzW+AH7eS/7CewNRGC+ALw8Eo8XjudsfBzxPMM/yA/yg/5Af2I/lrWfRGD2ASIwwE/4fh/PCfiMH/yD/KA/0J/YD+wnkRcgB0RgvgDMeiSIPBB5IPJA5GFY/yA/yA/yg/ycpD+IwOwDRGCANyDyQeTHwg9EzogcEjklcoz9wH7ecf4A7A1EYL4AjHok8JziOcVziud0WO8gP8gP8oP8nKw/iMDsA0RggCys7jkBn/GDf5Af9Af6E/uB/STyAuSACMwXAKtHAs8pnlM8p3hOh/UN8oP8ID/Iz4X64wmDNb/AOkAEBngDIh9Efmr8QOSLyBeRLyJfvfYC/YH+XM1+pF9bBfYGIjBfAHojMHhO8ZziOcVzOqxnkB/kB/lBfi7WH9TAfJ0IDAuYLwA5gX54Lv7zr/9b1fORnm8d5/D/4h//9HX893/+L9Xjf/4//u74s7/9q+7rwWf84B/kB/2B/sR+3MN+WucPo/MPFjD7AClkQBZqykOfbx238P9//8f/K4v/+Lsovxy+nAef8YN/kB+Bf/7rv0N/oD+xHzexn7PzhxF84IvAjwY8+YN26zH48f348ePxpr8fP/71D799P/f4lxzr863jGv7//Lf/e/P4gf/4P8XXx+AzfvAP8oP+QH9iP+5nP0v3i5p/pPOdq+detGNu7tpan7CA2Z/JSgKthd983wa+KK7H/9LScym+PpdeDz7jB/8gP+gP9Cf24572c2T+MDr/YAFzbNNYwCzwEq5uOYGOjLzIcarAcp6b0vXgM37wz37yo11nJUOVHnviX/384DN+8E/8/IMFzLFNYwGzwEu4ummBjo68SGt5bkrnwWf84J+95CddTAj+A7Ln1e+e/mfxVx8/8Bm/HfjnjPkHC5hjm8YCZoGXcHVLBfqMyIv8bnke5XzJc5m7H/iMH/xzP/mRhUQJXxYdEmlJDZjuX0dWrPjwz/34B/z7jl96fMb8gwXMsU1jAbPAS7i6vQT6pMiLtF7PTcuTAz7jB//cW37StK8cfhop0b9rkZsR/DuOH/iM31355yWLJ80/WMAc2zQWMAu8hKtbTqAjIy9y/DbByHhuSteDz/jBP19LfvSiI42saHw5P4q/4vODz/h9Ff6Jnn+wgDm2aS1gI8svALMbO41+Z/1//tv//e078XL8APlG/ONv6e/cefAZP/jn3vLzMEd/9l//6u38Izjy+Fv6+6kv/vrvjm/fPjale8xbvh1v/afnpX8L/h3HD3zG7+78MwrW+QcbWX6djSz5jPJXWMVW9oGJiLzI75bnRo5LnhvdP/iMH/xzX/nR0FXDkqSN5aAXf4XnB5/x+4r8o89Hzz+IwBzbNFLIFngJV7dRgfbKWe3NsU1/13JuwWf84B/kB/2B/sR+3MN+zswfzprv0I7lxoAFzAIv4Y41MB45q2kObM5zo/FLnhvwGT/4B/lBf6A/sR/3t5/R8w8WMMc+c1dqYABrTuhozYvGvzrnFnzGD/5BftAf6E/sxxr20zJ/GIUH/hMGa36BdYAamAVWkXeqgfH8WkjLc5PLoa3lzILP+ME/yA/6A/2J/biP/bTUwHjMP4jAHPvMXRtAEf9XYILOnFDv77SXcmZ1Tq3OmdXXg8/4wT/ID/oD/Yn9uJ/97K2B8Zp/sIA5tmksYBZ4CXeogYn4Trslh7bmuQGf8YN/kB/0B/oT+3F/+xk9/2ABc+wzd726Bub79+/PdlfYgf7fHd+rNTBeNS8aJAd2Jmf2x7/9U5uAX/7mOP7tvw/TDz7jB/8Eyc+f/OY4/kfj3vAf/If+Xhb/2y//H1M1M+lxDrznH2nN7++P+8/fvjL9P9gH5vpV5Mo1MJE75PbUwLRyZn/82z9N4c/2Dz7jB/8gP+gP9OdXtB8e9rdWAxMx/yACc2zTLo/AAOt+hSwq8iIgXyzp2aG39HWTf/5f/5/Hn/2//z9vxw+P0GuH73/776/j547c//ZPn64Hn/GDf5Af9Af6E/sxZz+t9lvsfy4CEzX/sH51FVgXiMAssIq8uuU8EpGRl54c2lrNTHr88ADN4M/2Dz7jB/8gP+gP9OdXtB8R9jd6/kEE5timEYEBPnkkoiMvAh7fmRcPUM5zVoqslDxJ4DN+8A/yg/5Af2I/+uyn2F+vfWIs84cStPCJwOwDRGAWWEVe3VKPxBmRF/nd8tzkviPfysG14s/2Dz7jB/8gP+gP9OdXtB8e9vftfifMP4jAHNs0IjDAT4/Eo6bphMiLwKdoSsFzU/PkPDxBrchJy5MEPuMH/yA/6A/0J/Zjzn5a7febLT8p84MIzD5ABGaBVeQd9oGJ+E57mgOb89yUrs/l4I7iz/YPPuMH/yA/6A/051e0HxH2N3r+QQTm2KYRgQGmPRKjnhPxzMzkzD73gfn4Tj01L9T8CFDzRM0XNW/U/FHzGFvzKfZ31H7rr5WNgHX+QQRmHyACs8AqcuV9YCIiL/K75bnpysEFn/GDf5Af9Af6E/txS/tZ2wcmYv5BBObYZ+7agOYVVz8ALSaFrAtPKQ9zvx/4DwUmTc6lv/WxXPuk+SOE/frbR1GhXJ87Bp/xg3+QH/QH+hP74Ws/rfY7d230/IMFzLHNvJkFzAIv4Y41MB45q7Xv0LdyaAW/9B36XvzZ/sFn/OAf5Af9gf78ivYjwv5Gzz9YwBzbNGpgAHNOqNfXQmZzZkv7wLDPC/vcsM8P+xyxzxP7XAmwz1fMPme5fWAs9luft8wfRuGB/4TBml9gHaAGZoFV5J1qYDy/FtLy3ORyaHXOrP4OvRV/tn/wGT/4B/lBf6A/v6L98LC/lhoYj/kHEZhjm0YK2QIv4erWK9BeNS/SSjmzOqdW58z25uimIe40Zxd8xg/+QX7QH+hP7Iev/bTab/37jPkHC5hjn7krRfzXv4Q71MBEfKfdkoNb8tz05uDWPD/gM37wD/KD/kB/Yj+ut7/R8w8WMMc+c9cGfPv40lgRvn0bz0UE7lEDE7VDruTAzuTMyk7A1DxQ80DNAzUPAtQ8xNQ8gM/4pfwh9nfUfus5gGX+0Asan31g9gFqYBZYRa5cAxO5Q25PDUwrZ7aVg2vJuQWf8YN/kB/0B/oT+3Ge/a3VwETMP4jAHPvMXYnAACWPRFTkRUC8fz079Ja+biJfQal5DlueRvAZP/gH+UF/oD+xH3P202q/xf7nIjBR8w8iMPsAEZgFVpFXt5xHIjLy0lODUquZ6cnB7cWf7R98xg/+QX7QH+jPr2g/Iuxv9PyDCMyxTSMCA3zySERHXgRGc2bfrs3sA0PONjnr5OxTs0DNBjUrAtT8xNQ85faBsdhvfd4yfyhBC58IzD5ABGaBVeTVLfVInBF5kd8tz03uO/KtHFwr/mz/4DN+8A/yg/5Af35F++Fhf9/ud8L8gwjMsU0jAgP89Eg8vip3QuRF4FM0peC5qXly5CsoNc9Ry5MEPuMH/yA/6A/0J/Zjzn5a7febLT8p84MIzD5ABGaBVeQd9oGJ+E57mgOb89yUrs/l4I7iz/YPPuMH/yA/6A/051e0HxH2N3r+QQTm2KYRgQGmPRKjnhPxzMzkzD48QMcvf0PNAzUP1DxQ8/DSD9Q8sM8L+9zE7/Mj9nfUfuuvlY2Adf5BBGYfIAKzwCpy5X1gIiIv8rvluenKwQWf8YN/kB/0B/oT+3FL+1nbByZi/kEE5thn7tqA5hVXPwAtJoWsC08pD3O/H/gPBSZNzqW/9bFc+6T5I4T9+ttHUaFcnzsGn/GDf5Af9Af6E/vhaz+t9jt3bfT8gwXMsc28mQXMAi/hjjUwHjmrte/Qt3JoBb/0HfpefEv/j75e7UN5S9PnW8cpfiT9Pf2P0u/x/nLXW8evl/7Z99/CH33/tes9+Vfje/GvPh8lfyLv3vIn56P0x93kr4efR+m/m/wJzZH6w1v+ND9H0p+T91n+k+uj5h8sYI5tGjUwgDkn1OtrIbM5s6V9YKJyfl/wUXMzDAo/kv43up3pj6q5yNLsQH/0PkHdYKBf+ojY52gYGvRLbnxkzn0E/VH64xNvLC5/gt/qfwSeOulG8veiOXCfMRPtBvoj5E/j5/aBsdhvfb4HPOYfTxis+QXWAWpgFlhF3qkGxvNrIS3PTS6HVufMpl69EXxL/9rzacXX/bc8v170lzyfo/TryIA3/dqT7/H8QrPn+0vxa578EfrT+3nxbzT/eT7/mfwn94uUP0/+05GBCP3hzX+5yJE3/d78Fy1/Kf/VIhlX689o+1uiJ2r+QQTm2KaRQrbAS7i69Qq0V82LtFRx6d/S0mO9+Gnl6IrhTPFz18/iyzVW/HQiEkm//M2Lfn29N/1vNDuMv067iOAfTfcs/+Tu502/7mOW/0ef30q/pteL/kj5q/HfiPylfBehPyz810N/tPzN8F+J/mj503rDi3+t+tOTf6z2W/+2zB+sTfBZwBzbNBYwC7yEO9TAeEZe5Hyq4Fo5tCXPjSjYUXxL/6mh8aA/NTRR9KeTp9nnT4261/vLXS/393p/ns9fw0+NuQf9cj8v/o3mv9L9POn35r/0flH6w5v/ouUviv/S+0XJnyf/vS0sAvWHN/9568+W/Hjzn5zX+LXzFnwWMMc2jRoYoFkDE7VDruTAzuTMyk7AUTn3uZqBUs2KnOvt/+yagZ6c9xb9mu7ImoGRnP3ImpHo/jX+WTUDLz5xoP9Fc2DOfYn/RujXdM+8/7P4R8tHZM2fhf9a9JfOe9fsjPKfpu+Kmj8P/TGqP0foF/s7ar/1HCAH3vMP9oHZB6iBWWAVuXINTETkRX63PDcSdi55bnpycC05ty187fm04ls9b170lzyfo/Tr+3nT/5YC4fT8uciZJ/0lT/4o/T2Rs9X4z/P5z+S/UuRsVf7T94vQH978l4ucedPvzX/R8qff56r6M9r+luiJmn8QgTm2aURggKJHIiryIiDen54dektfN5GvoNQ8Ry1PUy9+6pWs4cs1rf5L9/OmX/roxW/Rn9IcMf7a8zmCn9LfinR50K+/JNTz/qOev5f+Ev+N0l/y/HrTn9I8I3+5MYiSPxkXL/l7XROk/9LI7az8tSJdXvTrSMaM/M3gW+nX79OD/jP0Rw7far/F/uciMFHzDyIw+wARmAVWkVe3nEciMvLSk4Nbq5lJj2ueqx58S/+WGpie/lueNw/6a57PEfp7axBm6BfPp9f783z+Gv5bQbED/a3I2Wr8pz2/3vIXwX+1yNmq/Bctf1H8Z6mBWYH/WpEzL/q9+c9bf7bkx5v/oucfRGCObRoRGOCTRyI68iIwmjP7dm1mH5izagZ6Ix+l/q+uGRih/8yagdb49eJfVTPgRf/M+6/R3+I/a/9n1AxY+K+H/px8RO3z4fX+eyO3q8hfOga1SLCH/KX850G/3CNC/lqRy1n6I+QvJz/yTkfstz7/gOj5BxGYfYAIzAKryKtb6pE4I/Iiv1ueGzlvycG14lv678nhtvTf8rx50W+pgenpv1aD4EG/jgx4PH9vDcIo/WnNgMf764mcrcZ/ns9/Jv+VImer8l+tBmZV/uutgVmJ/6LlT7/PVfVntP19u98J8w8iMMc2jQgM8NMj8fACnRB5EfgUTSl4bmqeHPkKSs1z1PIk9eKXPKk9kZuaJzWa/lL/o/hyHDX+pZzwGfrT+42+/1r/ta+9jdCv6fbg31H+mx1/b/qt/Nei/8UbgfI3w3+afgHhu4jxf4toOMlfSveZ/DNKfyvS5UX/C5z0h+a3aPpTfKv9Tn+flflBBGYfIAKzwCryDvvAeEZecjmwOc9N6fr0uOa56sG39F+rgRnpv+V586C/twamt/9SDYIn/bl9DGbo93z+Gn5tH5iR/i01CCvwX20fjlX5rxY5W5X/ouUviv9qNTAr8p+lBmaGfm/+89afLfnx5j85bzm24BOBObZpRGCAaY/EqOdEPDMzObOWfU6iawZ68HOe1LNqBnT/o89/Vc3AKP2r1AxY6T+7ZsDKv1fUDMzUrOToP0N/5KJpM/qjN3I2S7/mPy/6Z95/jf4W/1n7T/lshZqTXvpL+jOCfpGfUfudRm5GwTr/IAKzDxCBWWAVufI+MBGRF/nd8tz05NCeiZ/zpM703/K8edFf86SO9J/eL4J+Sw537/OXPKle9Je+ZjVKf28Nwkr85/n8Z/JfbR+YFfkvvV+U/vDmv9L9Vua/aPlL+a/0Na8V9Gc0vj4vv6PmH0Rgjm1aC5pXXP0AtJgUsi48pTzM/X7gPxSYNDmX/tbHcq0o/xQ/nYw8+8gcj+K/0k2SsPlI/7P4VvrlGq/+o+l/m6A59K/vF8E/up/Z8avd7yr+b9Hf+/xR/Y/i62eIkD/9Xmfpl8Vn1Puv8d8I/Vp3RvCvp/zV7udN/xtNDvS39Gek/rDa79y10fMPFjDHNo0FzAIv4Y41MB45q6K4Sp4bjZ8qOsEXBTqKb+n/zTA40J8aoyj6pQ+P538zkE7vL3e90Ov1/jyfv4afGnsP+uV+XvwbzX+l+3nS781/qXxE6Q9v/ouWvyj+S+8XJX+e/Jfq+0j94c1/3vqzJT/e/CfXR80/WMAc2zRqYABzTqjX10Jmc2Ylvzwy5z49f8d9Bmo1AyP0n1kzMFtzUsoJP6tm4OyambP5T9OX8ll0zr2n/KV0R+iPEv/N0n91zYWV/hevsU/XFvsEpV85G7Xf+nwPeMw/njBY8wusA9TALLCKvFMNjOfXQlqeGzkueW5y36G34lv6155PK77V8+ZFf8nzOUq/9sx60689qR7Pn4ucedJf8+SP0N8TOVuN/zyf/0z+K0XOVuU/HRmI0B/e/JeLnHnT781/0fKX8l8tknG1/oy2vyV6ouYfRGCObRopZAu8hKtbr0B71bxISxWX/i0tPdaLn1aOrhjOFN+S49uLL9dY8Vs51l7065zpWfr19d7065zw2fFPJ08R7z9H9yz/5O7nTb/uY5b/R5/fSr+m14v+SPmr8d+I/KV8F6E/LPzXQ3+0/M3wX4n+aPnTesOLf63605N/rPZb/7bMH6xN8FnAHNs0FjALvIQ71MB4Rl7kfKrgWjm0Jc+NKNhRfEv/qXFIPV09xzX8SPp7+h+l3+P95a63jl8v/bPvv4U/+v5rx578q/G9+LfFz570R8ifHEfpj7vJX46fvei/m/wJzZH6w1v+ND9H0p+T91n+k/Mav3begs8C5timXV4D8/3792e7K+xA/++O79UamKgdciUHdiZnNt0J/Yx9PoYgydnPwZk1A570R9cMtPq30n/WPkGl/kfgjJqBJhjp1zU13jn3Zuik/27644qav1n6I2t+evqfof+MfYI86T+jZkrs76j91nOAHHjPP9Ka398f95+/fWX6f9SXJ+0lztUrMFpsDUxE5EV+tzw3EnYueW56cnAtObfgM37wD/KD/kB/Yj/Os78lexw1/yACc2wzb748AgOs+xWyqMiLgHh/enboLX3dRL6CUvMctTxN4DN+8A/yg/5Af2I/5uyn1X6L/c9FYKLmH9avrgLrAhGYBVaRV7ecRyIy8tKTg1urmenJwe3Fn+0ffMYP/kF+0B/oz69oPyLsb/T8gwjMsU0jAgN88khER14ERnNm367N7ANz1j4J4DN+8A/yg/5Af35V+5HbB8Ziv/X5B0TPP4jA7ANEYBZYRV7dUo/EGZEX+d3y3Mh5Sw6uFX+2f/AZP/gH+UF/oD+/ov3wsL9v9zth/kEE5timEYEBfnokHjVNJ0ReBD5FUwqem5onR76CUvMctTxJ4DN+8A/yg/5Af2I/5uyn1X6/2fKTMj+IwOwDRGAWWEXeYR+YiO+0pzmwOc9N6fpcDu4o/mz/4DN+8A/yg/5Af35F+xFhf6PnH0Rgjm0aERhg2iMx6jkRz8xMzmy6z8kdcobBZ/zgH+QH/YH+3MF+iP0dtd/6a2UjYJ1/EIHZB4jALLCKXHkfmIjIi/xueW66cnDBZ/zgH+QH/YH+xH7c0n7W9oGJmH8QgTn2mbu29qlkI8uvmULWhaeUh7nfD/yHApMm59Lf+liufdL8EcJ+/e2jqFCuzx2Dz/jBP8gP+gP9if3wtZ9W+527Nnr+wQLm2GfuygLm+pdwxxoYj5zV2nfoWzm0gl/6Dn0v/mz/4DN+8A/yg/5Af35F+xFhf6PnHyxgjm0aNTCAOSfU62shszmzpX1gVs4ZBp/xg3+QH/QH+nMH+5HbB8Ziv/X5HvCYfzxhsOYXWAeogVlgFXmnGhjPr4W0PDe5HFqdM6u/Q2/Fn+0ffMYP/kF+0B/oz69oPzzsr6UGxmP+QQTm2KaRQrbAS7i69Qq0V82LtFLOrM6p1TmzvTm6aYg7zdkFn/GDf5Af9Af6E/vhaz+t9lv/PmP+wQLm2GfuSg3M9S/hDjUwEd9pt+Tgljw3vTm4Nc8P+Iwf/IP8oD/Qn9iP6+1v9PyDBcyxz9y1Ad+enyKrwLdv47mIwD1qYKJ2yJUc2JmcWdkJ+C45w+AzfvAP8oP+QH/uYD/E/o7abz0HyIH3/IN9YPYBamAWWEWuXAMTuUNuTw1MK2e2lYNrybkFn/GDf5Af9Af6E/txnv2t1cBEzD+IwBz7zF2JwAAlj0RU5EVAvD89O/SWvm4iX0GpeY5anibwGT/4B/lBf6A/sR9z9tNqv8X+5yIwUfMPIjD7ABGYBVaRV7ecRyIy8tJTg1KrmenJwe3Fn+0ffMYP/kF+0B/oz69oPyLsb/T8gwjMsU0jAgN88khER14ERnNm367N7AOzcs4w+Iwf/IP8oD/QnzvYj9w+MBb7rc8/IHr+QQRmHyACs8Aq8uqWeiTOiLzI75bnJvcd+VYOrhV/tn/wGT/4B/lBf6A/v6L98LC/b/c7Yf5BBObYphGBAX56JB5flTsh8iLwKZpS8NzUPDnyFZSa56jlSQKf8YN/kB/0B/oT+zFnP632+82Wn5T5QQRmHyACs8Aq8g77wER8pz3Ngc15bkrX53JwR/Fn+wef8YN/kB/0B/rzK9qPCPsbPf8gAnNs04jAANMeiVHPiXhmZnJmHx6g45e/uU3OMPiMH/yD/KA/0J872A+xv6P2W3+tbASs8w8iMPsAEZgFVpEr7wMTEXmR3y3PTVcO7on4D2/TM4f23/7pZ3uMW3Ksz7eOz6C/1f8I/ZHjbx2/3usj+Wfm/beuj+J/L/7V56Pl11v+hDfuJH9Cc5T+iJC/HD970n83+RN8b/mT36vZzxJ+qSYnav5BBObYphGBAYY9El45qy3PjT5OIzc9nqOSJ8mK/zj3Bh+Rn2HojBzN0t/qfwSeX6AJGv9uMNIvHsPR91+j30S3kX4v/i3hD0OB/ij5+8TPTvL3gBdNN5G/aP1RpXuS/gj5E1wTbCp/Kd0R8lfDt9pvsf+5fWCi5h9EYPYBIjALrCLvWAPjkbOa5sDmPDcaP+e5ST1NI/iW/rXnc5Z+7SmLoL/m+RyhP/X8eby/3PXakz/7/jyfv4Zf8uSP0i/38+LfaP4r3c+Tfm/+q0WOVuW/aPmL4r/0flHy58l/qb6P1B/e/OetP1vy481/cn3U/IMIzLFNIwIDmD0SZ0VeevaJye0DE5Xza/XctvoXiKQ/pTvXv5X+M2qOhOae8euhX+4XnTMu9Fjef43+0nkv+mf5T9OX8ll0zr2n/KV0R+iPEv/N0h9d89DiPyv9L14LlD8L/7XoF4jeZ0zzx6z+6NWfHvTn9oGx2G99vgc85h9PGKz5BdYBIjALrCLvVAPj+bWQlucml0Orc2ZTr94IvqV/7fm04ls9b170lzyfo/Rrz6w3/bUc7tHnz0XOPOnvrQHp7b8ncrYa/3k+/5n8Z6mBWYH/dGQgQn94818ucuZNvzf/Rctfyn+1SMbV+jPa/pboiZp/EIE5tmktaF5x9QPQYlLIstcp5WHuR+Gnikv/lpYe68XP857J5EOOU/z0WBfseuHLNVb8dCISSb/8zYt+fb03/W80O4y/LniN4B9N9yz/5O7nTb/uY5b/R5/fSr+m14v+SPmr8d+I/KV8F6E/LPzXQ3+0/M3wX4n+aPnTesOLf63605N/rPZb/7bMH6xN8FnAHNs0FjALvIQ71MB4Rl7kfKrgWjm0Jc+NKNhRfEv/qaHxoD81NFH0p5On2edPjbrX+8tdL/f3en+ez1/DT425B/1yPy/+jea/0v086ffmv/R+UfrDm/+i5S+K/9L7RcmfJ/+9LSwC9Yc3/3nrz5b8ePOfnNf4tfMWfBYwxzaNGhigWQMTtUOu5MDO5MzKV1LOyBlv1QzIud7+z64ZmM15L9XUnFUz4EH/zPuP7l/jn10z4EH/i+bAnPsS/43Qr+meef9n8c9ozcRIzZ+F/1r0l857jt8M/2n6XnBSzV/v+2/Rf1bNX/qVs1H7recAOfCef/AVsn2AGpgFVpEr18BERF7kd8tzI2HnkuemJwfXknPbwteeTyu+1fPmRX/J8zlKv76fN/1vKRBOz5+LnHnSX/Lkj9LfEzlbjf88n/9M/itFzlblP32/CP3hzX+5yJk3/d78Fy1/+n2uqj+j7W+Jnqj5BxGYY5tGBAYoeiSiIi8C4v1peW7Sa+W3gHwFpeY5anmaevFLX3dpeS5bkYZo+qWPXvwW/SnNEeOvPZ8j+Cn9rUiXB/1vdHe+/6jn76W/xH+j9Jc8v970pzTPyF9uDKLkT8bFS/5e1wTpvzRyOyt/rUiXF/06kjEjfzP4Vvr1+/Sg/wz9kcO32m+x/7kITNT8gwjMPkAEZoFV5NUt55GIjLz05ODWambS45rnqgff0r+lBqan/5bnzYP+mudzhP7eGoQZ+sXz6fX+PJ+/hv9WUOxAfytythr/ac+vt/xF8F8tcrYq/0XLXxT/WWpgVuC/VuTMi35v/vPWny358ea/6PkHEZhjm0YEBvjkkYiOvAiM5sy+XZvZB4Z9BnxqVnKe6TNrBnL9j+BfVTPgRf9VNQPW/s+oGbDwXw/9Oflgn48Y/pVj9unaY5+gNAI4ar/1+QdEzz+IwOwDRGAWWEVe3VKPxBmRF/nd8tzIeUsOrhXf0n9PDrel/5bnzYt+Sw1MT/+1GgQP+nVkwOP5e2sQRulPawY83l9P5Gw1/vN8/jP5rxQ5W5X/ajUwq/Jfbw3MSvwXLX/6fa6qP6Pt79v9Tph/EIE5tmlEYICfHomHF+iEyIvAp2hKwXNT8+TIV1BqnqOWJ6kXv+TJ7/naUzbHvvNrMbP0l/ofxZfjqPEv5YTP0J/eb/T91/qvfe1thH5Ntwf/jvLf7Ph702/lvxb9L94IlL8Z/tP0C6RfgfIe/1xN1+zzp3SfyT+j9JdqxLzpf4GT/tD8Fk1/im+13+nvszI/iMDsA0RgFlhF3mEfGM/ISy4HNue5KV2fHtc8Vz34lv5rNTAj/bc8bx7099bA9PZfqkHwpD+3j8EM/Z7PX8Ov7QMz0r+lBmEF/qvtw7Eq/9UiZ6vyX7T8RfFfrQZmRf6z1MDM0O/Nf976syU/3vwn5y3HFnwiMMc2jQgMMO2RGPWciGdmJmfWss9JdM1AD37Ok3pWzYDuf/T5r6oZGKW/5Uk9q2bHSv/ZNQNW/m15fqNy7kf5L0f/GfojF02b0R+9kbNZ+jX/edE/8/5r9Lf4z9p/ymcr1Jz00l/SnxH0i/yM2u80cjMK1vkHEZh9gAjMAqvIlfeBiYi8yO+W56Ynh/ZM/Jwndab/lufNi/6aJ3Wk//R+EfRbcrh7n7/kSfWiv/Q1q1H6e2sQVuI/z+c/k/9q+8CsyH/p/aL0hzf/le63Mv9Fy1/Kf6Wvea2gP6Px9Xn5HTX/IAJzbNNa0Lzi6gegxaSQdeEp5WHu9wP/ocCkybn0tz6Wa0X5p/jpZOTZR+Z4FP+VbpKEzUf6n8W30i/XePUfTf/bBM2hf32/CP7R/cyOX+1+V/F/i/7e54/qfxRfP0OE/On3Oku/LD6j3n+N/0bo17ozgn895a92P2/632hyoL+lPyP1h9V+566Nnn+wgDm2aSxgFngJd6yB8chZFcVV8txo/FTRCb4o0FF8S/9vhsGB/tQYRdEvfXg8/5uBdHp/ueuFXq/35/n8NfzU2HvQL/fz4t9o/ivdz5N+b/5L5SNKf3jzX7T8RfFfer8o+fPkv1TfR+oPb/7z1p8t+fHmP7k+av7BAubYplEDA5hzQr2+FjKbMyv55ZE59+n5F3zkzLdqHmZztqNrBkboP7NmYLbmpJQTflbNwNk1M2fzn6Yv5bPonHtP+UvpjtAfJf6bpf/qmgsr/S9eC5Q/C/+16J+teZyt+Rul/6yav/QrZ6P2W5/vAY/5xxMGa36BdYAamAVWkXeqgfH8WkjLcyPHJc9N7jv0VnxL/2naRuq5tRzn8KPpb/U/Qv/I+PXSbx2/3uPZ91/Dn3n/rWMv/tX4Xvzb4mdv+r3lrxQ5W1n+0shAhP6IkD/Bj5C/Xn5eSf4E31v+5HeU/Hnb3xI9UfMPIjDHNo0IDNAdgfH+TnvuW/DyO/cd+fRrJamnqOU5enmpPjxHpe/Y9+IPQ+I5TiGa/lb/I/SnkQZv+q3jZ6V/9v3n8Kt0T9Lvzb+5r2N1QSf9d5M/oflO8vcA4bsI/ZHljYXlr4ufF5O/pr6bpD+NkETSnx5b7bf+XQOv+QdfIdsHiMAssIq8Qw2MZ+RFzltycEuem9TTNII/2z/4jB/8g/ygP9CfX9F+RNjf6PkHEZhjm3Z5BOb79+/PdlfYgf7fHd+rEZioHXLFMzOTM5t6wK/OGQef8YN/kB/0B/rzq9gPsb+j9lvPAXLgPf9IIzC/P+4/f/vK9P+oL0/aS5yrV2C02BqYiMiLpQamlTPbysG15NyCz/jBP8gP+gP9if04z/7WamAi5h9EYI5t5s2XR2CA66GUExoVeREQ70/PDr2lHNs0R7fkOerN8QWf8YN/kB/0B/oT+zFmP632W+x/LgITNf+gBmYfIAKzwCry6pbzSERGXnpycGs1Mz05uL34s/2Dz/jBP8gP+gP9+RXtR4T9jZ5/EIE5tmlEYIBPHonoyIvAaM7s27WZfWBWzhkGn/GDf5Af9Af6cwf7kdsHxmK/9fkHRM8/iMDsA0RgFlhFXt1Sj8QZkRf53fLc5L4j38rBteLP9g8+4wf/ID/oD/TnV7QfHvZX7xMTPf8gAnNs04jAAD89Eo+aphMiLwKfoikFz03Nk/O2D0DBc9TyJIHP+ME/yA/6A/2J/Zizn1b7/WbLT8r8IAKzDxCBWWAVeYd9YCK+057mwOY8N6Xrczm4o/iz/YPP+ME/yA/6A/35Fe1HhP2Nnn8QgTm2aURggGmPxKjnRO/QO5Iz+9zJ+GOH4jvkDIPP+ME/yA/6A/25g/0Q+ztqv/XXykbAOv8gArMPEIFZYBW58j4wEZEX+d3y3HTl4ILP+ME/yA/6A/2J/bil/aztAxMx/yACc+wzd23tU8lGll8zhawLTykPc78f+A8FJk3Opb/1sVz7pPkjhP3620dRoVyfOwaf8YN/kB/0B/oT++FrP632O3dt9PyDBcyxz9yVBcz1L+GONTAeOau179C3cmgFv/Qd+l782f7BZ/zgH+QH/YH+/Ir2I8L+Rs8/WMAc2zRqYABzTqjX10Jmc2ZL+8CsnDMMPuMH/yA/6A/05w72I7cPjMV+6/M94DH/eMJgzS+wDlADs8Aq8k41MJ5fC2l5bnI5tDpnVn+H3oo/2z/4jB/8g/ygP9CfX9F+eNhfSw2Mx/yDCMyxTSOFbIGXcHXrFWivmhdppZxZnVOrc2Z7c3TTEHeasws+4wf/ID/oD/Qn9sPXflrtt/59xvyDBcyxz9yVGpjrX8IdamAivtNuycEteW56c3Brnh/wGT/4B/lBf6A/sR/X29/o+QcLmGOfuWsDvj0/RVaBb9/GcxGBe9TARO2QKzmwMzmzshPwXXKGwWf84B/kB/2B/tzBfoj9HbXfeg6QA+/5B/vA7APUwCywily5BiZyh9yeGphWzmwrB9eScws+4wf/ID/oD/Qn9uM8+1urgYmYfxCBOfaZuxKBAUoeiajIi4B4f3p26C193US+glLzHLU8TeAzfvAP8oP+QH9iP+bsp9V+i/3PRWCi5h9EYPYBIjALrCKvbjmPRGTkpacGpVYz05OD24s/2z/4jB/8g/ygP9CfX9F+RNjf6PkHEZhjm0YEBvjkkYiOvAiM5sy+XZvZB2blnGHwGT/4B/lBf6A/d7AfuX1gLPZbn39A9PyDCMw+QARmgVXk1S31SJwReZHfLc9N7jvyrRxcK/5s/+AzfvAP8oP+QH9+RfvhYX/f7nfC/IMIzLFNIwID/PRIPL4qd0LkReBTNKXgual5cuQrKDXPUcuT1Iv/+F2FX/7miW+FaPq7wUC/eN0ixn8YGvTrSJ0n/Y//R99/i34v/tX4n3jDif4o+ZPjVv8j8OSNG8nfA9KvQHnrDxPdRvoj5C9Sf0TJn+C3+h+lP42QRNKf4lvtd/r7rMwPIjBfJwLzi9MoAa6H7z+F/1//8Nu3U61jrTws+Lrg7wF//+f/8lJwj/8fxyk8jkUxpvjySUfBfxyn+On5B55Wvi18gT/++99UjYc+XzuOpL+XHiv9o+PXS79l/Cz0z77/Ev7M+6/R782/6fmR8eul/07y94BI/TEyfj30I3/v4x8hfw+Ikj/BH33/Lfoj5E/je9jv2fnDCD7wNYB9YL4AzHokRj0nosBmcmZTz3d0zq/AaM2N4Mr5FwTS/+bhU/2PPr9AVM61jE1r/Hr7l/tF54yX6BulX66Pynm38l+L/pTHInPuR/kvR/8Z+iOleVb+0jGIrnnQ/OdF/8z7r9Hf4j9r/ymfrVBz0kt/SX9G0C/yM2q/c4uf6PkHEZh9gBqYBfL4Vt4HJnKH3FLOrD7uzZmNxn/k+3r2/7jfGfSnecoe9Kf3i6D/OS7J1208nl9ojuIf6cPr/aX3i+J/b/7zfP4z+U/uFyl/nvyX3i9Kf3jzX+l+K/NftPyl/Ffb0f5q/RmNX6rJiZp/UANzbNNa0Lzi6gegxXxGuQtPKQ9zvx/4DwUmTc6lv/WxXCvKP8VPJyPPPjLHo/hiGARntP9ZfCv9co1X/9H0v03QHPrX94vgH93P7PjV7ncV/7fo733+qP5H8fUzRMiffq+z9MviM+r91/hvhH6tOyP411P+avfzpv+NJgf6W/ozUn9Y7Xfu2uj5BwuYY5vGAmaBl3B1ywl0ZORF8EVxlTw3Gj9VdIIvCnQU39L/m2FwoD81RlH0Sx8ez/9mIJ3eX+56odfr/Xk+fw0/NfYe9Mv9vPg3mv9K9/Ok35v/UvmI0h/e/Bctf1H8l94vSv48+S/V95H6w5v/vPVnS368+U+uj5p/sIA5tml8hQww54R6fS1kNmdW8ssjc+7T87mCyVrNw2zOdnTNwAj9Z9YMzNaclHLCz6oZOLtm5mz+0/SlfBadc+8pfyndEfqjxH+z9F9dc2Gl/8VrgfJn4b8W/bM1j7M1f6P0n1Xzl37lbNR+6/M94DH/eMJgzS+wDlADs8Aq8k41MJ7faW95buS45LnJfYfeim/pX3s+rfhWz5sX/SXP5yj92jPrTb/2pHo8fy5y5kl/zZM/Qn9P5Gw1/vN8/jP5rxQ5W5X/dGQgQn94818ucuZNvzf/Rctfyn+1SMbV+jPa/pboiZp/EIE5tmmkkC3wEq5uvQLtVfMiLVVc+re09Fgvflo5umI4U3xLjm8vvlxjxW/lWHvRr3OmZ+nX13vTr3PCZ8c/nTxFvP8c3bP8k7ufN/26j1n+H31+K/2aXi/6I+Wvxn8j8pfyXYT+sPBfD/3R8jfDfyX6o+VP6w0v/rXqT0/+sdpv/dsyf7A2wWcBc2zTWMAs8BLuUAPjGXmR86mCa+XQljw3omBH8S39p4bGg/7U0ETRn06eZp8/Nepe7y93vdzf6/15Pn8NPzXmHvTL/bz4N5r/SvfzpN+b/9L7RekPb/6Llr8o/kvvFyV/nvz3trAI1B/e/OetP1vy481/cl7j185b8FnAHNs0amCAZg1M1A65kgM7kzOb7oR+xj4fd9tnwFKz0kN/rqbmrJqBq/eZiO5f459dM+BB/4vmwJz7Ev+N0K/pnnn/u+3zYeW/Fv2l8195n660ZqX3/bfoP6vmT+Tn8f+o/dZzgBx4zz/YB2YfoAZmgVXkyjUwEZEX+d3y3EjYueS56cnBteTctvC159OKb/W8edFf8nyO0q/v503/WwqE0/PnImee9Jc8+aP090TOVuM/z+c/k/9KkbNV+U/fL0J/ePNfLnLmTb83/0XLn36fq+rPaPtboidq/kEE5timEYEBih6JqMiLgHh/enboLX3dRL6CUvMctTxNvfilr7u0PJetSEM0/dJHL36L/pTmiPHXns8R/JT+VqTLg/43ujvff9Tz99Jf4r9R+kueX2/6U5pn5C83BlHyJ+PiJX+va4L0Xxq5nZW/VqTLi34dyZiRvxl8K/36fXrQf4b+yOFb7bfY/1wEJmr+QQRmHyACs8Aq8uqW80hERl56cnBrNTPpcc1z1YNv6d9SA9PTf8vz5kF/zfM5Qn9vDcIM/eL59Hp/ns9fw38rKHagvxU5W43/tOfXW/4i+K8WOVuV/6LlL4r/LDUwK/BfK3LmRb83/3nrz5b8ePNf9PyDCMyxTSMCA3zySERHXgRGc2bfrs3sA8M+Az41KznP9Jk1A7n+R/Cvqhnwov+qmgFr/2fUDFj4r4f+nHywz0cM/8ox+3TtsU9QGgEctd/6/AOi5x9EYPYBIjALrCKvbqlH4ozIi/xueW7kvCUH14pv6b8nh9vSf8vz5kW/pQamp/9aDYIH/Toy4PH8vTUIo/SnNQMe768ncrYa/3k+/5n8V4qcrcp/tRqYVfmvtwZmJf6Llj/9PlfVn9H29+1+J8w/iMAc2zQiMMBPj8TDC3RC5EXgUzSl4LmpeXLkKyg1z1HLk9SLX/Lk93ztKZtj3/m1mFn6S/2P4stx1PiXcsJn6E/vN/r+a/3XvvY2Qr+m24N/R/lvdvy96bfyX4v+F28Eyt8M/2n6BdKvQHmPf66ma/b5U7rP5J9R+ks1Yt70v8BJf2h+i6Y/xbfa7/T3WZkfRGD2ASIwC6wi77APjGfkJZcDm/PclK5Pj2ueqx58S/+1GpiR/lueNw/6e2tgevsv1SB40p/bx2CGfs/nr+HX9oEZ6d9Sg7AC/9X24ViV/2qRs1X5L1r+ovivVgOzIv9ZamBm6PfmP2/92ZIfb/6T85ZjCz4RmGObRgQGmPZIjHpOxDMzkzNr2eckumagBz/nST2rZkD3P/r8V9UMjNLf8qSeVbNjpf/smgEr/7Y8v1E596P8l6P/DP2Ri6bN6I/eyNks/Zr/vOifef81+lv8Z+0/5bMVak566S/pzwj6RX5G7XcauRkF6/yDCMw+QARmgVXkyvvARERe5HfLc9OTQ3smfs6TOtN/y/PmRX/NkzrSf3q/CPotOdy9z1/ypHrRX/qa1Sj9vTUIK/Gf5/OfyX+1fWBW5L/0flH6w5v/Svdbmf+i5S/lv9LXvFbQn9H4+rz8jpp/EIE5tmlEYIBhj4RXzmrLc6OP08hNj+eo5Emy4n/K5/7w3A5Dp+d3lv5W/yNQqxmYpb8bjPRrT6on/Sa6jfR78W8JfxgK9EfJX6lmwIP+nhqDleQvWn9U6Z6kP0L+BNcEm8pfSneE/NXwrfZb7H9uH5io+QcRmH2ACMwCq8g71sB45KymObA5z43Gz3luap6rHnxL/698+Q/PdXqsz7eOezxvHvT39D9Kv8f7y11vHb9e+mfffwt/9P3Xrvfk35Lnd5Z/9fko+Us9+RH0R+mPu8lfDz+P0n83+ROaI/WHt/xpfo6kPyfvs/wn10fNP4jAHNs0IjCA2SNxVuSllTMrUZHInHvwGT/4B/lBf6A/sR/5r9VJndSI/dbnLfOHUXjgP2Gw5hdYB4jALLCKvFMNjOfXQlqem1wOrc6ZTb16I/iz/YPP+ME/yA/6A/35Fe2Hh/211MB4zD+IwBzbtBY0r7j6AWgxKWTZ65TyMPej8FPFpX9LS4/14ud5z6QAV45T/PRYF+yCz/jBP8gP+gP9if3wsZ9W+61/nzH/YAFzbDNvZgGzwEu4Qw1MxHfaLTm4Jc9Nbw5uzfMDPuMH/yA/6A/0J/bjevsbPf9gAXPsM3dtwLePKEsRvn0bz0V8wPfv35/trrAD/b87vldrYKJ2yJUc2Jmc2XQndGpWqNkRoGaBmgVqFqj5o+YxtuZT7O+o/dZzAMv8oRc0flrz+/vj/vO3r0z/j/rypL3EuXoFRoutgYncIbenBqaVM9vKwbXk3ILP+ME/yA/6A/2J/TjP/tZqYCLmH0Rgjm3mzZdHYIB1v0IWFXkREO9Pzw69pa+byFdQap6jlqcJfMYP/kF+0B/oT+zHnP202m+x/7kITNT8g31g9gEiMAusIq9uOY9EZOSlpwalVjPTk4Pbiz/bP/iMH/yD/KA/0J9f0X5E2N/o+QcRmGObRgQG+OSRiI68CIzmzL5dm9kHhn1e2OeGfX7Y54h9ntjnSoB9vmL2OcvtA2Ox3/q8Zf5QghY+EZh9gAjMAqvIq1vqkTgj8iK/W56b3HfkWzm4VvzZ/sFn/OAf5Af9gf78ivbDw/6+3e+E+QcRmGObRgQG+OmReNQ0nRB5EfgUTSl4bmqeHPkKSs1z1PIkgc/4wT/ID/oD/Yn9mLOfVvv9ZstPyvwgArMPEIFZYBV5h31gIr7TnubA5jw3petzObij+LP9g8/4wT/ID/oD/fkV7UeE/Y2efxCBObZpRGCAaY/EqOdEPDMzObMPD9Dxy99Q80DNAzUP1Dy89AM1DzE1D+Azfil/iP0dtd/6a2UjYJ1/EIHZB4jALLCKXHkfmIjIi/xueW66cnDBZ/zgH+QH/YH+xH7c0n7W9oGJmH8QgTn2mbu29qlkI8uvmULWhaeUh7nfD/yHApMm59Lf+liufdL8EcJ+/e2jqFCuzx2Dz/jBP8gP+gP9if3wtZ9W+527Nnr+wQLm2GfuygLm+pdwxxoYj5zV2nfoWzm0gl/6Dn0v/mz/4DN+8A/yg/5Af35F+xFhf6PnHyxgjm0aNTCAOSfU62shszmzpX1gyNkmZ52cfWoWqNmgZkWAmp+YmqfcPjAW+63PW+YPo/DAf8JgzS+wDlADs8Aq8k41MJ5fC2l5bnI5tDpnVn+H3oo/2z/4jB/8g/ygP9CfX9F+eNhfSw2Mx/yDCMyxTSOFbIGXcHXrFWivmhdppZxZnVOrc2Z7c3TTEHeasws+4wf/ID/oD/Qn9sPXflrtt/59xvyDBcyxz9yVGpjrX8IdamAivtNuycEteW56c3Brnh/wGT/4B/lBf6A/sR/X29/o+QcLmGOfuWsDvj0/RVaBb9/GcxGBe9TARO2QKzmwMzmzshMwNQ/UPFDzQM2DADUP7PPCPjfx+/yI/R2133oOYJk/9ILGZx+YfYAamAVWkSvXwETukNtTA9PKmW3l4FpybsFn/OAf5Af9gf7Efpxnf2s1MBHzDyIwxz5zVyIwQMkjERV5ERDvT88OvaWvm8hXUGqeo5anCXzGD/5BftAf6E/sx5z9tNpvsf+5CEzU/IMIzD5ABGaBVeTVLeeRiIy89NSg1GpmenJwe/Et/T/6ktY6loLHnusj6e+ld4R+j/eXw7eOXy/9s++/hT/6/mv0e/Kvxvfi3xw/R8ifyLu3/MlxlP64m/ylBdve+uNu8ic0R+oPb/kT/Aj5O8P+Rs8/iMAc2zQiMMAnj0R05EVgNGf27drMPjBROb/d8MvfPPF7IZJ+E91G+qNrToahQH/0PkGt/kfolz4i9jnq6X+G/qic+97+rRClP8wyuKn8Cc13kj+hOXKfsU/8sbD8afzcPjAW+63PPyB6/kEEZh8gArPAKvLqlnokzoi8yO+W50bOW3JwrfiW/kue/NH+W55fL/pbnnxr//p+3vSnnnyv5695Uj3oz3k+Z+jPedq96ffmP8/nP5P/5H6R8ufJf/p+EfrDm/9q91uV/6LlT7/PVfVntP19u98J8w8iMMc2jQgM8NMj8fBCnhB5EfgUTSl4bmqeHPkKSs1z1PIk9eKLp8yKX/Kk6/tF0V/qfxRfjqPGXyCNIM3Sn95v9P3X+n9GBgqezxH6Nd0e/DvKf7Pj702/lf9a9L94I1D+ZvhP0y+QfgXKe/x1VMBD/lK6z+SfUfo17mj/3ZFQJ/2h+S2a/hTfar/T32dlfhCB2QeIwCywirzDPjCekZdcDmzOc1O6Pj2uea568C39lzypo/23PG8e9Pd4Ui39l3LwPenXkYHZ9+f5/DX81JPvQX8rcrYa/2nPr7f8RfBfLXK2Kv9Fy18U/9VqYFbkP0sNzAz93vznrT9b8uPNf3LecmzBJwJzbNOIwADTHolRz4l4ZmZyZmue76iagdGaFcGV81fUDGQjQYM1E9E1A63x6+2/5Un1rBno8fT39n92zYCVf1ue36ic+1H+y9F/hv7IRdNm9Edv5Myj5i/lPy/6Z95/jf4W/1n7T/lshX3Geukv6c8I+kV+Ru13GrkZBev8gwjMPkAEZoFV5Mr7wEREXuR3y3PTk0N7Jn7OkzrTf8vz5kV/zZM60n96vwj6LTncvc9f8qR60Z9GBjzeX28Nwkr85/n8Z/JfKXK2Kv+l94vSH978V7rfyvwXLX8p/5W+5rWC/ozG1+fld9T8gwjMsU1rQfOKqx+AFpNC1oWnlIe53w/8hwKTJufS3/pYrhXln+Knk5FnH5njUfz0M5Uz/c/iW+mXa7z6j6b/bYLm0L++XwT/6H5mx692v6v4v0V/7/NH9T+Kr58hQv70e52lXxafUe+/xn8j9GvdGcG/nvJXu583/W80OdDf0p+R+sNqv3PXRs8/WMAc2zQWMAu8hDvWwHjkrIriKnluNH6q6ARfFOgovqX/N8PgQH9qjKLolz48nv/NQDq9v9z1Qq/X+/N8/hp+auw96Jf7efFvNP+V7udJvzf/pfIRpT+8+S9a/qL4L71flPx58l+q7yP1hzf/eevPlvx4859cHzX/YAFzbNOogQHMOaFeXwuZzZmV/PLInPv0vPc+HVfXDIzQf2bNwGzNSSkn/KyagbNrZs7mP01fymfROfee8pfSHaE/Svw3S//VNRdW+l+8FrxPVy//teifrXmcrfkbpf+smr/0K2ej9luf7wGP+ccTBmt+gXWAGpgFVpF3qoHx/FpIy3MjxyXPTe479FZ8S//a82nFt3revOgveT5H6deeWW/6tSfV4/lzkTNP+mue/BH6eyJnq/Gf5/OfyX+lyNmq/KcjAxH6w5v/cpEzb/q9+S9a/lL+q0Uyrtaf0fa3RE/U/IMIzLFNI4VsgZdwdesVaK+aF2mp4tK/paXHevHTytEVw5niW3J8e/HlGit+K8fai36dMz1Lv77em36dEz47/unkKeL95+ie5Z/c/bzp133M8v/o81vp1/R60R8pfzX+G5G/lO8i9IeF/3roj5a/Gf4r0R8tf1pvePGvVX968o/VfuvflvmDtQk+C5hjm8YCZoGXcIcaGM/Ii5xPFVwrh7bkuREFO4pv6T81NB70p4Ymiv508jT7/KlR93p/uevl/l7vz/P5a/ipMfegX+7nxb/R/Fe6nyf93vyX3i9Kf3jzX7T8RfFfer8o+fPkv7eFRaD+8OY/b/3Zkh9v/pPzGr923oLPAubYplEDAzRrYKJ2yJUc2Jmc2XQn9DP2+bjbPgOWmpUe+nM1NWfVDFy9z0R0/xr/7JoBD/pfNAfm3Jf4b4R+TffM+99tnw8r/7XoL53/yvt0pTUrve+/Rf9ZNX8iP4//R+23ngPkwHv+wT4w+wA1MAusIleugYmIvMjvludGws4lz01PDq4l57aFrz2fVnyr582L/pLnc5R+fT9v+t9SIJyePxc586S/5Mkfpb8ncrYa/3k+/5n8V4qcrcp/+n4R+sOb/3KRM2/6vfkvWv70+1xVf0bb3xI9UfMPIjDHNo0IDFD0SERFXgTE+9OzQ2/p6ybyFZSa56jlaerFL33dpeW5bEUaoumXPnrxW/SnNEeMv/Z8juCn9LciXR70v9Hd+f6jnr+X/hL/jdJf8vx605/SPCN/uTGIkj8ZFy/5e10TpP/SyO2s/LUiXV7060jGjPzN4Fvp1+/Tg/4z9EcO32q/xf7nIjBR8w8iMPsAEZgFVpFXt5xHIjLy0pODW6uZSY9rnqsefEv/lhqYnv5bnjcP+muezxH6e2sQZugXz6fX+/N8/hr+W0GxA/2tyNlq/Kc9v97yF8F/tcjZqvwXLX9R/GepgVmB/1qRMy/6vfnPW3+25Meb/6LnH0Rgjm0aERjgk0ciOvIiMJoz+3ZtZh8Y9hnwqVnJeabPrBnI9T+Cf1XNgBf9V9UMWPs/o2bAwn899Ofkg30+YvhXjtmna499gtII4Kj91ucfED3/IAKzDxCBWWAVeXVLPRJnRF7kd8tzI+ctObhWfEv/PTnclv5bnjcv+i01MD3912oQPOjXkQGP5++tQRilP60Z8Hh/PZGz1fjP8/nP5L9S5GxV/qvVwKzKf701MCvxX7T86fe5qv6Mtr9v9zth/kEE5timEYEBfnokHl6gEyIvAp+iKQXPTc2TI19BqXmOWp6kXvySJ7/na0/ZHPvOr8XM0l/qfxRfjqPGv5QTPkN/er/R91/rv/a1txH6Nd0e/DvKf7Pj702/lf9a9L94I1D+ZvhP0y+QfgXKe/xzNV2zz5/SfSb/jNJfqhHzpv8FTvpD81s0/Sm+1X6nv8/K/CACsw8QgVlgFXmHfWA8Iy+5HNic56Z0fXpc81z14Fv6f3nZPzxz6XHq+cqdrx1H0t9Lzwj9Hu8vh28dv176Z99/C3/0/dfo9+Tfkud3ln81fpT8aU++N/1R+uNu8qcjR570303+hOZI/eEtf3I+Qv7OsL9y3nJswScCc2zTiMAA0x6JUc+JeGZmcmYt+5x41Qx8go/+h+GkmgFv+qNrBrqhk/4zanaGoEL/2TUDHvSXIg1eOfet/kfpj9IfTX5eTP7kfDcY6M9GoheWvweIHr2b/jijZkbs76j9TiM3o2CdfxCB2QeIwCywilx5H5iIyIv8bnluunJwwWf84B/kB/2B/sR+3NJ+lmpyouYfRGCOfeauDWhecfUD0GJSyLrwlPIw9/uB/1Bg0uRc+lsfy7USNk/xJeSfhuf1MfiMH/yD/KA/0J/YD1/7abXfuWuj5x8sYI5t5s0sYBZ4CXesgfHIWU1zYHOeG42f89zkcu4t+LP9g8/4wT/ID/oD/fkV7UeE/Y2ef7CAObZp1MAA5pxQr6+FzObMSn55ZM49+Iwf/IP8oD/Qn9iP/Nfq9D4wFvutz1vmD6PwwH/CYM0vsA5QA7PAKvJONTCeXwtpeW5yObQ6Zzb9ss0I/mz/4DN+8A/yg/5Af35F++Fhfy01MB7zDyIwxzaNFLIFXsLVrVegvWpepJVyZnVOrc6Z7c3RTUPcac4u+Iwf/IP8oD/Qn9gPX/tptd/69xnzDxYwxz5zV4r4r38Jd6iBifhOuyUHt+S56c3BrXl+wGf84B/kB/2B/sR+XG9/o+cfLGCOfeauDfj28aWxInz7Np6L+IDv378/211hB/p/d3x/1cD88S9/++maX/36H44//uG/DPcRif+r/+n/PP7473/z/J+aFWp2BKhZoGaBmgVq/laveYzcp+ss/MdzjNa8yN9qNTBeNbe5mt/fH/efv31l+n/UlyftJc7VKzBabA1MzvORXjPiOZFrempgcp6bty+KqJ2Se/AtOcDgM37wD/KD/kB/RtiPVg1JDj/FGenfE3+EfksNTETmBxGYfebNl0dggHW/QpbzfPzrH357/Odf/7e++zbwxXvVs0OvXPvA/4t//NPX9fIVlL//8395/j3n+Wp5ylqeM/AZP/gH+UF/oD9XsR/p1zdXwm/Zb/mdXp+ea80fLFDCt351FVgXiMAssIq8uuU8EpGRl54alF78Ug5ureZmtH/wGT/4B/lBf6A/vezHjP1KC+ivwo+wv6X5g+W4hk8E5timEYEBPnkkoiMvApac2UeE5YGvPTm5fWBWznkGn/GDf5Af9Af6U0cy7oxvqXmp7RNTmj9YoIVPBGYfIAKzwCry6pZ6JM6IvMjvludGzpciN7kamBy+pYYBfMYP/kF+0B/ozzPsh0QxZuzPlfi6Bmak/7f7BUZeXs/buW0E7Vh+DIjAAD89Eo+aphMiLwKfoimFyEta86I9OQ9P0MMz9Ojn8bWynOeo5UlqeZ7AZ/zgH+QH/YH+jLIfz6+RfXzt6474tchLTyTmea/gyMvrOmpgtgEiMAusIlfdByYq8pLLgbVGXnQOcQ6/1F9v/+AzfvAP8oP+QH9G2Y/UfpVqUnr57wr8CPvbM9+YqZkhAnNs04jAAFmPRGTkRUA8M5aaFwH5W81zRM0JNTfUHFFzRM0RNUer1hxp+5WrSbH0fza+0D9a86K/VjYC1sgNEZh9gAjMAqvI1faBiY68yO9W5KUrB/cDX/6eq7HpzbkFn/GDf5Af9Af680r7oSMhd8O3Pn+ppmh0/tE6JgJzbNOa+1SykeXX3siyiqeUR05h9OA/FJi0dPGSXpsey7US9k4VZap8n31kjnP4r7+Bz/jBP8gP+gP9eaH90P/fBT9nr2v2O3ftzPzDOt+5eu5FO6bGgAUMTFSsgYmKvAh+mgObi7xo/JznpvQd+l783PXgM37wD/KD/kB/RtuPmv1Kv/A10v8Z+BH2d3T+0XvMAmafhRM1MIA5J9Rrn5iRmhf9tZPZnN/cefAZP/gH+UF/oD+j7UfLfq2yz0uL/pGal9I+ML3zh1F44D+hc74DrAvUwCywilw5hSwi8iK/W5GXXA6tzpl9eIDkHiP4Nc8R+Iwf/IP8oD/Qn1H2Q++j0oqEjPQfid9Df0t+LDUwHl8rIwJzbNNIIVvgJVzdegXaq+ZFWqnmRefU6pzZ9Pp0I0s51jm9Omc3h5/L8QWf8YN/kB/0B/rzavvx3PDyBvhW+61/W+cfpnnOBz4LmGObxgJmgZdwhxoYz8iLxu/Joc15bsQ7NIpvyWEGn/GDf5Af9Af609N+WOxXqSblSvwI+9s7f7Acp/gsYI5tGjUwQLMGxqvmReP/xT/+6fP3SM6s1MykOwlH56wPw8d3/ksQSX+6z4A3/VE1Q49zPf1b6Y+ueWr1PwLPPPOgmq1uMNI/k3Pfot9Et5H+u+mP6Jq9Vv8j9Kcyfgf5i9YfVbon6T9jnxixv6M1L/K3Wg2MR81Lis8+MF+nBuYXp1ECLAGPhUVN+B/n08WLvt6K/1iIpPA41srvz/72r57Hj78/zsviJYU//vvfvOGnyveB/zgW/AeI0s0dl/DTfnS/pWNtfErX9/Q/Qn9v/1b6R8avl/6R8euhf/b91/Ct49d77Mm/OXwv/k2Po+Tv8fe7yZ9evHjTHyF/b5NJZ/0RJX8lfvagP1L+NHjSX5IfWXyM0K/xNfTYb329df5Qu96KD+wN356bwdQu+Da+MgbWgJJHIiryIvji/enZoVeuTSM3DxCP0EMRPv6e8xy1PE0tz9Pr+MMr2cKXa1r9l+7nTb/00Yvfoj+l2TJ+lv5T4z2Cn9LfinR50K8jAz3vP+r5e+kv8d8o/YIbJX+9/GelX98vQv5kXLzk73VNgPzpyO2s/OlIQ4T8pX1b378X/4/Sr99nT/+p3hnRHzX8HvpL+C37Lb/T69NzkZGX0a+uAusCXyFbII/v6pbLCY2seenJwe3FL+Xg5vAtNQw5/GchY/LRACu+7l/uF0m/9OHx/K9iTnU/b/qlYNTr/Xk+fw0/LWj1oL+2D8OK/JfeL0L+IvgvvV+U/vDmv2j5i+I/Sw3GCvxX0vee9M/wX6pvRvRnCf9q++Vd86LPUwNzbNOogQE+eSSiIy8CIzUv2pMz+537kZqBkie1FPko9X92zYAVP0d/zZPqTX9r/HrxdWQgsmZAR3486J95/zX6W/xn7f/smgGP8cvJh7f+GOW/Ev29kdtV5C8dg1ok2EP+Uv7zoF/uESF/Lf7roX/W/nnhW2peajWvkZGX13kiMNsAEZgFVpFXt9QjcUbkRX63PDdyvhS5efanPGQ5/JLnJ0dPDb/kSe3F1/23PG9e9Lc8qdb+9f286deePY/nr3lSPeiXPrzeX0/kbDX+83z+M/mvFDlblf/0/SL0hzf/1e63Kv9Fy9+b3shEjkb516o/Z/hf7wMzQv/b/QIjL6/n7dw2grb+GBCBAX56JB5eoBMiLwKfoimFyEta86I9OfIVlEc/v/r1P2Q9Ry1PUsvz1PKk9kRuap7U3v5H6S/1P4ovx9bx6+2/lBM+Q396v9H3X+s/rRnwGH9Ntwf/jvLf7Ph702/lvxb9L94IlL8Z/tP0CwjfRYz/W0TDSf5Sus/kn1H6W5EuL/pfMKE/cl+bzNWojOgvy/PnIi89kZjnvYIjL6/riMBsA0RgFlhFrroPTFTkJZcDa428pJ69En6pv97+LTUwI/23PG8e9PfWwPT2X6pB8KRfRwZm35/n89fwSznlo/RbahBW4L9STrwn/d78V4ucrcp/0fIXxX+1GpgV+c9SA+PBf7P6Q/BH9edI/xH2S85bji34RGCObRoRGCDrkYiMvAiIZ8ZS8yIgf6t5js6uGejBz3lSz9xnIBsJGtxn4eyagVH6V6kZsNJ/ds2AlX9XqxkYof8M/ZGLps3oj97I2Sz9mv+86J95/zX6W/xn7T/lswj5y/FfribFQn8pQje6z0sv/aM1L2nkZhSskRsiMPsAEZgFVpFXt9QjcUbkRX63Ii89ObSCL3/X9+/FT68v4ec8qRZ83X/L8+tFf82TOtJ/er8I+i053L3PX/KketFf+prQKP29NQgr8Z/n85/Jf7WvMa3If+n9ovSHN/+V7rcy/0XLX8p/qb7T/DijP1NeseBHyq/G1+fld8/xSOSGCMyxTWtB84qrH4Dmv4DpxlPKI6cwevAfCkxaunhJr02P5VpR/tpQptfnjnP4r79V8HMFlxZ8OZ7Ft9Iv13j1H03/2wTNoX99v9H3X8PX/cyOX+1+EfR7vP/e54/qfxRfP0OE/On3Oku/LD6j3n+N/0bo17ozgn895a92P2/632hSem+E/pz+tOq/Wv81/Jy9rtnv3LUz848uPIr4f+zSWMAs8BJWrYGJirwIviiuUuRF46eKTvBFgeY8Pz34uetL+G+GYQBf958aoyj6pQ+P538zkA7PX8IXer3en+fz1/BTY+9Bv9zPi3+j+a90P0/6vfkvlY8o/eHNf9HyF8V/6f2i5M+T/1J9H6U/avw3Ov5yP02/dfx7+o+wX3J97XimZoYFzLFNowYGMOeEeu0TM1Lzor92Ys3Z9awZaNU8zOZsR9cMjNB/Zs3AbM1JqabmrJqBs2tmzuY/Td/ZNQO977/1/CndEfqjxH+z9J9R89eqebLQ/+I19unq3qcrZ98s+wRpfKv+rvWfnh+pecmd7wGPr5U9oXO+A6wL1MAssIpcOYUsIvIiv1uRFzkueW5Sb5NcZ8WveY40vvZ8WvF1/y3Prxf9Jc/bKP3aM+dNv/akejx/LnLmSX/NkzpCf0/kbDX+83z+M/mvFDlblf+0Zz1Cf3jzXy5y5k2/N/9Fy186zrVIhlV/65Q0jW+Vn1r/6bnR91d6Hu/Iy+v5SSH7sUsjhWyBl3B16xVor5qXnMJLldjjt7T0WC9+nvdUhjyX05viW3KUe/HlGit+K8fai36dMz1Lv77em35tgGfHP508Rbz/HN2z/JO7nzf9uo9Z/h99fiv9ml4v+iPlr8Z/I/KX8l2E/rDwXw/90fI3w38l+qPlT+uN0fHLyYPWnxrfyj+9789qv/Vvy/zB2gSfBcyxTWMBs8BLuEMNjGfkReP35NDmPDfiHRrFTxVsD35qaEbwdf+poYmiP508zT5/atQ9nr+EL/f3en+ez1/DT425B/1yPy/+jea/0v086ffmv/R+UfrDm/+i5S+K/9L7RcmfJ/+9LSyC9IeF/3rHL71fSr/GL+krS/8R9kvOa/zaeQs+C5hjm0YNDNCsgfGqedH4f/GPf/r8PZIzKzUz1u/cf/V9Bmr4PfS3crY96B+tWbGO/9k1A1b8s2sGPOh/0Rw0/jX+G6Ff0z3z/s/iHy0fkTV/Fv5r0V86zz5dP6FH/7bsT8ofrX1mZveJEfzRmhf5W60GxqPmJcVnH5h9gBqYBVaRK9fAPP+efC77Ffn4+NvL01P4xHYN/+Xp+jj/Fjn4OP/yvBY+360jItoTZMm5beFrz6cVX/ff8rx50V/y3I3Sr+/nTf9bCoTT8+ciZ570lzypo/T3RM5W4z/P5z+T/2qe6BX5T98vQn94818ucuZNvzf/Rcvf2zgXIhkj/J/TnyX7nN7vAcX3V7j+LUqnoHf8S+PpHXl50U8NzI9dGhEYoOiREM+FrHK/ffv2jJz86n/5h9dxbkUsfy/hPyMnP34cf/Zf/+o/vEcfv1NPzBPn2/HCl2slcvPPf/13z7+JR+gRkXn+PeM5ann6Wp6n1texWp7LVqSht/9R+qWPXvwW/SnNlvGz9P+ED8/hCH5Kv0DJ0+hB/xvdne8/6vl76S/x3yj9pciZN/0pzTPylxuDKPmTcfGSv9c1AfKnPfez8teKdHnRn8rOrPzN4Fvp1++zp/9U7/ToD7HLb1+n/JPfHMf/+O+fjnP0N/E/7HEu8iLHpUyL9Fxk5GX0q6vAukAEZoFV5NUt55F4yxn9AB1tSe+Rnmvhy99enuCC5ye9ViI3vTm4Oc9Lbw5uCd9SA9PTf8vz5kF/zfM5Qn9vDcIM/eL59Hp/ns9fw38rKHagvxU5W43/tOfXW/4i+K8WOVuV/6LlL4r/LDUwK/BfK3J2Nf+VIoep/kyjJZ/wVeZDeqz7L+G/xjuZD8yOf1Tk5XWOCMyPXRoRGOCTR+JTzuiPH8cf/+//8hZ5SSMtn1bEH5GTHP4rOpNEXR7eG/n7y/Pz43idT6/RnpzWd+ojagaakOxT0QNn1Qx40x9dMzAMBfrPqBmo9T9C/xk1A7X+Z+iPqBmp0j1Jf5T+MMvgpvInNN9J/oTmCPkr6mdH+XvZR2U/n3JUiMBk5beBn2ZStGpeajWvkZGX13kiMF8mAvOL0ygBlgAt/I+UrQeUCvbl/AvU4kXj6+sfqV8COuws5x9NFk0PRaoL/x7///Hf/+YNXwoL5f7p8eO6x/ED73H8+D81PjX8Rz8p6GNtfFrXP44t/Vvp7+l/hP7R8euh3zp+Fvpn338J3zp+vfR782+KPzJ+PfTfTf7k/pH6wzJ+vfRHyV+qf+8if3LeW/5S/oig/xM405+C2M/npO9PfvO0qQ98WVyl+CX+1frjAfIcsnh5+saT63P4gqfPl+YfvcdWfGBv+PYRGixfkPHCA/eCl0fiuf74/LUwHTkpRWCeO9w+AjDJ32v4ugYm9dxITq3Utgik14sn6KFMn/38+h+ynq+WJ6zlOQOf8YN/kB/0B/ozyn7UvhbpgZ/WjPbg6xqbHP7jb7pmRttvqXFJ7XcuEvOkJTjy8rqOCMw2QA3MAnl8q+4Dk9a1fMoxVTUwr5zb5GslJfz0KyWvY7XJlcb59PUW+cpJJuc5l1PbysEFn/GDf5Af9Af680z7kdqv2j5SPf3n8Gs1MJ/wdU2M+sJYtQYm8/zpHMEyfnLecmzBpwbm2KZRAwNkPRLpPi/ZaEvma2Pp32v4smp+1cBkcmbTnNv0tz5v2eckOmccfMYP/kF+0B/oz1770dqnZaTmMcV/RViSmtMSvq6JaeG/1cyomlWdKfGAUiRGpy1awRq5IQKzDxCBWWAVudo+MDryoT0psvLVkZfid+YL+KnnJYcrnhyJyOjzaf9ynf6aS83zk+Kn14PP+ME/yA/6A/15hf3QkZQZfP2VsBp+DtL75WxwDb+Xfn0+KvLymo/wFbIfu7QWNK+4+gFosRtZVvGU8sgpjB78hwKTJvipUtPHcq2Ezd8WOonyfvaROc7hv/4GPuMH/yA/6A/054X2Q/9/NX76fw0/Z69r9jt37cz8wzrfYf543HoMWMAs8BJWr4GR45bno3Z9Dl9/Bz5dvLRygNMdnkuerx783PXgM37wD/KD/kB/RtuPmv2q7cPT039tH5te/LT/t5qYQPvbO3+wXE8NzLFlawFfIfvCNTClzyfnck7Tmpdmfx/4aU7s42tjD/zWd+I/fe1kMmc4dx58xg/+QX7QH+jPaPvRsl+z+5x545dqdnr3edH2W5+3zB9G4fm11Ack8x3gnkANzAKryBVrYNLmHXmR363ISy6HVufMyi7GvTUwtZxb8Bk/+Af5QX+gP8+yH2lUoycSYu0/jcKM0q/x34476G+Nn6UGxuNrZaSQHds0UsgWeAmrFvG3lEfummo/Cr9U86JzanXObHp9GiKXY53Tq3N2c/i5HGHwGT/4B/lBf6A/r7Yfz4XIQvilGhur/da/LfMH8zxHPhhEDcyPXRoLmAVewopF/Dqy4hl50fg9ObQ5z414h0bxLTnM4DN+8A/yg/5Af3raD4v9KtXE1PBfC41B/Fr/Et3xtp+98wfL8dvX0ljA/NilXV4D8/3792e7K+xA/++O768amD/+5X/UvjzgV//LP/zHXitONS8a/y/+8U+fv0dyZqVmJt1JmJx1ctYFqHmi5ouaN2r+Vq95tNova83nc/r2ML2PfV5G4aPmRSC3T4zVfmubX6uB8ah5SfHTmt/fH/efv31l+n/UlyftJc7VKzBa3GeUn16WCyMvEnbORV5e91dfWenBN+UQg8/4wT/ID/oD/RlgP1o1JDl8HQnpwU/t5Ai+0Jri6/qaUftZq4HxjLy8np8IzI9d5s2XR2CA6yH1SDwiMBJZiYq8CL54j3p26JVr08jNA8Qj9YjIPP6e81y1PFUtzxf4jB/8g/ygP9Cfq9iPNBLTg68jPVH4Lfstv9Pr03Ot+YMFSvi5r64C9wQiMAusIq9u2iMhkRcdafGKvPTk4Pbil3Jwc/iWGgbwGT/4B/lBf6A/I+3HjP1KC+hL+HoDSiu+4Kb9p5GYCPtbmj9Yjmv4RGCObRoRGOCTR+LhufjjH/7Lc2QkWuIZeREYqXnRnpzZ79znzoPP+ME/yA/6A/0ZbT+i93mZ3Wcmtw9MLhJjqXmp1byW5g8WaOETgdkHiMAssIq8uqUeidRzIVEP78iL/G55buR8KXKTq4HJ4VtqGMBn/OAf5Af9gf48w36kdSSj9qeGn34G2YpfirzUanhG6H+7X2Dk5fW81MD82KURgQF+eiQeNU2BNS8aPkVTCpGXtOZFe3LEI/To51e//oes56rlyWp5vsBn/OAf5Af9gf6Msh96h3tv/FokJoefw6vh1yIvPZGY572CIy+v66iB2QaIwCywiry65TwSkZGXXA6sNfKic4hz+KX+evsHn/GDf5Af9Af6M8p+pParVJPSy385/FoNTAlfIi0v256JvETa3575xkzNDBGYY5tGBAbIeiQiIy8C4pmx1LwIyN9qnidqXqj5oeaJmi9q3qj5W7XmsRb5GOm/VbPijS/0j9a86K+VjYA1ckMEZh8gArPAKnK1fWCiIy/yuxV56coh/sCXv+dqbHpzbsFn/OAf5Af9gf680n7oSMoMfqsGJlfzoiMx0c9f2wfGM/Iix0Rgjm1ac59KNrL8uhtZNvGU8sgpjB78hwKTli5e0mvTY7lWwt6pokyV97OPzHEO//U38Bk/+Af5QX+gPy+0H/r/WXydSqbx9UJntP+cva7Z79y1M/MP63zn6rkX7ZgaAxYwMFGxBiYq8iL4aQ5sLvKi8XOem9J36Hvxc9eDz/jBP8gP+gP9GW0/avYr/cLXSP/pF850DUyKX6p56ek/wv6Ozj96j1nAHNssnKiBAcw5oaM1Lxp/pOZFf+1kNmc4dx58xg/+QX7QH+jPaPsxu09Lq3+vfV5a+CM1L6V9YHrnD6PwwH9C53wHWBeogVlgFblyCllE5EV+tyIvuRxanTMr3qLeGphazm0L/+nR+gibS0s9XT3HOfze/kfpb/U/Qv/I+PXSbx2/3uPZ91/Dn3n/rWMv/tX4Xvzb4mdv+r3lL02TuYv8Cc1R+iNC/gQ/Qv56+Xkl+UvHOUJ/SISkpP+0vJbkV3BL9M++v9J45o49vlZGBObYphGBAbojMF6RF4GHB6Yn8qK/VlbaB+Zxn5znS47Fc1T6jn3Jc6bxh+HjazMarP1b6W/1P0K/eN1Gxq9Fv3X8rPTPvv/iPgqG8bOAN/++PKkpb/RAJ/13kz+h+U7y94DUY+6tP7K8sbD8dfHzYvLX1HeT9OsISjr+qd5qfW0sh196fqv91r9r4LVPDF8h2weIwCywirxDDYxn5EXj9+TQ5jw34h0axbfkMOc8n1Z83X/qKYuiv+b5HKE/55n0pl97Amffn+fz1/BLnvxR+muezxX5r3Q/T/q9+a8WOVqV/6LlL4r/0vtFyZ8n/5UiF570W/ivd/zS+6X0v34r/pnpP8J+yXmNXztvwScCc2zTiMAATY+Ed+RF8P/iH//0+XskZ1YiN9bv3M/kLAuUcpblXG//ApH0W/bJ6aFf0x1RMyR9WPGt4+9N/2z/Gv/Fa0H0a/7zoP9Fc2DNQIn/RujXdM+8/7P4R8tHVM2elf9a9JfOe47fDP9p+l4QuM+YjsD06N+W/Un5o7XPjNc+MaM1L/K3WgTGK/IyWvMLrAtEYBZYRa5cA3Nl5OXp4SlEXl73VxGRHvxSzm0LP5cTPUJ/r+fLi/6S526Ufn0/b/rfcridnj8XOfOkv+RJHaW/J3K2Gv95Pv+Z/FeKnK3Kf5YamFX4r1RTsjL/Rcvf2zgXIhkj/J/Tn7pGZkb+3yJzjRqYnvErjad35OVFP59R/rFLIwIDFD0SUZEXwRfvUc8OvXJtGrl5gHiEHhGZx99znqPeHGU5LuGnXskavlzT6r90P2/6pY9e/Bb9Kc2W8bP0/4RCzrWVfoFajvcs/Tr/vuf9Rz1/L/0l/hulvxQ586Y/pXlG/nJjECV/Mi5e8ve6JkD+tOd+Vv5akS4v+lPZmZW/GXwr/fp99vSf6p0e/VH7utgI/SX8lv2W3+n1pRoY78jL6+9EYLYBIjALrCKvbjmPRGTkpZUDK56bHvya50rj9+bglvAtNTA9/bc8bx701zyfI/T31iDM0C+eT6/35/n8NfzUk+9Bfytythr/ac+vt/xF8F8tcrYq/0XLXxT/WWpgVuC/VuTsav4rRQ5T/ZmjX0diVtEf0ZGX1zkiMD92aURggE8eiejIi8BIzYv25ORygs+qGeiNfJT6v7pmYIT+M2sGWuPXi39VzYAX/TPvv0Z/i/+s/Z9dM+Axfjn58NYfo/xXor83cruK/KVjUIsEe8hfyn8e9Ms9IuSvxX899LfsX6lmpRe/h355p701L7Wa18jIy+s8EZhtgAjMAqvIq1vqkTgj8iK/W54bOV+K3OQ8TDn83pzbFn5PDrel/5bnzYt+Sw1MT/+1HGwP+rVnz+P5e2sQRulPawY83l9P5Gw1/vN8/jP5rxQ5W5X/ajUwq/Jfbw3MSvwXLX9veiMTORrl37f7ffxfe54Z/tc1MCP0v90vMPLyel4iMD92aURggJ8eiYcX6ITIi8CnaEoh8pLWvGhPjniUHv386tf/kPUctTxJLc9Ty5PaE7mpeVJ7+x+lv9T/KL4cW8evt/9STvgM/en9Rt9/rf/a195G6Nd0e/DvKP/Njr83/Vb+a9H/4o1A+ZvhP02/QOpR9x7/t4iGk/yldJ/JP6P0tyJdXvS/YEJ/pPpH81sp0tKrvyzPn4u89ERinvcKjry8riMCsw0QgVlgFbnqPjBRkZdcDqw18pJ69kr4pf56+7fUwIz03/K8edDfWwPT23+pBsGTfh0ZmH1/ns9fwy/llI/Sb6lBWIH/SjnxnvR7818tcrYq/0XLXxT/1WpgVuQ/Sw2MB//N6o/c18Us+n+k/wj7JectxxZ8IjDHNo0IDJD1SERGXgTEM2OpeRGQv1n2OYmuGejBX32fgZ7nv6pmYJT+VWoGrPSfXTNg5d/VagZG6D9Df+SiaTP6ozdyNku/5j8v+mfef43+Fv9Z+0/5LEL+cvxXi5T00F+K0I3u89JL/2jNSxq5GQVr5IYIzD5ABGaBVeRq+8BER17kdyvy0pNDK/jyd33/Xvz0+hJ+zpNlwdf9tzy/XvTXPKkj/b/tAxBAv6UGpvf5S55UL/pLXxMapb+3BmEl/vN8/jP5r/Y1phX5L71flP7w5r/S/Vbmv2j5S/kv1XeaH8/Wn7P9W59fn5ffPccjkRsiMMc2rQXNK65+AFrsRpZVPKU8cgqjB/+hwKSli5f02vRYrhXlrw1len3uOIf/+lsFP1dwacGX41l8K/26kHN1+t8maA796/uNvv8avu5ndvxq94ug3+P99z5/VP+j+PoZIuRPv9dZ+mXxGfX+a/w3Qr/WnRH86yl/tft50/9Gk9J7I/S39Gfv+x/Bz9nrmv3OXTsz/+jCo4j/xy6NBcwCL2HVGpioyIvgi+IqRV40fqroBF8UaM7z04Ofu76E/2YYBvB1/6kxiqJf+vB4/jcD6fD8JXyh1+v9eT5/DT819h70y/28+Dea/0r386Tfm/9S+YjSH978Fy1/UfyX3i9K/jz5L9X3Ufqjxn+j4y/3m31/PfgR9kuurx3P1MywgDm2adTAAOacUK99YkZqXvTXTqw5u541A62ah9mc7eiagRH6z6wZmK05KdXUnFUzcHbNzNn8p+k7u2ag9/23nj+lO0J/lPhvlv4zav5aNU8W+l+8xj5d3ft05eybZZ+gGn6v/ajhy/mRmpfc+R7w+FrZEzrnO8C6QA3MAqvIlVPIIiIv8rsVeZHjkucm9TbJdVb8mudI42vPpxVf99/y/HrRX/J8jtKvPXPe9GtPqsfz5yJnnvTXPKkj9PdEzlbjP8/nP5P/SpGzVflPRwYi9Ic3/+UiZ970e/NftPyl41yLZFj1t77frP6v4afnRt9fiR7vyMtLfkgh+7FLI4VsgZdwdesVaK+al5zCS5XY47e09Fgvfp73VIY8l9Ob4ltylHvx5RorfivH2ot+nTM9S7++3pt+nRM+O/7p5Cni/efonuWf3P286dd9zPL/6PNb6df0etEfKX81/huRv5TvIvSHhf966I+Wvxn+K9EfLX9ab4yOX04etP6cHf9efKv91r8t8wdrE3wWMMc2jQXMAi/hDjUwnpEXjd+TQ5vz3Ih3aBQ/VbA9+KmhGcHX/aeGJor+dPI0+/ypUfd4/hK+3N/r/Xk+fw0/NeYe9Mv9vPg3mv9K9/Ok35v/0vtF6Q9v/ouWvyj+S+8XJX+e/Pe2sAjSHxb+6x2/kv6cHf8cfoT9kvMav3begs8C5timUQMDNGtgvGpeNP5f/OOfPn+P5MxKzYz1O/dffZ+BGn4P/a2cbQ/6R2tWrON/ds2AFf/smgEP+l80B41/jf9G6Nd0z7z/s/hHy0dkzZ+F/1r0l86zT9dP6NG/LftT05+zNaMaX+zvaM2L/K1WA+NR85Lisw/MPkANzAKryJVrYK6MvEjYORd5ed1fRUR68PVxb//i2UrD9K1jnfaRu976/Fb6LfT20j8yfr30W8evl/7Z91/Dn3n/Lfq9+Ffje/FvjZ8j6PeWv1LkbGX5S/k5Qn9EyJ+cj5C/Ej+vLH9v4xygP2ryMyt/Kf2z7680nt6Rlxf91MD82KURgQGKHomoyIvgi/enZ4deuTaN3DxAPEKPiMzj7znPUcvT1PI85XbU7oLka0k16O1/lP5hqNCfegq96e/pf4T+UqTLg/4sbzjR78W/pUhXq38rRMmfjvQ0wUB/zfO9ovwJzRHyl/vamyf9EfInv3v6X0X+sjSfRH+qt0boL+G37Lf8Tq9Pz0VGXka/ugqsC0RgFlhFXt1yHonIyEtPDm4vvniaevAtOczgM37wD/KD/kB/RtqPGfvVihyegR9hf0vzB8txDZ8IzLFNIwIDfPJIREdeBEZqXrQnZ/Y797nz4DN+8A/yg/5Af0bbj+h9Ws7Ct9S81GpeS/MHC7TwicDsA0RgFlhFXt1Sj8QZkRf53fLcyPlS5ObZn6ptyOFbcpjBZ/zgH+QH/YH+PMN+pPVMo/bnSnxdAzPS/9v9AiMvr+elBubHLo0IDPDTI/HIXz8h8iLwKZpSiLykNS/akyNfQXn086tf/0PWc9TyJLU8T+AzfvAP8oP+QH9G2Y/a1yLvgF+LvPREYp73Co68vK6jBmYbIAKzwCpy1X1goiIvuRxYa+RF5xDn8Ev99fYPPuMH/yA/6A/0Z5T9SO1XqSall/+uwI+wvz3zjZmaGSIwxzaNCAyQ9UhERl4ExDNjqXkRkL9Z9jmh5oWanxx/UPNEzRP6A/15hf3Q9st7n5ZofKF/tOZFf61sBKyRGyIw+wARmAVWkavtAxMdeZHfrchLVw7uB778PVdj05tzCz7jB/8gP+gP9OeV9kNHQu6Gb33+Uk3R6PyjdUwE5timtaB5xdUPQIvdyLKKp5RHTmH04D8UmLR08ZJemx7LtRL2ThVlqnyffWSOc/ivv4HP+ME/yA/6A/15of3Q/98FP2eva/Y7d+3M/MM632H+eNx6DFjALPASVq2BiYq8CH6aA5uLvGj8nOem9B36Xvzc9eAzfvAP8oP+QH9G24+a/Uq/8DXS/xn4EfZ3dP7Re8wC5timUQMDmHNCvfaJGal50V87mc35zZ0Hn/GDf5Af9Af6M9p+tOzXKvu8tOgfqXkp7QPTO38YhQf+EzrnO8C6QA3MAqvIlVPIIiIv8rsVecnl0Oqc2YcHSO4xgl/zHIHP+ME/yA/6A/0ZZT/0PiqtSMhI/5H4PfS35MdSA+PxtTIiMMc2jRSyBV7C1a1XoL1qXqSVal50Tq3OmU2vTzeylGOd06tzdnP4uRxf8Bk/+Af5QX+gP6+2H88NL2+Ab7Xf+rd1/mGa53zgs4A5tmksYBZ4CXeogfGMvGj8nhzanOdGvEOj+JYcZvAZP/gH+UF/oD897YfFfpVqUq7Ej7C/vfMHy3GKzwLm2KZdXgPz/fv3Z7sr7ED/747vrxqYP/7lbz9d89jh/o9/+C/DfUTi/+p/+j+PP/773zz/J2ednHUBap6o+aLmjZq/1Wsen/uotOBjn5hhCMZ/PMdozYv8rVYD41HzkuKnNb+/P+4/f/vK9P+oL0/aS5yrV2C02BqYyB1yW54bCTvXcmZbObiWnFvwGT/4B/lBf6A/sR/n2d9aDUzE/IMIzLHNvPnyCAyw7lfIvD0fGsR71bNDb+nrJvIVlJrnq+UpA5/xg3+QH/QH+hP7MWc/rfZb7H8uAhM1/7B+dRVYF4jALLCKvLrlPBKRkZeeHNwcviWHuBd/tn/wGT/4B/lBf6A/v6L9iLC/0fMPIjDHNo0IDPDJIxEdeREYzZl9u3byO/e58+AzfvAP8oP+QH9iP+r2M7cPjMV+6/OW+UMJWvhEYPYBIjALrCKvbqlH4ozIi/xueW7kvCUH14o/2z/4jB/8g/ygP9CfX9F+eNjft/udMP8gAnNs04jAAD89Eo+aphMiLwKfoikFz03Nk/PwBLUiJy1PKviMH/yD/KA/0J/Yjzn7abXfb7b8pMwPIjD7ABGYBVaRd9gHJuI77WkObM5zU7o+PX5ttDWIP9s/+Iwf/IP8oD/Qn1/RfkTY3+j5BxGYY5tGBAaY9kiMek7EMzOTM/v8jv7Hd+rJWSdnXYCaJ2q+qHmj5o+ax9iaT7G/o/Zbf61sBKzzDyIw+wARmAVWkSvvAxMReZHfLc9NVw4u+Iwf/IP8oD/Qn9iPW9rP2j4wEfMPIjDHPnNX9oEBRj0SXjmrLc+NPk4jNz2eo5InyYr/OBexw3E0/a3+R+D5BZqg8e8GI/3iMRx9/zX6TXQb6ffi3xL+MBToj5K/T/zsuMP4i6abyF+0/ojcIT5C/gTXBJvKX0p3hPzV8K32W+x/bh+YqPkHEZh9gAjMAqvIO9bAeOSs1r5D38qhFfzSd+h78S39P/p6tcd4Jcf6fOs4xY+kv6f/Ufo93l/ueuv49dI/+/5b+KPvv3a9J/9qfC/+1eej5E/k3Vv+5HyU/rib/PXw8yj9d5M/oTlSf3jLn+bnSPpz8j7Lf3J91PyDCMyxTSMCA5g9EmdFXnr2icntAxOV82v13Lb6F4ikP6U717+V/jNqjoTmnvHroV/uF73Pj9Bjef81+kvnveif5T9NX8pn0Tn3nvKX0h2hP0r8N0t/dM1fi/+s9L94LVD+LPzXol8gep8xzR+z+qNXf3rQn9sHxmK/9fke8Jh/PGGw5hdYB4jALLCKvFMNjOfXQlqem1wOrc6ZTb16I/iW/rXn04qv+295fr3oL3k+R+nXkQFv+rUn3+P5hWbP95fi1zz5I/Sn9/Pi32j+83z+M/lP7hcpf578pyMDEfrDm/9ykSNv+r35L1r+Uv6rRTKu1p/R9rdET9T8gwjMsU1rQfOKqx+AFpNClr1OKQ9zPwo/VVz6t7T0WC9+nvdMJh9ynOKnx+nkxxNfrrHipxORSPrlb1706+u96X+j2WH8ddpFBP9oumf5J3c/b/p1H7P8P/r8Vvo1vV70R8pfjf9G5C/luwj9YeG/Hvqj5W+G/0r0R8uf1hte/GvVn578Y7Xf+rdl/mBtgs8C5timsYBZ4CXcoQYm4jvtqYJr5dCWPDeiYEfxLf2nhsaD/tTQRNGfTp5mnz816l7vL3e93N/r/Xk+fw0/NeYe9Mv9vPg3mv9K9/Ok35v/0vtF6Q9v/ouWvyj+S+8XJX+e/Pe2sAjUH978560/W/LjzX9yXuPXzlvwWcAc2zRqYIBmDUzUDrmSAzuTMytfSTkjZ7xVMyDnevs/u2ZgNue9VFNzVs2AB/0z7z+6f41/ds2AB/0vmgNz7kv8N0K/pnvm/Z/FP6M1EyM1fxb+a9FfOu85fjP8p+l7wUk1f73vv0X/WTV/6VfORu23ngPkwHv+wVfI9gFqYBZYRa5cAxMReZHfLc+NhJ1LnpueHFxLzm0LX3s+rfhWz5sX/SXP5yj9+n7e9L+lQDg9fy5y5kl/yZM/Sn9P5Gw1/vN8/jP5rxQ5W5X/9P0i9Ic3/+UiZ970e/NftPzp97mq/oy2vyV6ouYfRGCObRoRGKDokYiKvAiI96fluUmvld8C8hWUmueo5WnqxS993aXluWxFGqLplz568Vv0pzRHjL/2fI7gp/S3Il0e9L/R3fn+o56/l/4S/43SX/L8etOf0jwjf7kxiJI/GRcv+XtdE6T/0sjtrPy1Il1e9OtIxoz8zeBb6dfv04P+M/RHDt9qv8X+5yIwUfMPIjD7ABGYBVaRV7ecRyIy8tKTg1urmUmPa56rHnxL/5YamJ7+W543D/prns8R+ntrEGboF8+n1/vzfP4a/ltBsQP9rcjZavynPb/e8hfBf7XI2ar8Fy1/UfxnqYFZgf9akTMv+r35z1t/tuTHm/+i5x9EYI5tGhEY4JNHIjryIjCaM/t2bWYfGPYZ8KlZyXmmz6wZyPU/gn9VzYAX/VfVDFj7P6NmwMJ/PfTn5IN9PmL4V47Zp2uPfYLSCOCo/dbnHxA9/yACsw8QgVlgFXl1Sz0SZ0Re5HfLcyPnLTm4VnxL/z053Jb+W543L/otNTA9/ddqEDzo15EBj+fvrUEYpT+tGfB4fz2Rs9X4z/P5z+S/UuRsVf6r1cCsyn+9NTAr8V+0/On3uar+jLa/b/c7Yf5BBObYphGBAX56JB5eoBMiLwKfoikFz03NkyNfQal5jlqepF78kie/52tP2Rz7zq/FzNJf6n8UX46jxr+UEz5Df3q/0fdf67/2tbcR+jXdHvw7yn+z4+9Nv5X/WvS/eCNQ/mb4T9MvkH4Fynv8czVds8+f0n0m/4zSX6oR86b/BU76Q/NbNP0pvtV+p7/PyvwgArMPEIFZYBV5h31gPCMvuRzYnOemdH16XPNc9eBb+q/VwIz03/K8edDfWwPT23+pBsGT/tw+BjP0ez5/Db+2D8xI/5YahBX4r7YPx6r8V4ucrcp/0fIXxX+1GpgV+c9SAzNDvzf/eevPlvx485+ctxxb8InAHNs0IjDAtEdi1HMinpmZnFnLPifRNQM9+DlP6lk1A7r/0ee/qmZglP6WJ/Wsmh0r/WfXDFj5t+X5jcq5H+W/HP1n6I9cNG1Gf/RGzmbp1/znRf/M+6/R3+I/a/8pn61Qc9JLf0l/RtAv8jNqv9PIzShY5x9EYPYBIjALrCJX3gcmIvIiv1uem54c2jPxc57Umf5bnjcv+mue1JH+0/tF0G/J4e59/pIn1Yv+0tesRunvrUFYif88n/9M/qvtA7Mi/6X3i9If3vxXut/K/Bctfyn/lb7mtYL+jMbX5+V31PyDCMyxTWtB84qrH4AWk0LWhaeUh7nfD/yHApMm59Lf+liuFeWf4qeTkWcfmeNR/Fe6SRI2H+l/Ft9Kv1zj1X80/W8TNIf+9f0i+Ef3Mzt+tftdxf8t+nufP6r/UXz9DBHyp9/rLP2y+Ix6/zX+G6Ff684I/vWUv9r9vOl/o8mB/pb+jNQfVvuduzZ6/sEC5timsYBZ4CXcsQbGI2dVFFfJc6PxU0Un+KJAR/Et/b8ZBgf6U2MURb/04fH8bwbS6f3lrhd6vd6f5/PX8FNj70G/3M+Lf6P5r3Q/T/q9+S+Vjyj94c1/0fIXxX/p/aLkz5P/Un0fqT+8+c9bf7bkx5v/5Pqo+QcLmGObRg0MYM4J9fpayGzOrOSXR+bcp+df8JEz36p5mM3Zjq4ZGKH/zJqB2ZqTUk74WTUDZ9fMnM1/mr6Uz6Jz7j3lL6U7Qn+U+G+W/qtrLqz0v3gtUP4s/Neif7bmcbbmb5T+s2r+0q+cjdpvfb4HPOYfTxis+QXWAWpgFlhF3qkGxvNrIS3PjRyXPDe579Bb8S39a8+nFd/qefOiv+T5HKVfe2a96deeVI/nz0XOPOmvefJH6O+JnK3Gf57Pfyb/lSJnq/KfjgxE6A9v/stFzrzp9+a/aPlL+a8Wybhaf0bb3xI9UfMPIjDHNo0IDNAdgfH+TnvuW/DyO/cd+fRrJamnqOU5enmpPjxHpe/Y9+IPQ+I5TiGa/lb/I/SnkQZv+q3jZ6V/9v3n8Kt0T9Lvzb+5r2N1QSf9d5M/oflO8vcA4bsI/ZHljYXlr4ufF5O/pr6bpD+NkETSnx5b7bf+XQOv+QdfIdsHiMAssIq8Qw2MZ+RFzltycEuem94c3Jrnpxc/LZBMPV09xzX8SPp7+h+l3+P95a63jl8v/bPvv4U/+v5rx578W/L8zvJvi5896Y+Qv1Ykapb+u8lfjp+96L+b/AnNkfrDW/40P0fSn5P3Wf6T8xq/dt6CTwTm2KYRgQGaHomoHXLFMzOTM5t6wK/OGQef8YN/kB/0B/rzq9gPsb+j9lvPAXLgPf8gArMPEIFZYBW5cg1MRORFfrc8N08PTyNnNvXqjeDP9g8+4wf/ID/oD/TnV7QfHva3VgMTMf8gAnNs04jAAEWPRFTkRUC8Pz079JZybNMc3ZLnqDfHF3zGD/5BftAf6E/sx5j9tNpvsf+5CEzU/IMIzD5ABGaBVeTVLeeRiIy89OTg1mpmenJwe/Fn+wef8YN/kB/0B/rzK9qPCPsbPf8gAnNs04jAAJ88EtGRF4HRnNm3azP7wKycMww+4wf/ID/oD/TnDvYjtw+MxX7r8w+Inn8QgdkHiMAssIq8uqUeiTMiL/K75bmR85YcXCv+bP/gM37wD/KD/kB/fkX74WF/3+53wvyDCMyxTSMCA/z0SDz2Fjgh8iLwKZpS8NzUPDlv+wAUPEctTxL4jB/8g/ygP9Cf2I85+2m132+2/KTMDyIw+wARmAVWkXfYBybiO+1pDmzOc1O6PpeDO4o/2z/4jB/8g/ygP9CfX9F+RNjf6PkHEZhjm0YEBpj2SIx6TvQOvSM5s8+djD92KL5DzjD4jB/8g/ygP9CfO9gPsb+j9lt/rWwErPMPIjD7ABGYBVaRK+8DExF5kd8tz01XDi74jB/8g/ygP9Cf2I9b2s/aPjAR8w8iMMc+c9cGNK+4+gFoMSlkXXhKeZj7/cB/KDBpci79rY/l2ifNHyHs198+igrl+twx+Iwf/IP8oD/Qn9gPX/tptd+5a6PnHyxgjm3mzSxgFngJd6yB8chZrX2HvpVDK/il79D34s/2Dz7jB/8gP+gP9OdXtB8R9jd6/sEC5timUQMDmHNCvb4WMpszW9oHZuWcYfAZP/gH+UF/oD93sB+5fWAs9luf7wGP+ccTBmt+gXWAGpgFVpF3qoHx/FpIy3OTy6HVObP6O/RW/Nn+wWf84B/kB/2B/vyK9sPD/lpqYDzmH0Rgjm0aKWQLvISrW69Ae9W8SCvlzOqcWp0z25ujm4a405xd8Bk/+Af5QX+gP7EfvvbTar/17zPmHyxgjn3mrhTxX/8S7lADE/GddksObslz05uDW/P8gM/4wT/ID/oD/Yn9uN7+Rs8/WMAc+8xdG/Dt40tjRfj2bTwX8QHfv39/trvCDvT/7vherYGJ2iFXcmBncmZlJ+C75AyDz/jBP8gP+gP9uYP9EPs7ar/1HCAH3vOPtOb398f9529fmf4f9eVJe4lz9QqMFlsDE7lDbk8NTCtntpWDa8m5BZ/xg3+QH/QH+hP7cZ79rdXARMw/iMAc28ybL4/AAOt+hSwq8iIg3p+eHXpLXzeRr6DUPEctTxP4jB/8g/ygP9Cf2I85+2m132L/cxGYqPmH9aurwLpABGaBVeTVLeeRiIy89NSg1GpmenJwe/Fn+wef8YN/kB/0B/rzK9qPCPsbPf8gAnNs04jAAJ88EtGRF4HRnNm3azP7wKycMww+4wf/ID/oD/TnDvYjtw+MxX7r8w+Inn8QgdkHiMAssIq8uqUeiTMiL/K75bnJfUe+lYNrxZ/tH3zGD/5BftAf6M+vaD887O/b/U6YfxCBObZpRGCAnx6JR03TCZEXgU/RlILnpubJka+g1DxHLU8S+Iwf/IP8oD/Qn9iPOftptd9vtvykzA8iMPsAEZgFVpF32Acm4jvtaQ5sznNTuj6XgzuKb+n/0Zc0fSybfJXO144j6e+lZ4R+j/eXw7eOXy/9s++/hT/6/mv0e/KvxvfiX40fJX8i797yJ/hR+uNu8if43vJX4ueV5U9ojtQf3vIn5yPk7wz7K+ctxxZ8IjDHNo0IDDDtkRj1nIhnZiZn9uEBOn75m1Nyfovw0f8wBNJfpXuS/qic68c5E3TSH50zPgwV+iW/PCLnvaf/Efp1TZp3zn2r/1H6o/RHk58Xkz853w0G+lMZv4P8PeCsfca86T+jZkbs76j91l8rGwHr/IMIzD5ABGaBVeTK+8BERF7kd8tz05WDeyJ+zpM/03/L8+tFf82TP9J/er8I+rUn3+P5S55UL/pzns8Z+nsiR6vxn+fzn8l/cr9I+fPkv/R+UfrDm/9K91uZ/6LlL+W/XORyFf0Zja/Py++o+QcRmGOb1tynko0sv2YKWReeUh7mfj/wHwpMmpxLf+tjuVaUf4qfTkaefWSOR/HTEP1M/7P4VvrlGq/+o+l/m6A59K/vF8E/up/Z8avd7yr+b9Hf+/xR/Y/i62eIkD/9Xmfpl8Vn1Puv8d8I/Vp3RvCvp/zV7udN/xtNDvS39Gek/rDa79y10fMPFjDHNo0FzAIv4Y41MB45q6K4Sp4bjZ8qOsEXBTqKb+n/zTA40J8aoyj6pQ+P538zkE7vL3e90Ov1/jyfv4afGnsP+uV+XvwbzX+l+3nS781/qXxE6Q9v/ouWvyj+S+8XJX+e/Jfq+0j94c1/3vqzJT/e/CfXR80/WMAc2zRqYABzTqjX10Jmc2ZL+8CcWTOQy+m25jyfVTOQ699K/xk1R0Jzz/j10C/3O6NmwFKz0qK/dN47536U/zR9KZ9F59x7yl9Kd4T+KPHfLP1n1PzV+M9K/4vXgmt2evmvRb9A9D5jmj9m9Uev/vSgP7cPjMV+6/M94DH/eMJgzS+wDlADs8Aq8k41MJ5fC2l5buS45LnJfYfeim/pX3s+rfhWz5sX/SXP5yj92jPrTb/2pHo8fy5y5kl/zZM/Qn9P5Gw1/vN8/jP5rxQ5W5X/dGQgQn94818ucuZNvzf/Rctfyn+1SMbV+jPa/pboiZp/EIE5tmmkkC3wEq5uvQLtVfMiLVVc+re09Fgvflo5umI4U3xLjm8vvlxjxW/lWHvRr3OmZ+nX13vTr3PCZ8c/nTxFvP8c3bP8k7ufN/26j1n+H31+K/2aXi/6I+Wvxn8j8pfyXYT+sPBfD/3R8jfDfyX6o+VP6w0v/rXqT0/+sdpv/dsyf7A2wWcBc2zTWMAs8BLuUAPjGXmR86mCa+XQljw3omBH8S39p4bGg/7U0ETRn06eZp8/Nepe7y93vdzf6/15Pn8NPzXmHvTL/bz4N5r/SvfzpN+b/9L7RekPb/6Llr8o/kvvFyV/nvz3trAI1B/e/OetP1vy481/cl7j185b8FnAHNs0amCAZg1M1A65kgM7kzMrOwGf+Z3+Us2AnOvt/+yagdmc91JNzVk1Ax70z7z/6P41/tk1Ax70v2gOzLkv8d8I/Zrumfd/Fv+M1kyM1PxZ+K9Ff+m89z5do/yn6btinyAP/XFWzZ/Iz+P/Ufut5wA58J5/sA/MPkANzAKryJVrYCIiL/K75bmRsHPJc9OTg2vJuW3ha8+nFd/qefOiv+T5HKVf38+b/rcUCKfnz0XOPOkvefJH6e+JnK3Gf57Pfyb/lSJnq/Kfvl+E/vDmv1zkzJt+b/6Llj/9PlfVn9H2t0RP1PyDCMyxTSMCAxQ9ElGRFwHx/vTs0Fv6uol8BaXmOWp5mnrxS193aXkuW5GGaPqlj178Fv0pzRHjrz2fI/gp/a1Ilwf9b3R3vv+o5++lv8R/o/SXPL/e9Kc0z8hfbgyi5E/GxUv+XtcE6b80cjsrf61Ilxf9OpIxI38z+Fb69fv0oP8M/ZHDt9pvsf+5CEzU/IMIzD5ABGaBVeTVLeeRiIy89OTg1mpm0uOa56oH39K/pQamp/+W582D/prnc4T+3hqEGfrF8+n1/jyfv4b/VlDsQH8rcrYa/2nPr7f8RfBfLXK2Kv9Fy18U/1lqYFbgv1bkzIt+b/7z1p8t+fHmv+j5BxGYY5tGBAb45JGIjrwIjObMvl2b2QeGfQZ8alZynukzawZy/Y/gX1Uz4EX/VTUD1v7PqBmw8F8P/Tn5YJ+PGP6VY/bp2mOfoDQCOGq/9fkHRM8/iMDsA0RgFlhFXt1Sj8QZkRf53fLcyHlLDq4V39J/Tw63pf+W582LfksNTE//tRoED/p1ZMDj+XtrEEbpT2sGPN5fT+RsNf7zfP4z+a8UOVuV/2o1MKvyX28NzEr8Fy1/+n2uqj+j7e/b/U6YfxCBObZpRGCAnx6JhxfohMiLwKdoSsFzU/PkyFdQap6jliepF7/kye/52lM2x77zazGz9Jf6H8WX46jxL+WEz9Cf3m/0/df6r33tbYR+TbcH/47y3+z4e9Nv5b8W/S/eCJS/Gf7T9AukX4HyHv9cTdfs86d0n8k/o/SXasS86X+Bk/7Q/BZNf4pvtd/p77MyP4jA7ANEYBZYRd5hHxjPyEsuBzbnuSldnx7XPFc9+Jb+azUwI/23PG8e9PfWwPT2X6pB8KQ/t4/BDP2ez1/Dr+0DM9K/pQZhBf6r7cOxKv/VImer8l+0/EXxX60GZkX+s9TAzNDvzX/e+rMlP978J+ctxxZ8IjDHNo0IDDDtkRj1nIhnZiZn1rLPSXTNQA9+zpN6Vs2A7n/0+a+qGRilv+VJPatmx0r/2TUDVv5teX6jcu5H+S9H/xn6IxdNm9EfvZGzWfo1/3nRP/P+a/S3+M/af8pnK9Sc9NJf0p8R9Iv8jNrvNHIzCtb5BxGYfYAIzAKryJX3gYmIvMjvluemJ4f2TPycJ3Wm/5bnzYv+mid1pP/0fhH0W3K4e5+/5En1or/0NatR+ntrEFbiP8/nP5P/avvArMh/6f2i9Ic3/5XutzL/Rctfyn+lr3mtoD+j8fV5+R01/yACc2zTWtC84uoHoMWkkHXhKeVh7vcD/6HApMm59Lc+lmtF+af46WTk2UfmeBT/lW6ShM1H+p/Ft9Iv13j1H03/2wTNoX99vwj+0f3Mjl/tflfxf4v+3ueP6n8UXz9DhPzp9zpLvyw+o95/jf9G6Ne6M4J/PeWvdj9v+t9ocqC/pT8j9YfVfueujZ5/sIA5tmksYBZ4CXesgfHIWRXFVfLcaPxU0Qm+KNBRfEv/ucmDNH2+ddzjefOgv6f/Ufo93l/ueuv49dI/+/5b+KPvv3a9J/9qfC/+1eej5O9tghZAf5T+uJv89fDzKP13kz+hOVJ/eMuf5udI+nPyPst/cn3U/IMFzLFNowYGMOeEen0tZDZnVvLLI3Pu0/Mv+MiZHwaFf1bNgDf9Z9QM1Pq3whk1A11goP+MmgEzNOiPrBlIa1a86Y/SH594Y3H5K9W8edBf+9rbivL3ojmw5sVEu4H+M2p2xP6O2m99vgc85h9PGKz5BdYBamAWWEXeqQbG82shLc+NHJc8N7nv0FvxZ/sHn/GDf5Af9Af68yvaDw/7W6Inav5BBObYppFCtsBLuLr1CrRXzYu0Us6szqnVObPp9aJA0+MUPz3WBbvgM37wD/KD/kB/Yj987KfVfuvfZ8w/WMAc+8xdKeK//iXcoQbGM/Ii5y05uCXPTW8Obs3zAz7jB/8gP+gP9Cf243r7Gz3/YAFz7DN3bcC3jy+NFeHbt/FcROAeNTBRO+RKDuxMzmy6E/rV3+kHn/GDf5Af9Af686vYD7G/o/ZbzwFy4D3/YB+YfYAamAVWkSvXwEREXiw1MK2c2VYOriXnFnzGD/5BftAf6E/sx3n2t1YDEzH/IAJz7DN3JQIDlDwSUZEXAfH+9OzQW/q6iXwFpeY5anmawGf84B/kB/2B/sR+zNlPq/0W+5+LwETNP4jA7ANEYBZYRV7dch6JyMhLTw1KrWamJwe3F3+2f/AZP/gH+UF/oD+/ov2IsL/R8w8iMMc2jQgM8MkjER15ERjNmX27NrMPzMo5w+AzfvAP8oP+QH/uYD9y+8BY7Lc+/4Do+QcRmH2ACMwCq8irW+qROCPyIr9bnpvcd+RbObhW/Nn+wWf84B/kB/2B/vyK9sPD/r7d74T5BxGYY5tGBAb46ZF4fFXuhMiLwKdoSsFzU/PkyFdQap6jlicJfMYP/kF+0B/oT+zHnP202u83W35S5gcRmH2ACMwCq8g77AMT8Z32NAc257kpXZ/LwR3Fn+0ffMYP/kF+0B/oz69oPyLsb/T8gwjMsU0jAgNMeyRGPSfimZnJmX14gI5f/uY2OcPgM37wD/KD/kB/7mA/xP6O2m/9tbIRsM4/iMDsA0RgFlhFrrwPTETkRX63PDddObjgM37wD/KD/kB/Yj9uaT9r+8BEzD+IwBz7zF0b0Lzi6gegxaSQdeEp5WHu9wP/ocCkybn0tz6Wa580f4SwX3/7KCqU63PH4DN+8A/yg/5Af2I/fO2n1X7nro2ef7CAObaZN7OAWeAl3LEGxiNntfYd+lYOreCXvkPfiz/bP/iMH/yD/KA/0J9f0X5E2N/o+QcLmGObRg0MYM4J9fpayGzObGkfmJVzhsFn/OAf5Af9gf7cwX7k9oGx2G99vgc85h9PGKz5BdYBamAWWEXeqQbG82shLc9NLodW58zq79Bb8Wf7B5/xg3+QH/QH+vMr2g8P+2upgfGYfxCBObZppJAt8BKubr0C7VXzIq2UM6tzanXObG+ObhriTnN2wWf84B/kB/2B/sR++NpPq/3Wv8+Yf7CAOfaZu1LEf/1LuEMNTMR32i05uCXPTW8Obs3zAz7jB/8gP+gP9Cf243r7Gz3/YAFz7DN3bcC3jy+NFeHbt/FcxAd8//792e4KO9D/u+N7tQYmaodcyYGdyZmVnYDvkjMMPuMH/yA/6A/05w72Q+zvqP3Wc4AceM8/0prf3x/3n799Zfp/1Jcn7SXO1SswWmwNTOQOuT01MK2c2VYOriXnFnzGD/5BftAf6E/sx3n2t1YDEzH/IAJzbDNvvjwCA6z7FbKoyIuAeH96dugtfd1EvoJS8xy1PE3gM37wD/KD/kB/Yj/m7KfVfov9z0VgouYf1q+uAusCEZgFVpFXt5xHIjLy0lODUquZ6cnB7cWf7R98xg/+QX7QH+jPr2g/Iuxv9PyDCMyxTSMCA3zySERHXgRGc2bfrs3sAxOV89sNv/zNE78XIuk30W2kPzrnehgK9EfnjLf6H6Ff+ojIee/pf4b+qJz73v6tEKU/zDK4qfwJzXeSP6E5subkE38sLH8aP7cPjMV+6/MPiJ5/EIH5OhGYX5xGCbAEaOH/1z/89u1869iK//d//i/FsLOc19frwr/H/6nyfeBLYaHgp8eP6x7HDzzpvxf/j//+N2/06GNtfFrXP44j6e/pf4T+0fHrod86fhb6Z99/Cd86fr30e/Nvij8yfj30303+5P6R+sMyfr30R8lfqn/vIn9y3lv+Uv6Iot8yfivpj9T+jtpvff7s+QewN1AD8wXg5ZF4vPATIi8Cn6IpBc9NzZMjX0GpeY5anqRefPGUWfFLnnR9vyj6S/2P4stx1PgLpBGkWfrT+42+/1r/z8hAwfM5Qr+m24N/R/lvdvy96bfyX4v+F28Eyt8M/2n6BYTvIsZfRwU85C+l+0z+GaVf44723x0JddIfmt+i6deLH4v9Tn+flflBBGYfoAZmgTy+O+wDE/Gd9jQHVm9yVbs+l4M7im/p/9GXfHXFg365XyT90ofH88t46/t50y/393p/ns9fw083dfOgP/3CTwT93vyX3i9C/iL4T+4XqT+8+S9a/qL4r3S/VfmvpO+96ffmP2/92ZIfb/6T85ZjCz41MMc2jRoYYNojMeo5Ec/MTM5szfPtnfM7W7MiuHL+ipqBbCRosGYiumagNX69/bc8qZ41Az2e/t7+z64ZsPJvy/PrLX86MjArf63ImRf9uWjajP7ojZzN0q/5z4v+mfdfo7/Ff9b+Uz5bYZ+WXvpL+jOCfpGfUfudSzuLnn8QgdkHiMAssIpceR+YiMiL/G55buS45LnR/Ufj5zypM/23PG9e9Nc8qSP9p/eLoF97Uj2ev+RJ9aI/jQx4vL+eyNlq/Of5/GfyXylytir/pfeL0h/e/Fe638r8Fy1/Kf/VdrS/Wn9G4+vz8jtq/kEE5timNfepZCPLr5lC1oWnlIe53w/8hwKTJufS3/pYrhXln+Knk5FnH5njUfxXukkSNh/pfxbfSr9c49V/NP1vEzSH/vX9IvhH9zM7frX7XcX/Lfp7nz+q/1F8/QwR8qff6yz9sviMev81/huhX+vOCP71lL/a/bzpf6PJgf6W/ozUH1b7nbs2ev7BAubYprGAWeAl3LEGxiNnVRRXyXOj8VNFJ/iiQEfxLf2/GQYH+lNjFEW/9OHx/G8G0un95a4Xer3en+fz1/BTY+9Bv9zPi3+j+a90P0/6vfkvlY8o/eHNf9HyF8V/6f2i5M+T/1J9H6k/vPnPW3+25Meb/+T6qPkHC5hjm0YNDGDOCfX6Wshszqzkl0fm3KfnvffpuLpmYIT+M2sGZmtOSjnhZ9UMnF0zczb/afpSPovOufeUv5TuCP1R4r9Z+q+uubDS/+K14H26evmvRf9szeNszd8o/WfV/KVfORu13/p8D3jMP54wWPMLrAPUwCywirxTDYzn10Janhs5LnlunseJV28E39K/9nxa8a2eNy/6S57PUfq1Z9abfu1J9Xj+XOTMk/6aJ3+E/p7I2Wr85/n8Z/JfKXK2Kv/pyECE/vDmv1zkzJt+b/6Llr+U/2qRjKv1Z7T9LdETNf8gAnNs00ghW+AlXN16Bdqr5kVaqrj0b2npsV78tHJ0xXCm+JYc3158ucaK38qx9qJf50zP0q+v96Zf54TPjn86eYp4/zm6Z/kndz9v+nUfs/w/+vxW+jW9XvRHyl+N/0bkL+W7CP1h4b8e+qPlb4b/SvRHy5/WG178a9Wfnvxjtd/6t2X+YG2CzwLm2KaxgFngJdyhBsYz8iLnUwXXyqEteW5EwY7iW/pPDY0H/amhiaI/nTzNPn9q1L3eX+56ub/X+/N8/hp+asw96Jf7efFvNP+V7udJvzf/pfeL0h/e/Bctf1H8l94vSv48+e9tYRGoP7z5z1t/tuTHm//kvMavnbfgs4A5tmnUwADNGpioHXIlB3YmZzbdCf2MfT7uts+ApWalh/5cTc1ZNQNX7zMR3b/GP7tmwIP+F82BOfcl/huhX9M98/532+fDyn8t+kvnv/I+XWnNSu/7b9F/Vs2fyM/j/1H7recAOfCef7APzD5ADcwCq8iVa2AiIi/yu+W5kbBzyXPTk4Nryblt4WvPpxXf6nnzor/k+RylX9/Pm/63FAin589FzjzpL3nyR+nviZytxn+ez38m/5UiZ6vyn75fhP7w5r9c5Mybfm/+i5Y//T5X1Z/R9rdET9T8gwjMsU0jAgMUPRJRkRcB8f707NBb+rqJfAWl5jlqeZp68Utfd2l5LluRhmj6pY9e/Bb9Kc0R4689nyP4Kf2tSJcH/W90d77/qOfvpb/Ef6P0lzy/3vSnNM/IX24MouRPxsVL/l7XBOm/NHI7K3+tSJcX/TqSMSN/M/hW+vX79KD/DP2Rw7fab7H/uQhM1PyDCMw+QARmgVXk1S3nkYiMvPTk4NZqZtLjmueqB9/Sv6UGpqf/lufNg/6a53OE/t4ahBn6xfPp9f48n7+G/1ZQ7EB/K3K2Gv9pz6+3/EXwXy1ytir/RctfFP9ZamBW4L9W5MyLfm/+89afLfnx5r/o+QcRmGObRgQG+OSRiI68CIzmzL5dm9kHhn0GfGpWcp7pM2sGcv2P4F9VM+BF/1U1A9b+z6gZsPBfD/05+WCfjxj+lWP26dpjn6A0Ajhqv/X5B0TPP4jA7ANEYBZYRV7dUo/EGZEX+d3y3Mh5Sw6uFd/Sf08Ot6X/lufNi35LDUxP/7UaBA/6dWTA4/l7axBG6U9rBjzeX0/kbDX+83z+M/mvFDlblf9qNTCr8l9vDcxK/Bctf/p9rqo/o+3v2/1OmH8QgTm2aURggJ8eiYcX6ITIi8CnaErBc1Pz5MhXUGqeo5YnqRe/5Mnv+dpTNse+82sxs/SX+h/Fl+Oo8S/lhM/Qn95v9P3X+q997W2Efk23B/+O8t/s+HvTb+W/Fv0v3giUvxn+0/QLpF+B8h7/XE3X7POndJ/JP6P0l2rEvOl/gZP+0PwWTX+Kb7Xf6e+zMj+IwOwDRGAWWEXeYR8Yz8hLLgc257kpXZ8e1zxXPfiW/ms1MCP9tzxvHvT31sD09l+qQfCkP7ePwQz9ns9fw6/tAzPSv6UGYQX+q+3DsSr/1SJnq/JftPxF8V+tBmZF/rPUwMzQ781/3vqzJT/e/CfnLccWfCIwxzaNCAww7ZEY9ZyIZ2YmZ9ayz4lXzcAn+Oh/GE6qGfCmP7pmoBs66T+jZmcIKvSfXTPgQX8p0uCVc9/qf5T+KP3R5OfF5E/Od4OB/mwkemH5e4Do0bvpjzNqZsT+jtrvNHIzCtb5BxGYrxOB+cVplABLwL/+4bemY608rPhaef39n//Lm3J7HIvie/z9cfwGH8rzoUxTfFG+gv84TvHleum/B/8Bf/z3v6kaD32+dRxNf0//I/SPjF8v/dbx66V/9v3X8K3j10u/J//m8D34V+NHyd/j7xHyJ5+KHRm/Hvqt42ehP0L+0oJqb/0RJX8l/exBf6T86cWLJ/0R8pfTHzP2+9H/n/3tX102/wA2h1aI5uoQEi0mhawLT4Vtzf1+4D9CyNLkXPpbH8u1kjaQ4qdpPM8+MsfgM37wD/KD/kB/Yj987afVfueujZ5/kEJ2bDNvbq5PWMB8ASYYqIHxyFlNc2D111BaObSCX/oOfS/+bP/gM37wD/KD/kB/fkX7EWF/o+cfLGCObRo1MIA5J9TrayGzObOSXx6Zcw8+4wf/ID/oD/Qn9iP/tTq9D4zFfuvzlvnDKDzwnzBY8wusA3yFbIFV5NUt9UicEXmR3y3PjRyXPDe579Bb8Wf7B5/xg3+QH/QH+vMr2g8P+1uiJ2r+QQTm2KaRQrbAS7i69Qq0V82LtFLOrM6p1TmzvTm6aYg7zdkFn/GDf5Af9Af6E/vhaz+t9lv/PmP+wQLm2GfuSg3M9S/hDjUwEd9pt+Tgljw3vTm4Nc8P+Iwf/IP8oD/Qn9iP6+1v9PyDBcyxz9y1Ad8+vjRWhG/fxnMRgXvUwETtkJt+XjE9tuTMpjuhU7NCzY4ANQvULFCzQM0fNY+xNZ9if0ftt54DWOYPvaDx2QdmH6AGZoFV5Mo1MJE75PbUwLRyZls5uJacW/AZP/gH+UF/oD+xH+fZ31oNTMT8gwjMsc/clQgMUPJIREVeBMT707NDb+nrJvIVlJrnqOVpAp/xg3+QH/QH+hP7MWc/rfZb7H8uAhM1/yACsw8QgVlgFXl1y3kkIiMvPTUotZqZnhzcXvzZ/sFn/OAf5Af9gf78ivYjwv5Gzz+IwBzbNCIwwCePRHTkRWA0Z/bt2sw+MOzzwj437PPDPkfs88Q+VwLs8xWzz1luHxiL/dbnLfOHErTwicDsA0RgFlhFXt1Sj8QZkRf53fLc5L4j38rBteLP9g8+4wf/ID/oD/TnV7QfHvb37X4nzD+IwBzbNCIwwE+PxOOrcidEXgQ+RVMKnpuaJ0e+glLzHLU8SeAzfvAP8oP+QH9iP+bsp9V+v9nykzI/iMDsA0RgFlhF3mEfmIjvtKc5sDnPTen6XA7uKP5s/+AzfvAP8oP+QH9+RfsRYX+j5x9EYI5tGhEYYNojMeo5Ec/MTM7swwN0/PI31DxQ80DNAzUPL/1AzUNMzQP4jF/KH2J/R+23/lrZCFjnH0Rg9gEiMAusIlfeByYi8iK/W56brhxc8Bk/+Af5QX+gP7Eft7SftX1gIuYfRGCOfeauDWhecfUD0GJSyLrwlPIw9/uB/1Bg0uRc+lsfy7VPmj9C2K+/fRQVyvW5Y/AZP/gH+UF/oD+xH77202q/c9dGzz9YwBzbzJtZwCzwEu5YA+ORs1r7Dn0rh1bwS9+h78Wf7R98xg/+QX7QH+jPr2g/Iuxv9PyDBcyxTaMGBjDnhHp9LWQ2Z7a0Dww52+Ssk7NPzQI1G9SsCFDzE1PzlNsHxmK/9XnL/GEUHvhPGKz5BdYBamAWWEXeqQbG82shLc9NLodW58zq79Bb8Wf7B5/xg3+QH/QH+vMr2g8P+2upgfGYfxCBObZppJAt8BKubr0C7VXzIq2UM6tzanXObG+ObhriTnN2wWf84B/kB/2B/sR++NpPq/3Wv8+Yf7CAOfaZu1LEf/1LuEMNTMR32i05uCXPTW8Obs3zAz7jB/8gP+gP9Cf243r7Gz3/YAFz7DN3bcC3jy+NFeHbt/FcxAd8//792e4KO9D/u+N7tQYmaodcyYGdyZmVnYCpeaDmgZoHah4EqHlgnxf2uYnf50fs76j91nMAy/yhFzR+WvP7++P+87evTP+P+vKkvcS5egVGi62Bidwht6cGppUz28rBteTctvAffT2/I/9v//RqrWMJu9euj6bfQm8v/SPj10u/dfx66Z99/zX8mfffot+LfzW+F//W+DmCfm/5S9Ng7iJ/KT9H6I8I+ZPzEfJX4ueV5a+Hn2foj5I/b/tbq4GJmH8QgTm2aZdHYIB1v0IWFXkREO9Pzw69pa+byFdQap6jlqepF/9xzgS//M0TvwXR9A9DhX7pM2L8e/ofob8UqfOgP8sbTvR78a/Gb/LzIP1R8if43WCgPx2TO8if0Byl/2SH9Qj6I+RPfvf0v4r8ZWm+If3psdV+i/3PRWCi5h/Wr64C6wIRmAVWkVe3nEciMvLSU4NSq5lJj8XTNIpv6b/kyR/tP/WURdFf83yO0J+7nzf94nn0en+ez1/DTz35HvSn3s0I+r35T3t+veUvgv9qkaNV+S9a/qL4r3S/VfmvpO+96ffmP2/92ZIfb/6Lnn8QgTm2aURggE8eiejIi8BozuzbtZl9YKJyfgV6a25Knl3tSY6kX9Ntwc/Rr+m2jJ9H/yP4MgbR+wS9+nOmf+b91+hv8Z+1f+35jcq57+W/Hvpz8uGtP0b5r0R/ymt3kL90DGTPkCj5S/nPg365R+Q+Y5o/zpJ/D/zcPjAW+63PPyB6/kEEZh8gArPAKvLqlnokzoi8yO+W50bOW3JwrfiW/ntyuC39tzxvXvS3PKnW/vX9vOnXkQGP5695Uj3oT3PWPd5fT+RsNf7zfP4z+a8UOVuV/2o1MKvyX28NzEr8Fy1/+n2uqj+j7e/b/U6YfxCBObZpRGCAnx6JhxfohMiLwKdoSsFzU/PkyFdQap6jliepF7/kSe2J3NQ8qdH0l/ofxZfjqPEXSD3ks/Sn9xt9/7X+05oBj/HXdHvw7yj/zY6/N/1W/mvR/+KNQPmb4T9Nv0D6FSjv8de1GR7yl9J9Jv+M0t+KdHnR/wIn/aH5LZr+FN9qv9PfZ2V+EIHZB4jALLCKvMM+MJ6Rl1wObM5zU7o+Pa55rnrwLf3XamBG+m953jzo762B6e2/VIPgSb+ODMy+P8/nr+GnnnwP+i01CCvwX6mmxpN+b/6rRc5W5b9o+Yviv1oNzIr8Z6mBmaHfm/+89WdLfrz5T85bji34RGCObRoRGGDaIzHqORHPzEzObM3zfXbNQA9+zpN6Vs2A7n/0+a+qGRilf5WaASv9Z9cMWPn3ipqBmZqVHP1n6I9cNG1Gf/RGzmbp1/znRf/M+6/R3+I/a/8pn61Qc9JLf0l/RtAv8jNqv9PIzShY5x9EYPYBIjALrCJX3gcmIvIiv1uem54c2jPxc57Umf5bnjcv+mue1JH+0/tF0G/J4e59/pIn1Yv+0tesRunvrUFYif88n/9M/itFzlblv/R+UfrDm/9K91uZ/6LlL+W/0te8VtCf0fj6vPyOmn8QgTm2ac19KtnI8mumkHXhKeVh7vcD/6HApMm59Lc+lmtF+af46WTk2UfmeBT/lW6ShM1H+p/Ft9Iv13j1H03/2wTNoX99vwj+0f3Mjl/tflfxf4v+3ueP6n8UXz9DhPzp9zpLvyw+o95/jf9G6Ne6M4J/PeWvdj9v+t9ocqC/pT8j9YfVfueujZ5/sIA5tmksYBZ4CXesgfHIWRXFVfLcaPxU0Qm+KNBRfEv/b4bBgf7UGEXRL314PP+bgXR6f7nrhV6v9+f5/DX81Nh70C/38+LfaP4r3c+Tfm/+S+UjSn9481+0/EXxX3q/KPnz5L9U30fqD2/+89afLfnx5j+5Pmr+wQLm2KZRAwOYc0K9vhYymzMr+eWROffp+TvuM1CrGRih/8yagdmak1JO+Fk1A2fXzJzNf5q+lM+ic+495S+lO0J/lPhvlv6ray6s9L94jX26ttgnKP3K2aj91ud7wGP+8YTBml9gHaAGZoFV5J1qYDy/FtLy3MhxyXOT+w69Fd/Sv/Z8WvGtnjcv+kuez1H6tWfWm37tSfV4/lzkzJP+mid/hP6eyNlq/Of5/GfyXylytir/6chAhP7w5r9c5Mybfm/+i5a/lP9qkYyr9We0/S3REzX/IAJzbNNIIVvgJVzdegXaq+ZFWqq49G9p6bFe/LRydMVwpviWHN9efLnGit/KsfaiX+dMz9Kvr/emX+eEz45/OnmKeP85umf5J3c/b/p1H7P8P/r8Vvo1vV70R8pfjf9G5C/luwj9YeG/Hvqj5W+G/0r0R8uf1hte/GvVn578Y7Xf+rdl/mBtgs8C5timsYBZ4CXcoQbGM/Ii51MF18qhLXluRMGO4lv6Tw2NB/2poYmiP508zT5/atS93l/uerm/1/vzfP4afmrMPeiX+3nxbzT/le7nSb83/6X3i9If3vwXLX9R/JfeL0r+PPnvbWERqD+8+c9bf7bkx5v/5LzGr5234LOAObZp1MAAzRqYqB1yJQd2Jmc23Qn9jH0+7rbPgKVmpYf+XE3NWTUDV+8zEd2/xj+7ZsCD/hfNgTn3Jf4boV/TPfP+d9vnw8p/LfpL57/yPl1pzUrv+2/Rf1bNn8jP4/9R+63nADnwnn+wD8w+QA3MAqvIlWtgIiIv8rvluZGwc8lz05ODa8m5beFrz6cV3+p586K/5PkcpV/fz5v+txQIp+fPRc486S958kfp74mcrcZ/ns9/Jv+VImer8p++X4T+8Oa/XOTMm35v/ouWP/0+V9Wf0fa3RE/U/IMIzLFNIwIDFD0SUZEXAfH+9OzQW/q6iXwFpeY5anmaevFLX3dpeS5bkYZo+qWPXvwW/SnNEeOvPZ8j+Cn9rUiXB/1vdHe+/6jn76W/xH+j9Jc8v970pzTPyF9uDKLkT8bFS/5e1wTpvzRyOyt/rUiXF/06kjEjfzP4Vvr1+/Sg/wz9kcO32m+x/7kITNT8gwjMPkAEZoFV5NUt55GIjLz05ODWambS45rnqgff0r+lBqan/5bnzYP+mudzhP7eGoQZ+sXz6fX+PJ+/hv9WUOxAfytythr/ac+vt/xF8F8tcrYq/0XLXxT/WWpgVuC/VuTMi35v/vPWny358ea/6PkHEZhjm0YEBvjkkYiOvAiM5sy+XZvZB4Z9BnxqVnKe6TNrBnL9j+BfVTPgRf9VNQPW/s+oGbDwXw/9Ofnw1h+j/Feivzdyu4r8pWNQiwR7yF/Kfx70yz0i5K8VuZylP0L+cvIj73TEfuvzD4iefxCB2QeIwCywiry6pR6JMyIv8rvluZHzlhxcK76lf/GUpZ+q1Mep567n+tnn78G30NNL/8j49dJvHb9e+mfffw1/5v236PfiX43vxb8aP0r+5Hpv+StFzlaWv5SfI/RHhPyV+NmL/rvJX46fPemPkj9v+/t2vxPmH0Rgjm0aERjgp0fi4QU6IfIi8CmaUvDc1Dw58hWUmueo5Unqxdd1Dp8g8fxZIJr+bjDQn3pSvekfhgb9JU+qB/16h3hP+r34V+N/4g0n+qPkT45b/Y9AGjm7g/w9IP0KlLf+MNFtpD9C/iL1R5T86Uiot/5o1UhFjL/Vfqe/z8r8IAKzDxCBWWAVeYd9YDwjL7kc2JznpnR9eiyeplH82f7BZ/zgH+QH/YH+/Ir2I8L+Rs8/iMAc2zQiMMC0R2LUcyKemZmcWcs+JyvkDIPP+ME/yA/6A/25g/0Q+ztqv/XXykbAOv8gArMPEIFZYBW58j4wEZEX+d3y3HTl4ILP+ME/yA/6A/2J/bil/SzV5ETNP4jAHPvMXRvQvOLqB6DFpJB14SnlYe73A/+hwKTJufS3PpZrpWAxxU8Lcp99ZI7BZ/zgH+QH/YH+xH742k+r/c5dGz3/YAFzbDNvZgGzwEu4Yw2MR85qmgOb89xo/JznJv3aygj+bP/gM37wD/KD/kB/fkX7EWF/o+cfLGCObRo1MIA5J9TrayGzObOlfWBWzhkGn/GDf5Af9Af6cwf7kdsHxmK/9fke8Jh/PGGw5hdYB6iBWWAVeacaGM+vhbQ8N7kcWp0zq79Db8Wf7R98xg/+QX7QH+jPr2g/POyvpQbGY/5BBObYppFCtsBLuLr1CrRXzYu0Us6szqnVObO9ObppiDvN2QWf8YN/kB/0B/oT++FrP632W/8+Y/7BAubYZ+5KEf/1L+EONTAR32m35OCWPDe9Obg1zw/4jB/8g/ygP9Cf2I/r7W/0/IMFzLHP3LUB3z6+NFaEb9/GcxGBe9TARO2QKzmwMzmz6U7od8gZBp/xg3+QH/TH19Wf//zXf/e67s/+61/djv70vNjfUfut5wA58J5/sA/MPkANzAKryJVrYCJ3yO2pgWnlzLZycC05t+AzfvDPtfKTfp7/KvnN9V+CXvye/jXk8PX2BRH0Sz+6fw1W+u+Or68Z4T+5r35/RVjcfnnY31oNTMT8gwjMsU1rAfvAfOEaGO+aF910jqzOi63lzOZydOU4xbfkOIPP+ME/18nPEz6uf1mfs/tXk9eUnhn8Vv8vnAr9Mj76+tH+0/ul9LxZ/8rzl+jJ0X93/Nx4lcavyn8f/Yy8/zvYL6v91ufOmH+wgDm2aSxgFngJV7ecQEdGXuQ4VWA5z03p+p4c3F782f7BZ/zgn3n5kQlmip/+7Uz5k8n7mz7LeM4t+LPPn+tfzo/0n94vxU8XP63nT/ufpf+O+Bb+K0Gt/zvYnwj7Gz3/YAFzbNNaQA3MFwCdExpV86JhNGf27drMPjAr5wyDz/jBPxn5+eu/e9ZTDstPUlfwVD0/ftYYuMjfB31pzrXcO+r5jz/5zU/6k/OC/3be2v+PH1n6n8/3MX5v51v9z9J/A3wNI+//Mb5PPvLm/4vsT24fGIv91ucfED3/oAZmH6AGZoFV5NUt9UicEXmR3y3PjZwveW5yObhW/Nn+wWf84J95+cl5/q+SPx3ZEA/5A1J8Oe7BH3n+tD+5ZxoJGO0/9faXIjfSj+6/9Py99O+K38t/uUjOa+w/xj+F1e2Ph/19u98J8w8iMMc2jQgM8NMj8XRexkdeBD5FUwqem5onR76CUvMctTxJ4DN+8M+18vPy/C8gvzqyUfRUP7zy/+O/D+Nn+/8PNfwT/sfHjud//XfPe3r0L+dr45/2l/t6VkpfD/13x7eMf5X/MpGg1fh/Bt9qv9PfZ2V+EIHZB4jALLCKvMM+MJ6Rl2wOeMZzU7o+PX4VQQ7iz/YPPuMH/8TIj44UtPBzMNK/9qyX8NNIxwi+5flznvuR/nORhNHxK/Xf+/7uhG8Z/xr/18b/jvYnwv7KecuxBZ8IzLFNIwIDTHskRj0n4pmZyZl95jL/8je3yRkGn/GDf/Ly06pZOHWfjsSzXqoZEXq78KVmIOfJ//D8z9acTPVfqPkpPr/uv0X/bviV91/jv+73fxP7IfZ31H6nkZtRsM4/iMDsA0RgFlhFrrwPTETkRX63PDddObjgM37wzzbyk3r+z+4/B7rmQUcnLPhyTU//Jfp1ZMSz/3T85LrS84/QvxO+XGPlv9L4p+N9Z/kdwdfn5XfU/IMIzLFNawH7wHzhfWCaeE7faX8oMGlyLv2tj+Va+U59ip/7br0+Bp/xg3+QH/QH+hP74Ws/rfY7d230/IMFzEZzVxYw17+EO9bAeOSspjmwOc+Nxs95bkrfoe/Fn+0ffMYP/kF+0B/oz69oPyLsb/T8gwXMsU1rAfvAfAGw5oR6fS1kNme2tA/MyjnD4DN+8A/yg/5Af+5gP3L7wFjstz7fAx7zjycM1vwC6wA1MAusIu9UA+P5tZCW5yabQ6xyZvV36K34s/2Dz/jBP8gP+gP9+RXth4f9tdTAeMw/iMAc2zRSyBZ4CVe3XoH2qnmRVsqZ1Tm1Ome2N0c3DXGnObvgM37wD/KD/kB/Yj987afVfuvfZ8w/WMAc+8xdqYG5/iXcoQYm4jvtlhzckuemNwe35vkBn/GDf5Af9Af6E/txvf2Nnn+wgDn2mbteXQPz/fv3Z7sr7ED/747v1RqYqB1yJQd2Jmf2+R36FnzsEzMM4DN+8E+M/PzJb557liB/6B/07z3tz6M2ZtR+6zlADrznH2nN7++P+8/fvjL9P+rLk/YS5+oVGC22BiZyh9yeGhhLziz4jB/8g/ygP9Cf2I/72M9aDUzE/IMIzLHNvJkUsgVewtWtJNDeNS+66RxZnRdby5nN5diCz/jBP8gP+gP9if24l/0cmT+Mzj9YwBzbNBYwC7yEq1tOoCMjLz01KLWaGfAZP/gH+UF/oD+xH/vZz+j5BwuYY5+569U1MMB6+8BE1bxoGM2ZnamZAZ/xg3+QH/QH+hP7sZ79tMwfStDCt+57B6wL1MAssIq8uqUeiTMiL/K75bnJfUe+lYMLPuMH/yA/6A/0J/bjHvYzPT5j/kEE5thn7spnlK9/CVe3l0AH17zoVsqZ7c2x1fcCn/GDf5Af9Af6E/txH/spv8+af7CAObZpLGAWeAl32Acm4jvtqYLLeW5K14PP+ME/yA/6A/2J/djPfkbPP1jAHPvMXamBAWZzQkdzViUHlpoVanaoWaJmi5o1avYEqFn8ejWbo2Cdf1ADsw9QA7PAKnLlfWAid8hteW56cmjBZ/zgH+QH/YH+xH7c036Wamqi5h9EYI595q7UwFz/Eq5uowLtlbPam2Ob/q7l3ILP+ME/yA/6A/2J/biH/ZyZP5w136Edy40BC5gFXsIda2A8clZr35Fv5dCCz/jBP8gP+gP9if3Yy35Gzz9YwBz7zF2pgQGsOaFe32m/OucWfMYP/kF+0B/oT+zHGvbTMn8YhQf+E9gH5vZADcwCq8g71cB4fi2k5bnJ5dDWcmbBZ/zgH+QH/YH+xH7cx35aamA85h9EYI595q7UwFz/Eq5uvQLt/Z322nfhc9+R14uf2r3AZ/zgH+QH/YH+xH6sbT97a2C85h8sYI7L55xejQXMAi/hDjUwEd9pt+TQ1jw34DN+8A/yg/5Af2I/7m8/o+cfLGCOfeau1MAArRoYr5oXDZIDS80KNTspP2ieoGaJmi1q1qjZo2Zxz5rF9Ngyf+gFjc8+MF+nBubbY4FTveDbOGMBa0Aq0H/8y98e//nX/60o/P/6h/fzreMa/kN5/f2f/8vxF//4p6/z+vih/P7sb/+qeB58xg/+QX7QH+hP7Md97acsYCzzh57jHP6v/r//bWrjbmAdYAEDFD0SUZEX8Bk/+Af5QX+gP7Ef2M+z5w9EYL7OAuYXp1ECLAU5z0UKrWPwGT/4B/lBf6A/sR/Yz9XmD8DXAFLIvgBojwSREyJHRM6IHA7rE+QH+UF+kJ9F9QcRmH2ACAzwzhBEDogcEDlY1nMIPuMH/yA/6A8f/QnsDURgvgC8PBKPF47nbHwc8TzDP8gP8oP+QH9iP5a1n0Rg9gEiMIvC9+/f39o5neL5FcDzjec/BSIfRD5q/EDkjMghkdP7zB+ALwLNnS4X2Mxmt/b9+/euv3m12Y2dvHbIBZ/xg3+QH/QH+hP7gf2Mmj+wkeVx+RzXbe7aAL5CdgHMRlxy+OnfapGd1T0n4DN+8A/yg/5Af2I/sJ+z8wdgcyACs0azRGBaERz9e9QjQeSEyNGU94TxY/zgH+QH/YH+PNF+EIE5tmlEYG4Ap9bBfACRDyI/NX4gckbkkMgpkeNee4H+QH+uZD+ALwJEYK5bXT6iIyO1L9ERGDzneM6nvCaMH+MH/yA/6A/050X2Y6bml3YsMwZEYBaF079A9gF4zvAcruw5A5/xg3+QH/QH+nPUfqRfWwU2ByIw568qZ784pvF1JGc0AoPnHM/5rOcLfMYP/kF+0B/oz6vsBzUwxzaNCMxN9oGxRmJm95HB843nPwUiH0Q+iHwQ+SjZByKnRI7vNH8AvggQgdk/gtPySOA5J3Iw5SVh/Bg/+Af5QX+gPxewH0Rgjm0aERjgVp4T8Bk/+Af5QX+gP7Ef2M/Z+QOwORCB+boRGDzneM6nvCOMH+MH/yA/6A/050L2gwjMsU0jArMheHy5jMgHkR8iX0T+BIh8EvlMgcg5mQM1flh9/gB8Dfj2WOFUL/hGYdTd4cdjvfMI2nz/dnz7/ln4zfcDn/GDf5Af9Af6E/uB/Vxs/qDnO8B9obE8OX5xGiXAErC65wR8xg/+QX7QH+hP7Af2c3b+AOwNp0dgzt64ETiO3x3f/8MjcRzH77//fvgdEHkh8kLkhcjLKKA/0B/oD/RHtP4gArMPEIE5aQ+XldtPwol8CBD5IfKVApE/In81fiByTOSczIH7zB+ArwFEYL5AFCn1SPz+sG98iecUzymeUzynw/oH+UF+kB/k5yT9QQRmHyACA7zB//aX/9fSnhPwGT/4B/lBf6A/sR/Yz9n5A7A3EIEZgK8SgcFziucUzyme02G9g/wgP8gP8nOy/iACsw8QgQGyQOSDyE+NH4icETkkckrkuNdeoD/QnyvZD+BrABGYr/QVss4IDJ5TPKd4TvGcjgL6A/2B/kB/XKk/nsA+MNtHYNjI8gtAGlJtQu914DN+8A/yg/5Af2I/sJ+rzR/YyHILYAED/FzAAAAAAAAA7A5EYLZfwPyn0ygBroUZrwYAAAAAAAAArAI/GvBMKZxo378/Xf+3bdDP+MM/18sh8nv9WKI/rx9P7Ne9GvMHxh/+OYbHoAXUwAAAAAAAAAAAsAzwGWUAAAAAAAAAALaBX1xNAAAAAAAAAAAAQC+wgAEAAAAAAAAA4DbAAgYAAAAAAAAAgNsACxgAAAAAAAAAAG4DLGAAAAAAAAAAALgNsIABAAAAAAAAAOA2wAIGAAAAAAAAAIDbAAsYAAAAAAAAAABuAyxgAAAAAAAAAAC4DbCAAQAAAAAAAADgNvCfWhf8+PHjHEoAAAAAAAAAAAAaQAQGAAAAAAAAAIDbAAsYAAAAAAAAAABuAyxgAAAAAAAAAAC4DbCAAQAAAAAAAADgNsACBgAAAAAAAACA2wALGAAAAAAAAAAAbgMsYAAAAAAAAAAAOO4C/38SVVhdld7H/wAAAABJRU5ErkJggg==",
       "text/plain": [
-       "Component(name=cmim_W10_L10_LMMetal5drawing_LMMIMdrawing_LVVmimdrawing_98194961$2$1, ports=['MINUS', 'PLUS'], pins=[], instances=['rectangle_gdsfactorypcomponentspshapesprectangle_S11p92_59dd5848_0_0', 'rectangle_gdsfactorypcomponentspshapesprectangle_S10p72_f76ae31b_0_0', 'rectangle_gdsfactorypcomponentspshapesprectangle_S10_10_ef94ac30_0_0', 'via_array_VTVmim_C10_R10_VS0p42_VS0p94_VE0p42_LCContdra_14498da7_-4440_-4440', 'rectangle_gdsfactorypcomponentspshapesprectangle_S11p92_316b73f6_0_0', 'rectangle_gdsfactorypcomponentspshapesprectangle_S11p92_2d7918b4_0_0', 'rectangle_gdsfactorypcomponentspshapesprectangle_S11p92_ff69e054_0_0', 'rectangle_gdsfactorypcomponentspshapesprectangle_S11p92_81cf13d4_0_0', 'rectangle_gdsfactorypcomponentspshapesprectangle_S11p92_3e735432_0_0', 'rectangle_gdsfactorypcomponentspshapesprectangle_S1_2_L_313130ad_-5460_0', 'rectangle_gdsfactorypcomponentspshapesprectangle_S1_2_L_21edbbcb_4500_0'], locked=False, kcl=DEFAULT)"
+       "<Figure size 800x600 with 1 Axes>"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -85,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "402977b2",
+   "id": "c3314a41",
    "metadata": {},
    "source": [
     "### Configure ElectrostaticSim"
@@ -93,8 +89,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "115539f6",
+   "execution_count": null,
+   "id": "101aa3f2",
    "metadata": {},
    "outputs": [
     {
@@ -126,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1efee757",
+   "id": "97ee2f16",
    "metadata": {},
    "source": [
     "### Mesh and generate config"
@@ -134,8 +130,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "4fae1dec",
+   "execution_count": null,
+   "id": "fecc3df9",
    "metadata": {},
    "outputs": [
     {
@@ -143,31 +139,36 @@
       "text/plain": [
        "Mesh Summary\n",
        "========================================\n",
-       "Dimensions: 31.9 x 31.9 x 20.2 µm\n",
-       "Nodes:      26,689\n",
-       "Elements:   203,560\n",
-       "Tetrahedra: 150,804\n",
-       "Edge length: 0.06 - 15.96 µm\n",
-       "Quality:    0.610 (min: 0.002)\n",
-       "SICN:       0.669 (all valid)\n",
+       "Dimensions: 31.9 x 31.9 x 27.9 µm\n",
+       "Nodes:      64,567\n",
+       "Elements:   480,531\n",
+       "Tetrahedra: 366,459\n",
+       "Edge length: 0.01 - 9.71 µm\n",
+       "Quality:    0.607 (min: 0.008)\n",
+       "SICN:       0.662 (all valid)\n",
        "----------------------------------------\n",
-       "Volumes (3):\n",
-       "  - vmim [1]\n",
-       "  - sio2 [2]\n",
-       "  - air [3]\n",
-       "Surfaces (7):\n",
-       "  - metal5_xy [4]\n",
-       "  - metal5_z [5]\n",
-       "  - topmetal1_xy [6]\n",
-       "  - topmetal1_z [7]\n",
-       "  - sio2__vmim [8]\n",
-       "  - air__sio2 [9]\n",
-       "  - air__None [10]\n",
+       "Volumes (5):\n",
+       "  - mim [1]\n",
+       "  - vmim [2]\n",
+       "  - si [3]\n",
+       "  - sin [4]\n",
+       "  - air [5]\n",
+       "Surfaces (10):\n",
+       "  - metal5_xy [6]\n",
+       "  - metal5_z [7]\n",
+       "  - topmetal1_xy [8]\n",
+       "  - topmetal1_z [9]\n",
+       "  - mim__si [10]\n",
+       "  - si__vmim [11]\n",
+       "  - air__si [12]\n",
+       "  - si__sin [13]\n",
+       "  - air__sin [14]\n",
+       "  - air__None [15]\n",
        "----------------------------------------\n",
        "Mesh:   palace-sim-electrostatic/palace.msh"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -179,26 +180,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "8b3073de",
+   "execution_count": null,
+   "id": "6215eb39",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
       "\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "13cd220370864fe1818fbc373211b82e",
+       "model_id": "3b94666b09354d529a389a6a22e88a3f",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:41833/index.html?ui=P_0x77330dfa7d10_4&reconnect=auto\" class=\"pyvi…"
+       "Widget(value='<iframe src=\"http://localhost:49777/index.html?ui=P_0x1663c6e10_6&reconnect=auto\" class=\"pyvista…"
       ]
      },
      "metadata": {},
@@ -208,109 +210,71 @@
    "source": [
     "# sim.plot_mesh(show_groups=[\"metal\", \"topmetal\", \"via\", \"dielectric\", \"SiO2__vmim\"])\n",
     "\n",
-    "# sim.plot_mesh(show_groups=[\"metal5\", \"topmetal1\", \"vmim\", \"SiO2__vmim\"])\n",
+    "sim.plot_mesh(show_groups=[\"metal5\", \"topmetal1\", \"vmim\", \"SiO2__vmim\"])\n",
     "\n",
-    "sim.plot_mesh(\n",
-    "    style=\"solid\",\n",
-    "    transparent_groups=[\"air__None\", \"sio2__None\", \"air__sio2\", \"air__passive\"],\n",
-    "    interactive=True,\n",
-    ")"
+    "# sim.plot_mesh(\n",
+    "#     style=\"solid\",\n",
+    "#     transparent_groups=[\"air__None\", \"sio2__None\", \"air__sio2\", \"air__passive\"],\n",
+    "#     interactive=True,\n",
+    "# )"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "219723a6",
+   "id": "937ddbd0",
    "metadata": {},
    "source": [
-    "### Analytical estimate\n",
+    "### IHP PDK compact-model reference\n",
     "\n",
-    "For the MIM capacitor: C = epsilon_0 * epsilon_r * A / d\n",
-    "\n",
-    "In this estimate, epsilon_r is read from the active PDK-derived stack material table for SiO2, the MIM drawing dimensions are read from the geometry `MIMdrawing` polygon bounding box, and we report two spacings:\n",
-    "- d_topmetal1 = topmetal1_bottom - metal5_top\n",
-    "- d_vmim = vmim_bottom - metal5_top"
+    "This is the value the IHP `cap_cmim` SPICE device would report for the same\n",
+    "geometry. We evaluate the PDK's own area+perimeter law using the process constants\n",
+    "from the active techParams (`caspec` [F/m^2], `cpspec` [F/m], `lwd` [m]), so the\n",
+    "reference is authoritative rather than hand-tuned. This is the number to compare the\n",
+    "Palace mutual capacitance `Cm[1,2]` against."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "b2ec945b",
+   "execution_count": null,
+   "id": "4782b439",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "eps_r(SiO2) = 4.1\n",
-      "MIM drawing from geometry: 10.720 x 10.720 um\n",
-      "Analytical (d=topmetal1_bottom-metal5_top=0.850 um): 4.9 fF\n",
-      "Analytical (d=vmim_bottom-metal5_top=0.200 um):      20.9 fF\n"
+      "IHP model 'cap_cmim' for 10.0 x 10.0 um cmim:\n",
+      "  area term      =  150.30 fF\n",
+      "  perimeter term =    1.60 fF\n",
+      "  C_pdk (total)  =  151.90 fF   <- reference for Palace Cm[1,2]\n"
      ]
     }
    ],
    "source": [
-    "import scipy.constants as const\n",
+    "from ihp.cells2.ihp_pycell.utility_functions import Numeric\n",
+    "from ihp.tech import techParams\n",
     "\n",
-    "# Pull SiO2 epsilon_r and plate spacings from the active stack derived from the current PDK.\n",
-    "stack = sim._resolve_stack()\n",
-    "sio2_props = stack.materials.get(\"sio2\") or stack.materials.get(\"SiO2\")\n",
-    "if sio2_props is None or sio2_props.get(\"permittivity\") is None:\n",
-    "    raise ValueError(\"Could not find SiO2 permittivity in active stack materials\")\n",
-    "eps_r = float(sio2_props[\"permittivity\"])\n",
+    "caspec = Numeric(techParams[\"cmim_caspec\"])  # F/m^2  area-specific capacitance\n",
+    "cpspec = Numeric(techParams[\"cmim_cpspec\"])  # F/m    perimeter-specific capacitance\n",
+    "lwd = Numeric(techParams[\"cmim_lwd\"])  # m      line-width delta\n",
     "\n",
-    "metal5 = stack.layers.get(\"metal5\")\n",
-    "topmetal1 = stack.layers.get(\"topmetal1\")\n",
-    "vmim = stack.layers.get(\"vmim\")\n",
-    "if metal5 is None or topmetal1 is None or vmim is None:\n",
-    "    raise ValueError(\"Could not find metal5/topmetal1/vmim in active stack layers\")\n",
+    "# Use the device w/l (what the SPICE model is parameterized by), in meters.\n",
+    "leff = cap_width * 1e-6 + lwd\n",
+    "weff = cap_length * 1e-6 + lwd\n",
     "\n",
-    "metal5_top = metal5.zmin + metal5.thickness\n",
-    "topmetal1_bottom = topmetal1.zmin\n",
-    "vmim_bottom = vmim.zmin\n",
+    "C_pdk_area = caspec * leff * weff\n",
+    "C_pdk_perim = cpspec * 2.0 * (leff + weff)\n",
+    "C_pdk = C_pdk_area + C_pdk_perim\n",
     "\n",
-    "d_topmetal1_um = topmetal1_bottom - metal5_top\n",
-    "d_vmim_um = vmim_bottom - metal5_top\n",
-    "if d_topmetal1_um <= 0:\n",
-    "    raise ValueError(f\"Non-physical topmetal1 spacing: {d_topmetal1_um} um\")\n",
-    "if d_vmim_um <= 0:\n",
-    "    raise ValueError(f\"Non-physical vmim spacing: {d_vmim_um} um\")\n",
-    "\n",
-    "d_topmetal1 = d_topmetal1_um * 1e-6  # m\n",
-    "d_vmim = d_vmim_um * 1e-6  # m\n",
-    "\n",
-    "# Read MIM drawing dimensions from geometry.\n",
-    "geom_component = sim.geometry.component\n",
-    "mim_polys = geom_component.get_polygons(by=\"name\").get(\"MIMdrawing\", [])\n",
-    "if not mim_polys:\n",
-    "    raise ValueError(\"Could not find MIMdrawing polygons in geometry\")\n",
-    "\n",
-    "dbu = geom_component.kcl.dbu\n",
-    "left = min(poly.bbox().left for poly in mim_polys)\n",
-    "right = max(poly.bbox().right for poly in mim_polys)\n",
-    "bottom = min(poly.bbox().bottom for poly in mim_polys)\n",
-    "top = max(poly.bbox().top for poly in mim_polys)\n",
-    "\n",
-    "mim_width_um = (right - left) * dbu\n",
-    "mim_length_um = (top - bottom) * dbu\n",
-    "A_mim = (mim_width_um * 1e-6) * (mim_length_um * 1e-6)  # m^2\n",
-    "\n",
-    "C_analytical_topmetal1 = const.epsilon_0 * eps_r * A_mim / d_topmetal1\n",
-    "C_analytical_vmim = const.epsilon_0 * eps_r * A_mim / d_vmim\n",
-    "C_analytical = C_analytical_topmetal1\n",
-    "\n",
-    "print(f\"eps_r(SiO2) = {eps_r}\")\n",
-    "print(f\"MIM drawing from geometry: {mim_width_um:.3f} x {mim_length_um:.3f} um\")\n",
-    "print(\n",
-    "    f\"Analytical (d=topmetal1_bottom-metal5_top={d_topmetal1_um:.3f} um): {C_analytical_topmetal1 * 1e15:.1f} fF\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"Analytical (d=vmim_bottom-metal5_top={d_vmim_um:.3f} um):      {C_analytical_vmim * 1e15:.1f} fF\"\n",
-    ")"
+    "print(f\"IHP model '{techParams['cmim_model']}' for {cap_width} x {cap_length} um cmim:\")\n",
+    "print(f\"  area term      = {C_pdk_area * 1e15:7.2f} fF\")\n",
+    "print(f\"  perimeter term = {C_pdk_perim * 1e15:7.2f} fF\")\n",
+    "print(f\"  C_pdk (total)  = {C_pdk * 1e15:7.2f} fF   <- reference for Palace Cm[1,2]\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "360bf9f4",
+   "id": "60b70ea8",
    "metadata": {},
    "source": [
     "### Run on cloud\n",
@@ -321,16 +285,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec6b701e",
+   "id": "4fbbe8db",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  palace-938301e5  completed  1m 14s\n",
+      "Extracting results.tar.gz...\n",
+      "Downloaded 11 files to /Users/vahid/doplaydo/gsim/nbs/sim-data-palace-938301e5\n"
+     ]
+    }
+   ],
    "source": [
     "results = sim.run()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "8d779e94",
+   "id": "36129242",
    "metadata": {},
    "source": [
     "### Load and analyze results"
@@ -338,23 +312,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "0130be42",
+   "execution_count": null,
+   "id": "cff7a02b",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Capacitance matrix (F):\n",
-      "  C[1,1] = +1.4403e-14 F  (+14.403 fF)\n",
-      "  C[1,2] = -1.4403e-14 F  (-14.403 fF)\n",
-      "  C[2,1] = -1.4403e-14 F  (-14.403 fF)\n",
-      "  C[2,2] = +1.4403e-14 F  (+14.403 fF)\n",
+      "Maxwell capacitance matrix (F):\n",
+      "  C[1,1] = +2.1692e-14 F  (+21.692 fF)\n",
+      "  C[1,2] = -2.1692e-14 F  (-21.692 fF)\n",
+      "  C[2,1] = -2.1692e-14 F  (-21.692 fF)\n",
+      "  C[2,2] = +2.1692e-14 F  (+21.692 fF)\n",
       "\n",
-      "Mutual capacitance C_m[1,2] = 14.403 fF\n",
+      "Mutual (plate-to-plate) capacitance  Cm[1,2] = 21.692 fF\n",
       "\n",
-      "Stored electric energy: 2.7130e-03 J (excitation 1), 2.7130e-03 J (excitation 2)\n"
+      "Stored electric energy: 4.0861e-12 J (excitation 1), 4.0861e-12 J (excitation 2)\n"
      ]
     }
    ],
@@ -376,17 +350,19 @@
     "    return [h.strip() for h in header], data\n",
     "\n",
     "\n",
-    "# Capacitance matrix\n",
+    "# Maxwell capacitance matrix (terminal-C.csv): diagonal = self-capacitance,\n",
+    "# off-diagonal = negative induced charge on the grounded neighbor.\n",
     "header, C_matrix = read_palace_csv(results_dir / \"terminal-C.csv\")\n",
-    "print(\"Capacitance matrix (F):\")\n",
+    "print(\"Maxwell capacitance matrix (F):\")\n",
     "print(f\"  C[1,1] = {C_matrix[0, 1]:+.4e} F  ({C_matrix[0, 1] * 1e15:+.3f} fF)\")\n",
     "print(f\"  C[1,2] = {C_matrix[0, 2]:+.4e} F  ({C_matrix[0, 2] * 1e15:+.3f} fF)\")\n",
     "print(f\"  C[2,1] = {C_matrix[1, 1]:+.4e} F  ({C_matrix[1, 1] * 1e15:+.3f} fF)\")\n",
     "print(f\"  C[2,2] = {C_matrix[1, 2]:+.4e} F  ({C_matrix[1, 2] * 1e15:+.3f} fF)\")\n",
     "\n",
-    "# Mutual capacitance\n",
+    "# Mutual (lumped \"SPICE\") matrix (terminal-Cm.csv): off-diagonal is the physical\n",
+    "# plate-to-plate capacitor. Cm[1,2] is the device capacitance the PDK models.\n",
     "_, Cm = read_palace_csv(results_dir / \"terminal-Cm.csv\")\n",
-    "print(f\"\\nMutual capacitance C_m[1,2] = {Cm[0, 2] * 1e15:.3f} fF\")\n",
+    "print(f\"\\nMutual (plate-to-plate) capacitance  Cm[1,2] = {Cm[0, 2] * 1e15:.3f} fF\")\n",
     "\n",
     "# Domain energy\n",
     "_, E = read_palace_csv(results_dir / \"domain-E.csv\")\n",
@@ -397,103 +373,42 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37e18052",
+   "id": "4b151d85",
    "metadata": {},
    "source": [
-    "### Compare with analytical estimate"
+    "### Compare: Palace vs IHP PDK model\n",
+    "\n",
+    "The Palace plate-to-plate capacitance is `Cm[1,2]` (equivalently `|C[1,2]|`),\n",
+    "compared against the IHP `cap_cmim` compact-model value `C_pdk`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "cc69ea26",
+   "execution_count": null,
+   "id": "67d9ee9c",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Palace result:                                14.403 fF\n",
-      "Analytical (d=topmetal1_bottom-metal5_top):   4.9 fF\n",
-      "Analytical (d=vmim_bottom-metal5_top):        20.9 fF\n",
-      "Ratio Palace / topmetal1-based analytical:    2.935\n",
-      "Ratio Palace / vmim-based analytical:         0.690\n",
-      "Using A_mim = 10.720 x 10.720 um^2 from MIMdrawing\n",
-      "d_topmetal1 = 0.850 um, d_vmim = 0.200 um\n"
+      "Palace mutual Cm[1,2]:      21.692 fF\n",
+      "IHP PDK model (cap_cmim):   151.902 fF\n"
      ]
     }
    ],
    "source": [
-    "import scipy.constants as const\n",
+    "# Palace device (mutual) capacitance — the quantity the PDK models.\n",
+    "C_palace = abs(Cm[0, 2])\n",
     "\n",
-    "C_palace = abs(C_matrix[0, 1])\n",
-    "\n",
-    "stack = sim._resolve_stack()\n",
-    "sio2_props = stack.materials.get(\"sio2\") or stack.materials.get(\"SiO2\")\n",
-    "if sio2_props is None or sio2_props.get(\"permittivity\") is None:\n",
-    "    raise ValueError(\"Could not find SiO2 permittivity in active stack materials\")\n",
-    "eps_r = float(sio2_props[\"permittivity\"])\n",
-    "\n",
-    "metal5 = stack.layers.get(\"metal5\")\n",
-    "topmetal1 = stack.layers.get(\"topmetal1\")\n",
-    "vmim = stack.layers.get(\"vmim\")\n",
-    "if metal5 is None or topmetal1 is None or vmim is None:\n",
-    "    raise ValueError(\"Could not find metal5/topmetal1/vmim in active stack layers\")\n",
-    "\n",
-    "metal5_top = metal5.zmin + metal5.thickness\n",
-    "topmetal1_bottom = topmetal1.zmin\n",
-    "vmim_bottom = vmim.zmin\n",
-    "\n",
-    "d_topmetal1_um = topmetal1_bottom - metal5_top\n",
-    "d_vmim_um = vmim_bottom - metal5_top\n",
-    "if d_topmetal1_um <= 0:\n",
-    "    raise ValueError(f\"Non-physical topmetal1 spacing: {d_topmetal1_um} um\")\n",
-    "if d_vmim_um <= 0:\n",
-    "    raise ValueError(f\"Non-physical vmim spacing: {d_vmim_um} um\")\n",
-    "\n",
-    "d_topmetal1 = d_topmetal1_um * 1e-6\n",
-    "d_vmim = d_vmim_um * 1e-6\n",
-    "\n",
-    "geom_component = sim.geometry.component\n",
-    "mim_polys = geom_component.get_polygons(by=\"name\").get(\"MIMdrawing\", [])\n",
-    "if not mim_polys:\n",
-    "    raise ValueError(\"Could not find MIMdrawing polygons in geometry\")\n",
-    "\n",
-    "dbu = geom_component.kcl.dbu\n",
-    "left = min(poly.bbox().left for poly in mim_polys)\n",
-    "right = max(poly.bbox().right for poly in mim_polys)\n",
-    "bottom = min(poly.bbox().bottom for poly in mim_polys)\n",
-    "top = max(poly.bbox().top for poly in mim_polys)\n",
-    "\n",
-    "mim_width_um = (right - left) * dbu\n",
-    "mim_length_um = (top - bottom) * dbu\n",
-    "A_mim = (mim_width_um * 1e-6) * (mim_length_um * 1e-6)\n",
-    "\n",
-    "C_analytical_topmetal1 = const.epsilon_0 * eps_r * A_mim / d_topmetal1\n",
-    "C_analytical_vmim = const.epsilon_0 * eps_r * A_mim / d_vmim\n",
-    "C_analytical = C_analytical_topmetal1\n",
-    "\n",
-    "print(f\"Palace result:                                {C_palace * 1e15:.3f} fF\")\n",
-    "print(\n",
-    "    f\"Analytical (d=topmetal1_bottom-metal5_top):   {C_analytical_topmetal1 * 1e15:.1f} fF\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"Analytical (d=vmim_bottom-metal5_top):        {C_analytical_vmim * 1e15:.1f} fF\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"Ratio Palace / topmetal1-based analytical:    {C_palace / C_analytical_topmetal1:.3f}\"\n",
-    ")\n",
-    "print(\n",
-    "    f\"Ratio Palace / vmim-based analytical:         {C_palace / C_analytical_vmim:.3f}\"\n",
-    ")\n",
-    "print(f\"Using A_mim = {mim_width_um:.3f} x {mim_length_um:.3f} um^2 from MIMdrawing\")\n",
-    "print(f\"d_topmetal1 = {d_topmetal1_um:.3f} um, d_vmim = {d_vmim_um:.3f} um\")"
+    "print(f\"Palace mutual Cm[1,2]:      {C_palace * 1e15:.3f} fF\")\n",
+    "print(f\"IHP PDK model (cap_cmim):   {C_pdk * 1e15:.3f} fF\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2a721f8",
+   "id": "3c4e8e98",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -504,18 +419,6 @@
    "display_name": ".venv",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/nbs/_palace_electrostatic.py
+++ b/nbs/_palace_electrostatic.py
@@ -15,15 +15,26 @@
 # %% [markdown]
 # # Electrostatic Capacitance Extraction with Palace
 #
-# This notebook demonstrates electrostatic simulation using `gsim.palace.ElectrostaticSim` to extract the capacitance matrix between conductor terminals.
+# We use `gsim.palace.ElectrostaticSim` to extract the **plate-to-plate (mutual)
+# capacitance** of the IHP `cmim` (MIM capacitor) cell and compare it against the IHP
+# PDK compact model. The bottom plate is on Metal5
+# (terminal `T1` = SPICE `MINUS`), the top plate on TopMetal1 (`T2` = `PLUS`), joined
+# by a 10x10 array of Vmim vias through a 0.19 um SiO2 MIM dielectric.
 #
-# We use the IHP `cmim` (MIM capacitor) cell. The bottom plate is on Metal5 and the top plate on TopMetal1, connected by a 10x10 array of Vmim vias through a thin MIM dielectric (0.19 um SiO2).
+# Palace writes two matrices: `terminal-C.csv` (Maxwell — self-cap on the diagonal,
+# negative induced charge off-diagonal) and `terminal-Cm.csv` (mutual/"SPICE" — its
+# off-diagonal `Cm[i,j] = -C[i,j]` is the physical two-terminal capacitor). The MIM cap
+# value is `Cm[1,2]`, which is exactly what the PDK `cap_cmim` model describes.
 #
-# **Limitation:** The current terminal system assigns one terminal per layer. Structures with multiple electrodes on the same layer (e.g., interdigitated capacitors) are not yet supported.
+# The IHP `cap_cmim` is a 2-terminal model with an area + perimeter law (plate-to-plate
+# only; substrate parasitics are left to extraction). See
+# [`capacitors_mod.lib`](https://github.com/IHP-GmbH/IHP-Open-PDK/blob/main/ihp-sg13g2/libs.tech/ngspice/models/capacitors_mod.lib).
 #
-# **Requirements:**
-# - IHP PDK: `uv pip install ihp-gdsfactory`
-# - [GDSFactory+](https://gdsfactory.com) account for cloud simulation
+# **Limitation:** one terminal per layer — multiple electrodes on the same layer (e.g.
+# interdigitated caps) are not yet supported.
+#
+# **Requirements:** IHP PDK (`uv pip install ihp-gdsfactory`) and a
+# [GDSFactory+](https://gdsfactory.com) account for cloud simulation.
 
 # %% [markdown]
 # ### Load IHP MIM capacitor
@@ -76,81 +87,43 @@ sim.mesh(preset="fine", refined_mesh_size=0.1, merge_via_distance=0)
 # %%
 # sim.plot_mesh(show_groups=["metal", "topmetal", "via", "dielectric", "SiO2__vmim"])
 
-# sim.plot_mesh(show_groups=["metal5", "topmetal1", "vmim", "SiO2__vmim"])
+sim.plot_mesh(show_groups=["metal5", "topmetal1", "vmim", "SiO2__vmim"])
 
-sim.plot_mesh(
-    style="solid",
-    transparent_groups=["air__None", "sio2__None", "air__sio2", "air__passive"],
-    interactive=True,
-)
+# sim.plot_mesh(
+#     style="solid",
+#     transparent_groups=["air__None", "sio2__None", "air__sio2", "air__passive"],
+#     interactive=True,
+# )
 
 # %% [markdown]
-# ### Analytical estimate
+# ### IHP PDK compact-model reference
 #
-# For the MIM capacitor: C = epsilon_0 * epsilon_r * A / d
-#
-# In this estimate, epsilon_r is read from the active PDK-derived stack material table for SiO2, the MIM drawing dimensions are read from the geometry `MIMdrawing` polygon bounding box, and we report two spacings:
-# - d_topmetal1 = topmetal1_bottom - metal5_top
-# - d_vmim = vmim_bottom - metal5_top
+# This is the value the IHP `cap_cmim` SPICE device would report for the same
+# geometry. We evaluate the PDK's own area+perimeter law using the process constants
+# from the active techParams (`caspec` [F/m^2], `cpspec` [F/m], `lwd` [m]), so the
+# reference is authoritative rather than hand-tuned. This is the number to compare the
+# Palace mutual capacitance `Cm[1,2]` against.
 
 # %%
-import scipy.constants as const
+from ihp.cells2.ihp_pycell.utility_functions import Numeric
+from ihp.tech import techParams
 
-# Pull SiO2 epsilon_r and plate spacings from the active stack derived from the current PDK.
-stack = sim._resolve_stack()
-sio2_props = stack.materials.get("sio2") or stack.materials.get("SiO2")
-if sio2_props is None or sio2_props.get("permittivity") is None:
-    raise ValueError("Could not find SiO2 permittivity in active stack materials")
-eps_r = float(sio2_props["permittivity"])
+caspec = Numeric(techParams["cmim_caspec"])  # F/m^2  area-specific capacitance
+cpspec = Numeric(techParams["cmim_cpspec"])  # F/m    perimeter-specific capacitance
+lwd = Numeric(techParams["cmim_lwd"])  # m      line-width delta
 
-metal5 = stack.layers.get("metal5")
-topmetal1 = stack.layers.get("topmetal1")
-vmim = stack.layers.get("vmim")
-if metal5 is None or topmetal1 is None or vmim is None:
-    raise ValueError("Could not find metal5/topmetal1/vmim in active stack layers")
+# Use the device w/l (what the SPICE model is parameterized by), in meters.
+leff = cap_width * 1e-6 + lwd
+weff = cap_length * 1e-6 + lwd
 
-metal5_top = metal5.zmin + metal5.thickness
-topmetal1_bottom = topmetal1.zmin
-vmim_bottom = vmim.zmin
+C_pdk_area = caspec * leff * weff
+C_pdk_perim = cpspec * 2.0 * (leff + weff)
+C_pdk = C_pdk_area + C_pdk_perim
 
-d_topmetal1_um = topmetal1_bottom - metal5_top
-d_vmim_um = vmim_bottom - metal5_top
-if d_topmetal1_um <= 0:
-    raise ValueError(f"Non-physical topmetal1 spacing: {d_topmetal1_um} um")
-if d_vmim_um <= 0:
-    raise ValueError(f"Non-physical vmim spacing: {d_vmim_um} um")
-
-d_topmetal1 = d_topmetal1_um * 1e-6  # m
-d_vmim = d_vmim_um * 1e-6  # m
-
-# Read MIM drawing dimensions from geometry.
-geom_component = sim.geometry.component
-mim_polys = geom_component.get_polygons(by="name").get("MIMdrawing", [])
-if not mim_polys:
-    raise ValueError("Could not find MIMdrawing polygons in geometry")
-
-dbu = geom_component.kcl.dbu
-left = min(poly.bbox().left for poly in mim_polys)
-right = max(poly.bbox().right for poly in mim_polys)
-bottom = min(poly.bbox().bottom for poly in mim_polys)
-top = max(poly.bbox().top for poly in mim_polys)
-
-mim_width_um = (right - left) * dbu
-mim_length_um = (top - bottom) * dbu
-A_mim = (mim_width_um * 1e-6) * (mim_length_um * 1e-6)  # m^2
-
-C_analytical_topmetal1 = const.epsilon_0 * eps_r * A_mim / d_topmetal1
-C_analytical_vmim = const.epsilon_0 * eps_r * A_mim / d_vmim
-C_analytical = C_analytical_topmetal1
-
-print(f"eps_r(SiO2) = {eps_r}")
-print(f"MIM drawing from geometry: {mim_width_um:.3f} x {mim_length_um:.3f} um")
-print(
-    f"Analytical (d=topmetal1_bottom-metal5_top={d_topmetal1_um:.3f} um): {C_analytical_topmetal1 * 1e15:.1f} fF"
-)
-print(
-    f"Analytical (d=vmim_bottom-metal5_top={d_vmim_um:.3f} um):      {C_analytical_vmim * 1e15:.1f} fF"
-)
+print(f"IHP model '{techParams['cmim_model']}' for {cap_width} x {cap_length} um cmim:")
+print(f"  area term      = {C_pdk_area * 1e15:7.2f} fF")
+print(f"  perimeter term = {C_pdk_perim * 1e15:7.2f} fF")
+print(f"  C_pdk (total)  = {C_pdk * 1e15:7.2f} fF   <- reference for Palace Cm[1,2]")
 
 # %% [markdown]
 # ### Run on cloud
@@ -181,17 +154,19 @@ def read_palace_csv(path):
     return [h.strip() for h in header], data
 
 
-# Capacitance matrix
+# Maxwell capacitance matrix (terminal-C.csv): diagonal = self-capacitance,
+# off-diagonal = negative induced charge on the grounded neighbor.
 header, C_matrix = read_palace_csv(results_dir / "terminal-C.csv")
-print("Capacitance matrix (F):")
+print("Maxwell capacitance matrix (F):")
 print(f"  C[1,1] = {C_matrix[0, 1]:+.4e} F  ({C_matrix[0, 1] * 1e15:+.3f} fF)")
 print(f"  C[1,2] = {C_matrix[0, 2]:+.4e} F  ({C_matrix[0, 2] * 1e15:+.3f} fF)")
 print(f"  C[2,1] = {C_matrix[1, 1]:+.4e} F  ({C_matrix[1, 1] * 1e15:+.3f} fF)")
 print(f"  C[2,2] = {C_matrix[1, 2]:+.4e} F  ({C_matrix[1, 2] * 1e15:+.3f} fF)")
 
-# Mutual capacitance
+# Mutual (lumped "SPICE") matrix (terminal-Cm.csv): off-diagonal is the physical
+# plate-to-plate capacitor. Cm[1,2] is the device capacitance the PDK models.
 _, Cm = read_palace_csv(results_dir / "terminal-Cm.csv")
-print(f"\nMutual capacitance C_m[1,2] = {Cm[0, 2] * 1e15:.3f} fF")
+print(f"\nMutual (plate-to-plate) capacitance  Cm[1,2] = {Cm[0, 2] * 1e15:.3f} fF")
 
 # Domain energy
 _, E = read_palace_csv(results_dir / "domain-E.csv")
@@ -200,72 +175,16 @@ print(
 )
 
 # %% [markdown]
-# ### Compare with analytical estimate
+# ### Compare: Palace vs IHP PDK model
+#
+# The Palace plate-to-plate capacitance is `Cm[1,2]` (equivalently `|C[1,2]|`),
+# compared against the IHP `cap_cmim` compact-model value `C_pdk`.
 
 # %%
-import scipy.constants as const
+# Palace device (mutual) capacitance — the quantity the PDK models.
+C_palace = abs(Cm[0, 2])
 
-C_palace = abs(C_matrix[0, 1])
-
-stack = sim._resolve_stack()
-sio2_props = stack.materials.get("sio2") or stack.materials.get("SiO2")
-if sio2_props is None or sio2_props.get("permittivity") is None:
-    raise ValueError("Could not find SiO2 permittivity in active stack materials")
-eps_r = float(sio2_props["permittivity"])
-
-metal5 = stack.layers.get("metal5")
-topmetal1 = stack.layers.get("topmetal1")
-vmim = stack.layers.get("vmim")
-if metal5 is None or topmetal1 is None or vmim is None:
-    raise ValueError("Could not find metal5/topmetal1/vmim in active stack layers")
-
-metal5_top = metal5.zmin + metal5.thickness
-topmetal1_bottom = topmetal1.zmin
-vmim_bottom = vmim.zmin
-
-d_topmetal1_um = topmetal1_bottom - metal5_top
-d_vmim_um = vmim_bottom - metal5_top
-if d_topmetal1_um <= 0:
-    raise ValueError(f"Non-physical topmetal1 spacing: {d_topmetal1_um} um")
-if d_vmim_um <= 0:
-    raise ValueError(f"Non-physical vmim spacing: {d_vmim_um} um")
-
-d_topmetal1 = d_topmetal1_um * 1e-6
-d_vmim = d_vmim_um * 1e-6
-
-geom_component = sim.geometry.component
-mim_polys = geom_component.get_polygons(by="name").get("MIMdrawing", [])
-if not mim_polys:
-    raise ValueError("Could not find MIMdrawing polygons in geometry")
-
-dbu = geom_component.kcl.dbu
-left = min(poly.bbox().left for poly in mim_polys)
-right = max(poly.bbox().right for poly in mim_polys)
-bottom = min(poly.bbox().bottom for poly in mim_polys)
-top = max(poly.bbox().top for poly in mim_polys)
-
-mim_width_um = (right - left) * dbu
-mim_length_um = (top - bottom) * dbu
-A_mim = (mim_width_um * 1e-6) * (mim_length_um * 1e-6)
-
-C_analytical_topmetal1 = const.epsilon_0 * eps_r * A_mim / d_topmetal1
-C_analytical_vmim = const.epsilon_0 * eps_r * A_mim / d_vmim
-C_analytical = C_analytical_topmetal1
-
-print(f"Palace result:                                {C_palace * 1e15:.3f} fF")
-print(
-    f"Analytical (d=topmetal1_bottom-metal5_top):   {C_analytical_topmetal1 * 1e15:.1f} fF"
-)
-print(
-    f"Analytical (d=vmim_bottom-metal5_top):        {C_analytical_vmim * 1e15:.1f} fF"
-)
-print(
-    f"Ratio Palace / topmetal1-based analytical:    {C_palace / C_analytical_topmetal1:.3f}"
-)
-print(
-    f"Ratio Palace / vmim-based analytical:         {C_palace / C_analytical_vmim:.3f}"
-)
-print(f"Using A_mim = {mim_width_um:.3f} x {mim_length_um:.3f} um^2 from MIMdrawing")
-print(f"d_topmetal1 = {d_topmetal1_um:.3f} um, d_vmim = {d_vmim_um:.3f} um")
+print(f"Palace mutual Cm[1,2]:      {C_palace * 1e15:.3f} fF")
+print(f"IHP PDK model (cap_cmim):   {C_pdk * 1e15:.3f} fF")
 
 # %%


### PR DESCRIPTION
Reworks the electrostatic capacitance notebook (`nbs/_palace_electrostatic`) to make clear what it simulates and to compare against the IHP PDK model rather than a hand-rolled parallel-plate estimate.

## Changes
- **Intro** now states the simulated quantity is the **plate-to-plate (mutual) capacitance** of the IHP `cmim`, and explains the two capacitance-matrix conventions Palace writes: `terminal-C.csv` (Maxwell) vs `terminal-Cm.csv` (mutual/"SPICE"), with `Cm[1,2]` being the device value.
- **Links the IHP SPICE model** (`capacitors_mod.lib`) and notes `cap_cmim` is a 2-terminal area+perimeter model.
- **New PDK compact-model reference cell** evaluates the PDK's own area+perimeter law using process constants from the live `techParams` (`caspec`, `cpspec`, `lwd`), so `C_pdk` is authoritative rather than hand-tuned.
- **Comparison** now reports Palace `Cm[1,2]` against the PDK model value.
- **Removed** the parallel-plate analytical sections.

## Note
Running the notebook surfaces a large Palace-vs-PDK gap (~7×) that traces to a separate stack-modeling bug in `ihp-gdsfactory` (the MIM dielectric + top plate are lumped into one SiO₂ level). Tracked upstream in gdsfactory/IHP#188 — out of scope for this docs PR.
