### PR TITLE
fix(palace): omit BoundaryMode Target when set to auto

### DIFF
--- a/src/gsim/palace/models/problems.py
+++ b/src/gsim/palace/models/problems.py
@@ -322,10 +322,11 @@ class BoundaryModeConfig(BaseModel):
             "Freq": self.freq / 1e9,
             "N": self.num_modes,
             "Save": self.save,
-            "Target": self.target,
             "Tol": self.tolerance,
             "Type": self.solver_type,
         }
+        if self.target > 0:  # Palace requires Target > 0 when present; 0 means auto
+            config["Target"] = self.target
         if (
             self.max_size > 0
         ):  # Even when the default is zero, passing it explicitly makes Palace fail

--- a/tests/palace/test_boundarymode_models.py
+++ b/tests/palace/test_boundarymode_models.py
@@ -53,3 +53,9 @@ class TestBoundaryModeConfig:
         assert result["MaxSize"] == 80
         assert result["Type"] == "SLEPc"
         assert "Attributes" not in result
+
+    def test_to_palace_config_omits_auto_target(self):
+        """target=0 means automatic shift, so Target is left out of the config."""
+        result = BoundaryModeConfig(freq=50e9, num_modes=2, save=2).to_palace_config()
+        assert "Target" not in result
+        assert "MaxSize" not in result


### PR DESCRIPTION
`BoundaryModeConfig.to_palace_config()` always emitted `"Target"`, so the documented `target=0` ("automatic shift") sentinel reached Palace as `Target: 0.0`. Palace 0.17.0 declares `Solver.BoundaryMode.Target` with `exclusiveMinimum: 0.0`, so schema validation fails and the solver aborts before the solve starts:

```
At ["Solver"]["BoundaryMode"]["Target"]: instance is below or equals minimum of 0.0
MFEM abort: Configuration file validation failed!
```

`Target` is optional — when omitted Palace derives the shift-and-invert target from material properties (`k_n = (ω / c_min) × √1.1`). So the fix is to guard the key, exactly as `MaxSize` already is a few lines below.

This only bit newer Palace builds: when BoundaryMode landed the schema had `minimum: 0.0` (inclusive), which is why an older locally-built Palace accepts the same config that the released 0.17.0 rejects.

Verified by validating a real failing 2D job config against Palace v0.17.0's `config-schema.json` (`urn:palace:schema:1-0-0`): 1 error before, 0 after dropping `Target`.

Note: `tests/palace/test_field_viz.py` has 4 failures on this branch, but they reproduce unchanged on `main` — a pyvista API change removed the `algorithm=` kwarg from `extract_surface()`. Unrelated to this PR.