### PR TITLE
docs: simplify eigenmode nav labels and de-emphasize solver in titles

### DIFF
--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -12,9 +12,9 @@ nav = [
     { "2D Grating Coupler: Wavelength Sweep" = "nbs/meep_2d_xz_gc_wavelength_sweep.md" }
   ] },
   { "Eigenmode Analysis" = [
-    { "MEEP — Rib Waveguide" = "nbs/meep_mode_solver_rib.md" },
-    { "MEEP — SOI Slab" = "nbs/meep_mode_solver_soi.md" },
-    { "MEEP — TFLN Ridge" = "nbs/meep_mode_solver_tfln.md" }
+    { "Rib Waveguide" = "nbs/meep_mode_solver_rib.md" },
+    { "SOI Slab" = "nbs/meep_mode_solver_soi.md" },
+    { "TFLN Ridge" = "nbs/meep_mode_solver_tfln.md" }
   ] },
   { "FEM for RF" = [
     { "CPW (Lumped Ports)" = "nbs/palace_cpw_lumped.md" },

--- a/nbs/meep_mode_solver_rib.ipynb
+++ b/nbs/meep_mode_solver_rib.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# MEEP Mode Solver — Rib Waveguide\n",
+    "# Mode Solver — Rib Waveguide (meep)\n",
     "\n",
     "Fundamental TE mode of a silicon rib waveguide: ``n_eff`` + 2D (Y, Z) field profile.\n",
     "\n",

--- a/nbs/meep_mode_solver_rib.py
+++ b/nbs/meep_mode_solver_rib.py
@@ -14,7 +14,7 @@
 # ---
 
 # %% [markdown] papermill={"duration": 0.002045, "end_time": "2026-07-24T11:58:07.011380", "exception": false, "start_time": "2026-07-24T11:58:07.009335", "status": "completed"}
-# # MEEP Mode Solver — Rib Waveguide
+# # Mode Solver — Rib Waveguide (meep)
 #
 # Fundamental TE mode of a silicon rib waveguide: ``n_eff`` + 2D (Y, Z) field profile.
 #

--- a/nbs/meep_mode_solver_soi.ipynb
+++ b/nbs/meep_mode_solver_soi.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# MEEP Eigenmode Solver — 1D Slab Modes\n",
+    "# Eigenmode Solver — 1D Slab Modes (meep)\n",
     "\n",
     "Solve 1D slab modes with ``sim.mode_solver()`` + ``sim.solve_modes()``.\n",
     "Runs on GDSFactory+ cloud by default; ``sim.solve_modes_local()`` for local MEEP."

--- a/nbs/meep_mode_solver_soi.py
+++ b/nbs/meep_mode_solver_soi.py
@@ -14,7 +14,7 @@
 # ---
 
 # %% [markdown] papermill={"duration": 0.002263, "end_time": "2026-07-24T09:46:47.879125", "exception": false, "start_time": "2026-07-24T09:46:47.876862", "status": "completed"}
-# # MEEP Eigenmode Solver — 1D Slab Modes
+# # Eigenmode Solver — 1D Slab Modes (meep)
 #
 # Solve 1D slab modes with ``sim.mode_solver()`` + ``sim.solve_modes()``.
 # Runs on GDSFactory+ cloud by default; ``sim.solve_modes_local()`` for local MEEP.

--- a/nbs/meep_mode_solver_tfln.ipynb
+++ b/nbs/meep_mode_solver_tfln.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# MEEP Mode Solver — TFLN Ridge Waveguide\n",
+    "# Mode Solver — TFLN Ridge Waveguide (meep)\n",
     "\n",
     "Fundamental TE mode of thin-film lithium niobate ridge waveguide at lambda=1.55 µm.\n",
     "Reference: Ying Li et al., ACS Omega 2023, 8(10), 9644–9651.\n",

--- a/nbs/meep_mode_solver_tfln.py
+++ b/nbs/meep_mode_solver_tfln.py
@@ -14,7 +14,7 @@
 # ---
 
 # %% [markdown] papermill={"duration": 0.003127, "end_time": "2026-07-24T12:00:00.754624", "exception": false, "start_time": "2026-07-24T12:00:00.751497", "status": "completed"}
-# # MEEP Mode Solver — TFLN Ridge Waveguide
+# # Mode Solver — TFLN Ridge Waveguide (meep)
 #
 # Fundamental TE mode of thin-film lithium niobate ridge waveguide at lambda=1.55 µm.
 # Reference: Ying Li et al., ACS Omega 2023, 8(10), 9644–9651.


### PR DESCRIPTION
Follow-up to the Eigenmode Analysis section.

- Nav: drop the `MEEP —` prefix from the section entries (now just `Rib Waveguide`, `SOI Slab`, `TFLN Ridge`).
- Notebook titles: move the solver into lowercase brackets for less emphasis, e.g. `MEEP Mode Solver — Rib Waveguide` → `Mode Solver — Rib Waveguide (meep)`.

Markdown/config only — no notebook re-execution needed.