### PR TITLE
docs: fix broken changelog and API reference links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ dist/
 docs/_build/
 docs/nbs/
 docs/site/
+docs/CHANGELOG.md
 downloads/
 eggs/
 env.bak/

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,4 +62,5 @@ result = sim.run()
 
 ## API Reference
 
-See the [API docs](api.md) for full details.
+See the API docs for full details: [Palace](api/palace.md), [Meep](api/meep.md), [Common](api/common.md),
+[Cloud](api/cloud.md).

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -22,7 +22,7 @@ nav = [
     { "CPW Via Transition" = "nbs/palace_cpw_via.md" },
     { "Field Visualization" = "nbs/palace_cpw_fields.md" }
   ] },
-  { "Changelog" = "../CHANGELOG.md" },
+  { "Changelog" = "CHANGELOG.md" },
   { "API Reference" = [
     { "Palace" = "api/palace.md" },
     { "Meep" = "api/meep.md" },

--- a/justfile
+++ b/justfile
@@ -37,10 +37,14 @@ test:
 cov:
   uv run pytest --cov=gsim --cov-report=term-missing:skip-covered --cov-report=xml
 
-docs:
+# Copy the root CHANGELOG into docs/ so zensical can build it (docs_dir is docs/)
+sync-changelog:
+  cp CHANGELOG.md docs/CHANGELOG.md
+
+docs: sync-changelog
   uv run zensical build -f docs/zensical.toml
 
-serve:
+serve: sync-changelog
   uv run zensical serve -f docs/zensical.toml -a localhost:8080
 
 # Run a notebook normally (interactive plots): just nbrun nbs/foo.ipynb


### PR DESCRIPTION
## What

Two broken links on the GitHub Pages docs:

1. **Changelog** — the nav pointed to `../CHANGELOG.md`, which lives outside `docs_dir` (`docs/`), so zensical never built the page and the nav link was dead. Now `CHANGELOG.md` is copied into `docs/` before the build (mirroring how `nbs/` are handled) via a `sync-changelog` justfile recipe that both `docs` and `serve` depend on. Root `CHANGELOG.md` stays the single source of truth; the copy is gitignored.

2. **API Reference** — the home page linked to a nonexistent `api.md`. Repointed to the actual per-solver pages (Palace, Meep, Common, Cloud).

## Verified

`just docs` now reports **"No issues found"** and generates `docs/site/CHANGELOG/`.