### PR TITLE
Fix docs formulas and meshing plots rendering

### DIFF
--- a/nbs/_palace_dc.ipynb
+++ b/nbs/_palace_dc.ipynb
@@ -248,20 +248,6 @@
      "text": [
       "\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "99b89e7a2eaa4c27a90723651f4afa97",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:45603/index.html?ui=P_0x74bddd93b3e0_0&reconnect=auto\" class=\"pyvi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [

--- a/nbs/_palace_electrostatic.ipynb
+++ b/nbs/_palace_electrostatic.ipynb
@@ -189,20 +189,6 @@
      "text": [
       "\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "13cd220370864fe1818fbc373211b82e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:41833/index.html?ui=P_0x77330dfa7d10_4&reconnect=auto\" class=\"pyvi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [

--- a/nbs/_palace_mzm.ipynb
+++ b/nbs/_palace_mzm.ipynb
@@ -421,20 +421,6 @@
      "text": [
       "\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3f6b1bb532ec477894489fdf0a206ceb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:45793/index.html?ui=P_0x7f3adbc4acf0_0&reconnect=auto\" class=\"pyvi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -624,20 +610,6 @@
       "|E| stats (valid points): min=0.000e+00, max=6.198e+06\n",
       "z_conductor (from metal3_xy surface): 5.200 um\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "43306af8c82c432a817900fb1c7e79df",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:45793/index.html?ui=P_0x7f397feb93a0_1&reconnect=auto\" class=\"pyvi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -806,20 +778,6 @@
      "text": [
       "\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "05c25a910e774569b8fef53c5818dffb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:45793/index.html?ui=P_0x7f3a4157bbf0_2&reconnect=auto\" class=\"pyvi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [

--- a/nbs/_palace_straight_diel_waveguide.ipynb
+++ b/nbs/_palace_straight_diel_waveguide.ipynb
@@ -176,20 +176,6 @@
      "text": [
       "\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f83aae889aa946e2a25b138717db56af",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:35709/index.html?ui=P_0x7a0b66b2d340_0&reconnect=auto\" class=\"pyvi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [

--- a/nbs/palace_inductor.ipynb
+++ b/nbs/palace_inductor.ipynb
@@ -318,20 +318,6 @@
       "\n",
       "\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3f22913560db4039ba1c6ac78254464c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:39245/index.html?ui=P_0x762615572e70_3&reconnect=auto\" class=\"pyvi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -2282,21 +2268,29 @@
     "\n",
     "The total impedance is:\n",
     "\n",
-    "$$Z(f) = \\frac{1}{j2\\pi f C + \\frac{1}{R + j2\\pi f L}}$$\n",
+    "$$\n",
+    "Z(f) = \\frac{1}{j2\\pi f C + \\frac{1}{R + j2\\pi f L}}\n",
+    "$$\n",
     "\n",
     "We define the RLC impedance as a function of frequency. The total admittance (inverse of impedance) is the sum of the admittance of the series RL branch and the parasitic capacitance:\n",
     "\n",
-    "$$\\frac{1}{Z(f)} = \\frac{1}{R + j2\\pi f L} + j2\\pi f C$$\n",
+    "$$\n",
+    "\\frac{1}{Z(f)} = \\frac{1}{R + j2\\pi f L} + j2\\pi f C\n",
+    "$$\n",
     "\n",
     "We rewrite the RLC impedance in normalized form. Defining $\\tilde\\omega = \\omega/\\omega_0$, the dimensionless impedance is:\n",
     "\n",
-    "$$z(\\tilde\\omega, Q) = \\frac{1 + j\\tilde\\omega Q}{1 - \\tilde\\omega^2 + j\\tilde\\omega/Q}$$\n",
+    "$$\n",
+    "z(\\tilde\\omega, Q) = \\frac{1 + j\\tilde\\omega Q}{1 - \\tilde\\omega^2 + j\\tilde\\omega/Q}\n",
+    "$$\n",
     "\n",
     "so that $Z(f) = R \\cdot z(f/f_0, Q)$.\n",
     "\n",
     "The loss function measures the total squared error between the model and the simulated data across all frequencies:\n",
     "\n",
-    "$$\\mathcal{L}(f_0, Q, R) = \\sum_k \\left| Z_\\text{sim}(f_k) - R \\cdot z(f_k/f_0, Q) \\right|^2$$\n",
+    "$$\n",
+    "\\mathcal{L}(f_0, Q, R) = \\sum_k \\left| Z_\\text{sim}(f_k) - R \\cdot z(f_k/f_0, Q) \\right|^2\n",
+    "$$\n",
     "\n",
     "This is a real-valued scalar that JAX will differentiate with respect to $f_0$, $Q$, and $R$ to drive the optimization."
    ]
@@ -2380,7 +2374,9 @@
     "\n",
     "At each step, Adam computes the gradient $\\nabla_\\theta \\mathcal{L}$ automatically via JAX autodiff and updates the parameters:\n",
     "\n",
-    "$$\\theta_{n+1} = \\theta_n - \\alpha \\cdot \\text{Adam}(\\nabla_\\theta \\mathcal{L}(\\theta_n))$$"
+    "$$\n",
+    "\\theta_{n+1} = \\theta_n - \\alpha \\cdot \\text{Adam}(\\nabla_\\theta \\mathcal{L}(\\theta_n))\n",
+    "$$"
    ]
   },
   {
@@ -2431,7 +2427,9 @@
     "\n",
     "Once converged, $L$ and $C$ are recovered analytically from the fitted $(f_0, Q, R)$ using the RLC resonance relations:\n",
     "\n",
-    "$$L = \\frac{Q \\cdot R}{\\omega_0}, \\quad C = \\frac{1}{L\\omega_0^2}$$\n",
+    "$$\n",
+    "L = \\frac{Q \\cdot R}{\\omega_0}, \\quad C = \\frac{1}{L\\omega_0^2}\n",
+    "$$\n",
     "\n",
     "where $\\omega_0 = 2\\pi f_0$."
    ]
@@ -2553,7 +2551,9 @@
     "\n",
     "The admittance matrix for a symmetric two-port is:\n",
     "\n",
-    "$$Y = \\begin{pmatrix} Y_\\text{tot} & -Y_\\text{tot} \\\\ -Y_\\text{tot} & Y_\\text{tot} \\end{pmatrix}, \\quad Y_\\text{tot} = \\frac{1}{R + j2\\pi f L} + j2\\pi f C$$\n",
+    "$$\n",
+    "Y = \\begin{pmatrix} Y_\\text{tot} & -Y_\\text{tot} \\\\ -Y_\\text{tot} & Y_\\text{tot} \\end{pmatrix}, \\quad Y_\\text{tot} = \\frac{1}{R + j2\\pi f L} + j2\\pi f C\n",
+    "$$\n",
     "\n",
     "The netlist connects the inductor directly between `IN` and `GND` — a single-port measurement configuration, consistent with how $Z_\\text{diff}$ was extracted from the simulation."
    ]

--- a/nbs/palace_inductor.py
+++ b/nbs/palace_inductor.py
@@ -183,21 +183,29 @@ f_sim = f
 #
 # The total impedance is:
 #
-# $$Z(f) = \frac{1}{j2\pi f C + \frac{1}{R + j2\pi f L}}$$
+# $$
+# Z(f) = \frac{1}{j2\pi f C + \frac{1}{R + j2\pi f L}}
+# $$
 #
 # We define the RLC impedance as a function of frequency. The total admittance (inverse of impedance) is the sum of the admittance of the series RL branch and the parasitic capacitance:
 #
-# $$\frac{1}{Z(f)} = \frac{1}{R + j2\pi f L} + j2\pi f C$$
+# $$
+# \frac{1}{Z(f)} = \frac{1}{R + j2\pi f L} + j2\pi f C
+# $$
 #
 # We rewrite the RLC impedance in normalized form. Defining $\tilde\omega = \omega/\omega_0$, the dimensionless impedance is:
 #
-# $$z(\tilde\omega, Q) = \frac{1 + j\tilde\omega Q}{1 - \tilde\omega^2 + j\tilde\omega/Q}$$
+# $$
+# z(\tilde\omega, Q) = \frac{1 + j\tilde\omega Q}{1 - \tilde\omega^2 + j\tilde\omega/Q}
+# $$
 #
 # so that $Z(f) = R \cdot z(f/f_0, Q)$.
 #
 # The loss function measures the total squared error between the model and the simulated data across all frequencies:
 #
-# $$\mathcal{L}(f_0, Q, R) = \sum_k \left| Z_\text{sim}(f_k) - R \cdot z(f_k/f_0, Q) \right|^2$$
+# $$
+# \mathcal{L}(f_0, Q, R) = \sum_k \left| Z_\text{sim}(f_k) - R \cdot z(f_k/f_0, Q) \right|^2
+# $$
 #
 # This is a real-valued scalar that JAX will differentiate with respect to $f_0$, $Q$, and $R$ to drive the optimization.
 
@@ -250,7 +258,9 @@ print(f"f0 = {f0_ini / 1e9:.3f} GHz | Q = {Q_ini:.3f} | R = {R_ini:.4f} Ohm")
 #
 # At each step, Adam computes the gradient $\nabla_\theta \mathcal{L}$ automatically via JAX autodiff and updates the parameters:
 #
-# $$\theta_{n+1} = \theta_n - \alpha \cdot \text{Adam}(\nabla_\theta \mathcal{L}(\theta_n))$$
+# $$
+# \theta_{n+1} = \theta_n - \alpha \cdot \text{Adam}(\nabla_\theta \mathcal{L}(\theta_n))
+# $$
 
 # %%
 import optax
@@ -277,7 +287,9 @@ f0_fit, Q_fit, R_fit = float(par[0]), float(par[1]), float(par[2])
 #
 # Once converged, $L$ and $C$ are recovered analytically from the fitted $(f_0, Q, R)$ using the RLC resonance relations:
 #
-# $$L = \frac{Q \cdot R}{\omega_0}, \quad C = \frac{1}{L\omega_0^2}$$
+# $$
+# L = \frac{Q \cdot R}{\omega_0}, \quad C = \frac{1}{L\omega_0^2}
+# $$
 #
 # where $\omega_0 = 2\pi f_0$.
 
@@ -337,7 +349,9 @@ plt.show()
 #
 # The admittance matrix for a symmetric two-port is:
 #
-# $$Y = \begin{pmatrix} Y_\text{tot} & -Y_\text{tot} \\ -Y_\text{tot} & Y_\text{tot} \end{pmatrix}, \quad Y_\text{tot} = \frac{1}{R + j2\pi f L} + j2\pi f C$$
+# $$
+# Y = \begin{pmatrix} Y_\text{tot} & -Y_\text{tot} \\ -Y_\text{tot} & Y_\text{tot} \end{pmatrix}, \quad Y_\text{tot} = \frac{1}{R + j2\pi f L} + j2\pi f C
+# $$
 #
 # The netlist connects the inductor directly between `IN` and `GND` — a single-port measurement configuration, consistent with how $Z_\text{diff}$ was extracted from the simulation.
 

--- a/nbs/palace_qpdk_resonator.ipynb
+++ b/nbs/palace_qpdk_resonator.ipynb
@@ -384,20 +384,6 @@
       "Task was destroyed but it is pending!\n",
       "task: <Task pending name='Task-13' coro=<_async_in_context.<locals>.run_in_context() running at /home/bench/dev/gds/dev/gsim/.venv/lib/python3.12/site-packages/ipykernel/utils.py:60> wait_for=<Task pending name='Task-14' coro=<Kernel.shell_main() running at /home/bench/dev/gds/dev/gsim/.venv/lib/python3.12/site-packages/ipykernel/kernelbase.py:597> cb=[Task.__wakeup()]> cb=[ZMQStream._run_callback.<locals>._log_error() at /home/bench/dev/gds/dev/gsim/.venv/lib/python3.12/site-packages/zmq/eventloop/zmqstream.py:563]>\n"
      ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f7746244ecbb42b691892a685dcad7b7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Widget(value='<iframe src=\"http://localhost:34817/index.html?ui=P_0x7f9b01f38c50_0&reconnect=auto\" class=\"pyvi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [


### PR DESCRIPTION
## Summary
- Fix LaTeX display math formatting in notebook markdown cells — put `$$` delimiters on separate lines so GitHub renders the math properly
- Remove PyVista widget outputs that render as raw `Widget(value='<iframe...')` text on GitHub

Closes #184

> Reminder: AI-created PRs still require human review of the actual code changes before merge.

## Test plan
- [ ] Verify math renders correctly on GitHub notebook viewer
- [ ] Verify widget text is no longer visible
- [ ] Check docs site renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)