### PR TITLE
fix(meep): repair mode-solver parity rejection test

### DIFF
--- a/tests/meep/test_mode_solver.py
+++ b/tests/meep/test_mode_solver.py
@@ -621,7 +621,7 @@ class TestModeSolver:
         from gsim.meep.models.api import ModeSolver
 
         with pytest.raises(ValidationError):
-            ModeSolver(wavelengths=[1.55], parity="EVEN_Z")  # ty: ignore[invalid-argument-type]
+            ModeSolver(wavelengths=[1.55], parity="EVEN_X")  # ty: ignore[invalid-argument-type]
 
     def test_fundamental_sets_bands(self):
         """fundamental() sets num_bands=1, band=None."""


### PR DESCRIPTION
The `test_parity_rejects_invalid` test that landed with the mode-solver PR (#174) was failing on main across macos, windows, and the coverage job.

The test constructed `ModeSolver(parity="EVEN_Z")` expecting a `ValidationError`, but `"EVEN_Z"` is a valid member of the `parity` Literal (`api.py`), so Pydantic accepted it and nothing was raised (`DID NOT RAISE ValidationError`).

Switch the test to `parity="EVEN_X"`, which is genuinely not a member of the Literal, so the rejection path is actually exercised.

Note: the `ubuntu-latest` job's 6h timeout on that run is a separate, unrelated issue.