### PR TITLE
feat(docs): add dark theme toggle and gdsfactory header link

### DIFF
--- a/docs/overrides/partials/source.html
+++ b/docs/overrides/partials/source.html
@@ -1,0 +1,20 @@
+<style>
+  /* Invert the white gdsfactory wordmark to dark in light mode so it stays visible. */
+  [data-md-color-scheme="default"] .md-source img {
+    filter: invert(1);
+  }
+</style>
+<a
+  href="{{ config.repo_url }}"
+  title="{{ config.repo_name }}"
+  class="md-source"
+  data-md-component="source"
+  target="_blank"
+  rel="noopener"
+>
+  <img
+    src="https://gdsfactory.com/static/images/GDSF_logo.png"
+    alt="{{ config.repo_name }}"
+    style="height: 0.8rem; width: auto; display: block"
+  />
+</a>

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -31,6 +31,8 @@ nav = [
 site_dir = "site"
 site_name = "gsim"
 site_url = "https://gdsfactory.com/gsim"
+repo_url = "https://gdsfactory.com/"
+repo_name = "gdsfactory.com"
 
 [project.plugins.search]
 
@@ -62,3 +64,20 @@ summary = true
 
 [project.theme]
 name = "material"
+custom_dir = "overrides"
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: light)"
+scheme = "default"
+
+[project.theme.palette.toggle]
+icon = "material/brightness-7"
+name = "Switch to dark mode"
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: dark)"
+scheme = "slate"
+
+[project.theme.palette.toggle]
+icon = "material/brightness-4"
+name = "Switch to light mode"


### PR DESCRIPTION
Builds on the recent zensical migration to add theming and a header link.

- **Dark/light theme**: palette that follows the OS `prefers-color-scheme` with a manual sun/moon toggle (the migrated config had no palette, so docs were light-only).
- **Header link**: replaces the unused source slot (top-right) with a gdsfactory.com logo link, via a `custom_dir` override of `partials/source.html`.
- **Light-mode visibility**: the logo is a white wordmark, so an inline CSS `filter: invert(1)` flips it to dark in light mode. CSS is inlined in the override partial to keep it self-contained.