### PR TITLE
fix: case-insensitive material override and overlay matching (#163)

### DIFF
--- a/src/gsim/common/stack/materials.py
+++ b/src/gsim/common/stack/materials.py
@@ -739,6 +739,59 @@ MATERIAL_ALIASES: dict[str, str] = {
 }
 
 
+def _normalize_material_keys[T](
+    d: dict[str, T],
+    *,
+    used_names: set[str] | None = None,
+    label: str = "overrides",
+) -> dict[str, T]:
+    """Normalize material dict keys to case-insensitive, warning on duplicates.
+
+    Strips whitespace and lowercases each key.  When multiple keys collapse
+    to the same normalized form a duplicate warning is emitted and the last
+    value wins.  When *used_names* is provided, keys that match no entry in
+    the set produce an unmatched-key warning.
+
+    Args:
+        d: Dict whose keys are material names (potentially mixed case).
+        used_names: Set of material names known to be in use.  If provided,
+            unmatched keys after normalization trigger a warning.
+        label: Human-readable label for the warning messages (e.g. "overrides",
+            "overlay").
+
+    Returns:
+        New dict with normalized keys.
+    """
+    normalized: dict[str, T] = {}
+    collisions: list[str] = []
+
+    for key, val in d.items():
+        key_lower = key.lower().strip()
+        if key_lower in normalized:
+            collisions.append(f"'{key}'")
+        normalized[key_lower] = val
+
+    if collisions:
+        warnings.warn(
+            f"Duplicate material entries in {label} after case normalization: "
+            f"{', '.join(collisions)}. Only the last value for each name kept.",
+            stacklevel=3,
+        )
+
+    if used_names is not None:
+        used_lower = {n.lower() for n in used_names}
+        unmatched = sorted(k for k in normalized if k not in used_lower)
+        if unmatched:
+            warnings.warn(
+                f"Material {label} key(s) {unmatched} do not match any "
+                f"material in the geometry ({sorted(used_names)}). "
+                f"Check spelling/case.",
+                stacklevel=3,
+            )
+
+    return normalized
+
+
 def get_material_properties(material_name: str) -> MaterialProperties | None:
     """Look up material properties by name."""
     name_lower = material_name.lower().strip()
@@ -763,6 +816,7 @@ def _resolve_with_overlay(
     """Look up material properties with optional PDK overlay.
 
     Priority: overlay entry > built-in database.
+    Matching is case-insensitive.
 
     Args:
         material_name: Material name from PDK
@@ -771,15 +825,19 @@ def _resolve_with_overlay(
     Returns:
         MaterialProperties if found, else None
     """
-    if overlay and material_name in overlay:
-        return overlay[material_name]
+    name_lower = material_name.lower().strip()
 
     if overlay:
+        for key, val in overlay.items():
+            if key.lower().strip() == name_lower:
+                return val
+
         from gsim.common.stack.overlays import merge_overlay
 
         merged = merge_overlay(overlay)
-        if material_name in merged:
-            return merged[material_name]
+        for key, val in merged.items():
+            if key.lower() == name_lower:
+                return val
 
     return get_material_properties(material_name)
 
@@ -808,9 +866,11 @@ def resolve_material_at_wavelength(
         ResolvedMaterial with evaluated properties, or None if not found
     """
     overrides = overrides or {}
+    name_lower = material_name.lower().strip()
 
-    if material_name in overrides:
-        return overrides[material_name].evaluate_at_wavelength(wavelength_um)
+    for key, val in overrides.items():
+        if key.lower().strip() == name_lower:
+            return val.evaluate_at_wavelength(wavelength_um)
 
     props = _resolve_with_overlay(material_name, overlay)
     if props is not None:
@@ -859,12 +919,11 @@ def should_enable_dispersion(
         True if dispersion should be enabled
     """
     overrides = overrides or {}
+    name_lower = material_name.lower().strip()
 
-    if material_name in overrides:
-        return (
-            overrides[material_name].index_variation(wavelength_um, bandwidth_um)
-            > threshold
-        )
+    for key, val in overrides.items():
+        if key.lower().strip() == name_lower:
+            return val.index_variation(wavelength_um, bandwidth_um) > threshold
 
     props = _resolve_with_overlay(material_name, overlay)
     if props is not None:

--- a/src/gsim/common/stack/overlays.py
+++ b/src/gsim/common/stack/overlays.py
@@ -129,12 +129,15 @@ def merge_overlay(
         base = dict(MATERIALS_DB)
 
     merged = dict(base)
+    merged_lower = {k.lower(): k for k in merged}
     for name, props in overlay.items():
-        if name in merged:
-            existing = merged[name]
-            merged[name] = _merge_material(existing, props)
+        name_lower = name.lower()
+        if name_lower in merged_lower:
+            existing_key = merged_lower[name_lower]
+            merged[existing_key] = _merge_material(merged[existing_key], props)
         else:
             merged[name] = props
+            merged_lower[name_lower] = name
 
     return merged
 

--- a/src/gsim/meep/materials.py
+++ b/src/gsim/meep/materials.py
@@ -34,6 +34,7 @@ from gsim.common.stack.materials import (
     ResolvedMaterial,
     _as_list,
     _is_tensor,
+    _normalize_material_keys,
     get_material_properties,
     resolve_material_at_wavelength,
     should_enable_dispersion,
@@ -350,11 +351,14 @@ def resolve_materials(
         Dict mapping material name to MaterialData
     """
     overrides = overrides or {}
+    normalized_overrides = _normalize_material_keys(
+        overrides, used_names=used_material_names, label="overrides"
+    )
     materials: dict[str, MaterialData] = {}
 
     for name in sorted(used_material_names):
-        if name in overrides:
-            props = overrides[name]
+        if name.lower() in normalized_overrides:
+            props = normalized_overrides[name.lower()]
             if wavelength_um is not None:
                 resolved = props.evaluate_at_wavelength(wavelength_um)
                 if resolved.behavior == "conductive":
@@ -454,6 +458,9 @@ def resolve_materials_with_dispersion(
         Dict mapping material name to MaterialData
     """
     overrides = overrides or {}
+    normalized_overrides = _normalize_material_keys(
+        overrides, used_names=used_material_names, label="overrides"
+    )
     materials: dict[str, MaterialData] = {}
     force_dispersion = dispersion == "true"
     force_nodispersion = dispersion == "false"
@@ -462,9 +469,10 @@ def resolve_materials_with_dispersion(
         resolved: ResolvedMaterial | None
         props: MaterialProperties | None = None
 
-        if name in overrides:
-            resolved = overrides[name].evaluate_at_wavelength(wavelength_um)
-            props = overrides[name]
+        if name.lower() in normalized_overrides:
+            override_props = normalized_overrides[name.lower()]
+            resolved = override_props.evaluate_at_wavelength(wavelength_um)
+            props = override_props
         else:
             resolved = resolve_material_at_wavelength(
                 name, wavelength_um, overlay=overlay

--- a/tests/common/test_materials_dispersion.py
+++ b/tests/common/test_materials_dispersion.py
@@ -14,6 +14,7 @@ from gsim.common.stack.materials import (
     ResolvedMaterial,
     SellmeierTerm,
     ValidityRange,
+    _resolve_with_overlay,
     get_material_properties,
     resolve_material_at_wavelength,
     should_enable_dispersion,
@@ -502,3 +503,85 @@ class TestOverlayInResolution:
         resolved = resolve_material_at_wavelength("SiO2", 1.55, overlay=None)
         assert resolved is not None
         assert resolved.permittivity is not None
+
+
+class TestResolveMaterialAtWavelengthCaseInsensitive:
+    """resolve_material_at_wavelength override matching must be
+    case-insensitive."""
+
+    def test_override_different_case(self):
+        overrides = {
+            "sio2": MaterialProperties(permittivity=3.8),
+        }
+        resolved = resolve_material_at_wavelength("SiO2", 1.55, overrides=overrides)
+        assert resolved is not None
+        assert resolved.permittivity == 3.8
+
+    def test_override_whitespace(self):
+        overrides = {
+            "  SiO2  ": MaterialProperties(permittivity=3.8),
+        }
+        resolved = resolve_material_at_wavelength("SiO2", 1.55, overrides=overrides)
+        assert resolved is not None
+        assert resolved.permittivity == 3.8
+
+    def test_no_override_falls_through(self):
+        overrides = {
+            "other": MaterialProperties(permittivity=5.0),
+        }
+        resolved = resolve_material_at_wavelength("SiO2", 1.55, overrides=overrides)
+        assert resolved is not None
+        assert resolved.permittivity is not None
+
+
+class TestShouldEnableDispersionCaseInsensitive:
+    """should_enable_dispersion override matching must be case-insensitive."""
+
+    def test_override_different_case(self):
+        overrides = {
+            "SILICON": MaterialProperties(
+                permittivity=11.9,
+                dispersion_models=[
+                    DispersionModel(
+                        type="sellmeier",
+                        sellmeier_terms=[
+                            SellmeierTerm(B=10.668, C=0.3015**2),
+                        ],
+                        validity=ValidityRange(valid_wavelength=(1.36, 11)),
+                    ),
+                ],
+            ),
+        }
+        result = should_enable_dispersion("silicon", 1.55, 0.5, overrides=overrides)
+        assert result is True
+
+    def test_no_override_falls_through(self):
+        result = should_enable_dispersion(
+            "SiO2", 1.55, 0.1, overrides={"other": MaterialProperties()}
+        )
+        assert isinstance(result, bool)
+
+
+class TestResolveWithOverlayCaseInsensitive:
+    """_resolve_with_overlay must match overlay keys case-insensitively."""
+
+    def test_overlay_different_case_matches(self):
+        overlay = {
+            "sio2": MaterialProperties(permittivity=3.9),
+        }
+        result = _resolve_with_overlay("SiO2", overlay=overlay)
+        assert result is not None
+        assert result.permittivity == 3.9
+
+    def test_overlay_falls_to_merged(self):
+        overlay = {
+            "Si": MaterialProperties(permittivity=11.9),
+        }
+        result = _resolve_with_overlay("silicon", overlay=overlay)
+        assert result is not None
+        assert result.permittivity == 11.9
+
+    def test_no_overlay_falls_to_builtin(self):
+        result = _resolve_with_overlay("SiO2", overlay=None)
+        assert result is not None
+        assert result.permittivity is not None

--- a/tests/common/test_overlays.py
+++ b/tests/common/test_overlays.py
@@ -129,3 +129,20 @@ class TestMergeOverlay:
         }
         merge_overlay(overlay)
         assert len(MATERIALS_DB) == original_count
+
+    def test_merge_case_insensitive_override(self):
+        """merge_overlay matches overlay keys case-insensitively to base."""
+        overlay = {
+            "sio2": MaterialProperties(permittivity=3.8),
+        }
+        merged = merge_overlay(overlay)
+        assert merged["SiO2"].permittivity == 3.8
+
+    def test_merge_case_insensitive_preserves_base(self):
+        """Case-insensitive merge preserves non-overlaid base materials."""
+        overlay = {
+            "custom_material": MaterialProperties(permittivity=5.0),
+        }
+        merged = merge_overlay(overlay)
+        assert "aluminum" in merged
+        assert merged["custom_material"].permittivity == 5.0

--- a/tests/meep/test_material_resolution.py
+++ b/tests/meep/test_material_resolution.py
@@ -409,3 +409,120 @@ class TestResolveMaterialsWithDispersion:
         assert "germanium" in materials
         ge = materials["germanium"]
         assert ge.epsilon_susceptibilities is not None
+
+
+class TestResolveMaterialsCaseInsensitive:
+    """Override key matching must be case-insensitive (issue #163)."""
+
+    def test_override_with_different_case_matches(self):
+        """User set_material('sio2', ...) matches stack material 'SiO2'."""
+        overrides = {
+            "sio2": MaterialProperties(permittivity=3.9),
+        }
+        materials = resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
+        assert "SiO2" in materials
+        assert materials["SiO2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
+
+    def test_override_with_upper_case_matches_lower_stack(self):
+        """User set_material('SIO2', ...) matches stack material 'sio2'."""
+        overrides = {
+            "SIO2": MaterialProperties(permittivity=3.9),
+        }
+        materials = resolve_materials({"sio2"}, overrides=overrides, wavelength_um=1.55)
+        assert "sio2" in materials
+        assert materials["sio2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
+
+    def test_override_with_mixed_case_and_whitespace(self):
+        """Mixed case and whitespace in override keys normalize correctly."""
+        overrides = {
+            "  SiO2  ": MaterialProperties(permittivity=3.9),
+        }
+        materials = resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
+        assert "SiO2" in materials
+        assert materials["SiO2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
+
+    def test_override_without_wavelength_legacy(self):
+        """Case-insensitive override works in legacy (no wavelength) path."""
+        overrides = {
+            "sio2": MaterialProperties(permittivity=3.9),
+        }
+        materials = resolve_materials({"SiO2"}, overrides=overrides)
+        assert "SiO2" in materials
+        assert materials["SiO2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
+
+    def test_duplicate_override_keys_warn(self):
+        """Two overrides that normalize to same key emit a warning."""
+        overrides = {
+            "SiO2": MaterialProperties(permittivity=3.9),
+            "sio2": MaterialProperties(permittivity=4.0),
+        }
+        with pytest.warns(UserWarning, match="Duplicate material entries"):
+            resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
+
+    def test_unmatched_override_key_warns(self):
+        """Override key that matches no stack material emits a warning."""
+        overrides = {
+            "made_up_material": MaterialProperties(permittivity=5.0),
+        }
+        with pytest.warns(UserWarning, match="do not match any material"):
+            resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
+
+    def test_unmatched_override_does_not_break_resolution(self):
+        """Unmatched override key warns but does not prevent resolution of
+        other materials."""
+        overrides = {
+            "unknown_key": MaterialProperties(permittivity=5.0),
+        }
+        with pytest.warns(UserWarning, match="do not match any material"):
+            materials = resolve_materials(
+                {"SiO2"}, overrides=overrides, wavelength_um=1.55
+            )
+        assert "SiO2" in materials
+
+
+class TestResolveMaterialsWithDispersionCaseInsensitive:
+    """resolved_materials_with_dispersion override matching must be
+    case-insensitive."""
+
+    def test_override_case_insensitive(self):
+        overrides = {
+            "SIO2": MaterialProperties(
+                permittivity=3.9,
+                dispersion_models=[
+                    DispersionModel(type="constant", permittivity=3.9),
+                ],
+            ),
+        }
+        materials = resolve_materials_with_dispersion(
+            {"sio2"},
+            overrides=overrides,
+            wavelength_um=1.55,
+            dispersion="false",
+        )
+        assert "sio2" in materials
+        assert materials["sio2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
+
+    def test_duplicate_override_warns(self):
+        overrides = {
+            "SiO2": MaterialProperties(permittivity=3.9),
+            "sio2": MaterialProperties(permittivity=4.0),
+        }
+        with pytest.warns(UserWarning, match="Duplicate material entries"):
+            resolve_materials_with_dispersion(
+                {"SiO2"},
+                overrides=overrides,
+                wavelength_um=1.55,
+                dispersion="false",
+            )
+
+    def test_unmatched_override_warns(self):
+        overrides = {
+            "fake": MaterialProperties(permittivity=5.0),
+        }
+        with pytest.warns(UserWarning, match="do not match any material"):
+            resolve_materials_with_dispersion(
+                {"SiO2"},
+                overrides=overrides,
+                wavelength_um=1.55,
+                dispersion="false",
+            )


### PR DESCRIPTION
Material override keys in sim.materials and PDK overlay keys were matched case-sensitively, silently omitting mis-cased entries. Add _normalize_material_keys() helper and apply case-insensitive matching in resolve_materials, resolve_materials_with_dispersion, _resolve_with_overlay, resolve_material_at_wavelength, should_enable_dispersion, and merge_overlay. Warn on duplicate keys after normalization and on unmatched override keys.