### PR TITLE
feat: derive cloud cache key from simulation inputs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,7 +7,12 @@ concurrency:
   cancel-in-progress: true
 jobs:
   claude-review:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # Skip on PRs from forks: secrets (including ANTHROPIC_API_KEY) are not
+    # exposed to fork workflows, so the action can only fail. Deliberately not
+    # switched to pull_request_target -- that would hand the repo secrets and a
+    # write-scoped token to a run that checks out untrusted PR code.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,16 @@
 name: PR Labeler
 on:
-  pull_request:
+  # pull_request_target so the job still gets a write-scoped token on PRs from
+  # forks (a plain pull_request token is read-only there, and addLabels 403s).
+  # Safe here: nothing from the PR is checked out or executed, the title is
+  # only regex-tested, and the job stays read-only towards code.
+  pull_request_target:
     types: [opened, edited]
 jobs:
   label:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
     - uses: actions/github-script@v7

--- a/docs/api/cloud.md
+++ b/docs/api/cloud.md
@@ -17,3 +17,29 @@
       show_source: false
       inherited_members: false
       members: false
+
+## Result caching
+
+Passing `check_cache=True` to `sim.run()` looks for a completed cloud job with
+byte-identical inputs and reuses its results instead of submitting a new job:
+
+```python
+sp = sim.run(check_cache=True)
+```
+
+The cache key is derived from the files written by `write_config()` — the same
+bytes the solver consumes — rather than from the simulation object, so it also
+covers changes to the generated solver script. A lookup failure is never fatal:
+it degrades to a normal submit.
+
+::: gsim.gcloud.check_cache
+    options:
+      show_source: false
+
+::: gsim.gcloud.check_cache_for_dir
+    options:
+      show_source: false
+
+::: gsim.hashing.compute_input_hash
+    options:
+      show_source: false

--- a/src/gsim/gcloud.py
+++ b/src/gsim/gcloud.py
@@ -69,6 +69,8 @@ def _is_forbidden_error(exc: Exception) -> bool:
 __all__ = [
     "CloudSimulationNotEnabledError",
     "RunResult",
+    "check_cache",
+    "check_cache_for_dir",
     "get_status",
     "print_job_summary",
     "register_result_parser",
@@ -216,6 +218,78 @@ def _get_job_definition(job_type: str):
     return getattr(sim.JobDefinition, job_type_upper)
 
 
+# ---------------------------------------------------------------------------
+# Result cache
+# ---------------------------------------------------------------------------
+
+
+def _sdk_accepts(func: Any, param: str) -> bool:
+    """Return True if *func* accepts a keyword argument named *param*.
+
+    Used to stay compatible with SDK versions released before the caching
+    parameters existed.
+    """
+    import inspect
+
+    try:
+        return param in inspect.signature(func).parameters
+    except (TypeError, ValueError):  # pragma: no cover - builtins / C funcs
+        return False
+
+
+def check_cache(job_type: str, input_hash: str) -> str | None:
+    """Look up a previously completed job with identical inputs.
+
+    Never raises: a cache lookup is an optimization, so an unsupported SDK,
+    a transient network error, or a server error all degrade to a miss and
+    the caller submits the job normally.
+
+    Args:
+        job_type: Solver name, e.g. ``"meep"`` or ``"palace"``.
+        input_hash: Value from :func:`gsim.hashing.compute_input_hash`.
+
+    Returns:
+        ``job_id`` of the cached job, or ``None`` on a miss.
+    """
+    sdk_check = getattr(sim, "check_cache", None)
+    if sdk_check is None:
+        logger.debug(
+            "Installed gdsfactoryplus has no check_cache(); skipping cache lookup"
+        )
+        return None
+
+    try:
+        result = sdk_check(
+            job_definition=_get_job_definition(job_type),
+            input_hash=input_hash,
+        )
+    except Exception as exc:
+        logger.debug("Cache lookup failed (%s); submitting normally", exc)
+        return None
+
+    if not getattr(result, "cached", False):
+        return None
+    return getattr(result, "job_id", None)
+
+
+def check_cache_for_dir(input_dir: str | Path, job_type: str) -> tuple[str, str | None]:
+    """Hash a prepared input directory and look it up in the cloud cache.
+
+    Args:
+        input_dir: Directory holding the files that would be uploaded.
+        job_type: Solver name, e.g. ``"meep"`` or ``"palace"``.
+
+    Returns:
+        ``(input_hash, job_id)`` where ``job_id`` is ``None`` on a cache
+        miss. The hash is returned either way so the caller can pass it to
+        :func:`upload` and populate the cache for the next run.
+    """
+    from gsim.hashing import compute_input_hash
+
+    input_hash = compute_input_hash(input_dir, job_type)
+    return input_hash, check_cache(job_type, input_hash)
+
+
 def _download_job(job, parent_dir: str | Path | None, verbose: bool) -> RunResult:
     """Download results from a finished job.
 
@@ -277,6 +351,7 @@ def upload(
     job_type: str,
     *,
     verbose: bool = True,
+    input_hash: str | None = None,
 ) -> str:
     """Upload simulation files to the cloud. Does NOT start execution.
 
@@ -284,6 +359,10 @@ def upload(
         config_dir: Directory containing simulation config files.
         job_type: Simulation type (e.g. ``"palace"``, ``"meep"``).
         verbose: Print progress messages.
+        input_hash: Optional cache key from
+            :func:`gsim.hashing.compute_input_hash`. Recorded server-side so
+            a later identical run can be served from cache. Ignored by SDK
+            versions that predate the caching API.
 
     Returns:
         ``job_id`` string that can be passed to :func:`start`,
@@ -296,7 +375,10 @@ def upload(
     if verbose:
         print("Uploading simulation... ", end="", flush=True)  # noqa: T201
 
-    pre_job = upload_simulation_dir(config_dir, job_type)
+    # Only forward input_hash when set, keeping the call shape unchanged for
+    # callers that don't use caching.
+    extra = {"input_hash": input_hash} if input_hash is not None else {}
+    pre_job = upload_simulation_dir(config_dir, job_type, **extra)
 
     if verbose:
         print(f"done (job_id: {pre_job.job_id})")  # noqa: T201
@@ -591,12 +673,19 @@ class CloudSimulationNotEnabledError(Exception):
     """Raised when the user's account does not have cloud simulation enabled."""
 
 
-def upload_simulation_dir(input_dir: str | Path, job_type: str):
+def upload_simulation_dir(
+    input_dir: str | Path,
+    job_type: str,
+    *,
+    input_hash: str | None = None,
+):
     """Upload a simulation directory for cloud execution.
 
     Args:
         input_dir: Directory containing simulation files
         job_type: Simulation type (e.g., "palace")
+        input_hash: Optional cache key recorded with the job. Silently
+            dropped when the installed SDK does not support it.
 
     Returns:
         PreJob object from gdsfactoryplus
@@ -606,8 +695,19 @@ def upload_simulation_dir(input_dir: str | Path, job_type: str):
     """
     input_dir = Path(input_dir)
     job_definition = _get_job_definition(job_type)
+    kwargs: dict[str, Any] = {}
+    if input_hash is not None:
+        if _sdk_accepts(sim.upload_simulation, "input_hash"):
+            kwargs["input_hash"] = input_hash
+        else:
+            logger.debug(
+                "Installed gdsfactoryplus does not accept input_hash; "
+                "uploading without a cache key"
+            )
     try:
-        return sim.upload_simulation(path=input_dir, job_definition=job_definition)
+        return sim.upload_simulation(
+            path=input_dir, job_definition=job_definition, **kwargs
+        )
     except Exception as exc:
         if _is_forbidden_error(exc):
             raise CloudSimulationNotEnabledError(

--- a/src/gsim/hashing.py
+++ b/src/gsim/hashing.py
@@ -1,0 +1,151 @@
+"""Deterministic hashing of simulation inputs for cloud result caching.
+
+The cache key for a cloud job is derived from the *materialized* simulation
+inputs — the files written by ``write_config()`` — rather than from the
+simulation object itself.
+
+Hashing the pydantic model directly would be fragile: the simulation models
+hold gdsfactory ``Component`` references, ``LayerStack`` and material objects,
+callables, and private path attributes, none of which serialize stably across
+processes. More importantly, a model dump would miss the generated solver
+script, which does change results.
+
+The written config directory, by contrast, is exactly the set of bytes the
+solver consumes, and it is produced on every submit anyway, so hashing it is
+close to free::
+
+    digest = sha256 over sorted (relpath, sha256(file_bytes)) pairs
+    key    = sha256(digest || job_type || gsim_version)
+
+Usage:
+    from gsim.hashing import compute_input_hash
+
+    sim.write_config(config_dir)
+    input_hash = compute_input_hash(config_dir, job_type="meep")
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+__all__ = ["HASH_PREFIX", "compute_dir_digest", "compute_input_hash"]
+
+HASH_PREFIX = "sha256:"
+"""Prefix the cloud API expects on an ``input_hash`` value."""
+
+_CHUNK_SIZE = 1024 * 1024
+
+#: Files and directories that never affect simulation results.
+_IGNORED_NAMES = frozenset({".DS_Store", "__pycache__", ".ipynb_checkpoints"})
+
+
+def _iter_files(input_dir: Path):
+    """Yield regular files under *input_dir*, sorted by POSIX relative path.
+
+    Ignores editor/interpreter droppings that cannot affect the solver run.
+
+    Args:
+        input_dir: Directory to walk.
+
+    Yields:
+        ``(relative_posix_path, absolute_path)`` pairs in sorted order.
+    """
+    entries: list[tuple[str, Path]] = []
+    for path in input_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        rel_parts = path.relative_to(input_dir).parts
+        if any(part in _IGNORED_NAMES for part in rel_parts):
+            continue
+        entries.append(("/".join(rel_parts), path))
+    entries.sort(key=lambda item: item[0])
+    yield from entries
+
+
+def _file_digest(path: Path) -> str:
+    """Return the hex SHA-256 digest of a file's contents.
+
+    Args:
+        path: File to hash.
+
+    Returns:
+        Lowercase hex digest.
+    """
+    hasher = hashlib.sha256()
+    with path.open("rb") as fh:
+        while chunk := fh.read(_CHUNK_SIZE):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def compute_dir_digest(input_dir: str | Path) -> str:
+    """Compute a deterministic digest of a directory's contents.
+
+    The digest covers both file names (as POSIX-style relative paths, so it
+    is stable across operating systems) and file bytes. It does not cover
+    file modes, timestamps, or directory entries that hold no files.
+
+    Args:
+        input_dir: Directory to digest.
+
+    Returns:
+        Lowercase hex SHA-256 digest of the directory contents.
+
+    Raises:
+        FileNotFoundError: If *input_dir* does not exist.
+        ValueError: If *input_dir* contains no files.
+    """
+    input_dir = Path(input_dir)
+    if not input_dir.is_dir():
+        raise FileNotFoundError(f"Input directory not found: {input_dir}")
+
+    hasher = hashlib.sha256()
+    count = 0
+    for rel_path, path in _iter_files(input_dir):
+        hasher.update(rel_path.encode("utf-8"))
+        hasher.update(b"\0")
+        hasher.update(_file_digest(path).encode("ascii"))
+        hasher.update(b"\n")
+        count += 1
+
+    if count == 0:
+        raise ValueError(f"Input directory is empty: {input_dir}")
+
+    return hasher.hexdigest()
+
+
+def compute_input_hash(input_dir: str | Path, job_type: str) -> str:
+    """Compute the cloud cache key for a prepared simulation input directory.
+
+    Folds the solver name and the gsim version into the directory digest.
+    Including the gsim version is deliberately conservative: gsim generates
+    the solver driver script, so an upgrade may change results even when the
+    written inputs are byte-identical. It can be dropped once the server-side
+    key includes the solver image version.
+
+    Args:
+        input_dir: Directory holding the files that will be uploaded.
+        job_type: Solver name, e.g. ``"meep"`` or ``"palace"``.
+
+    Returns:
+        ``"sha256:<hex>"`` — the value to pass as ``input_hash``.
+
+    Raises:
+        FileNotFoundError: If *input_dir* does not exist.
+        ValueError: If *input_dir* contains no files.
+
+    Example:
+        >>> compute_input_hash("./sim", "meep")  # doctest: +SKIP
+        'sha256:6a1f...'
+    """
+    from gsim import __version__
+
+    digest = compute_dir_digest(input_dir)
+    hasher = hashlib.sha256()
+    hasher.update(digest.encode("ascii"))
+    hasher.update(b"\0")
+    hasher.update(job_type.lower().encode("utf-8"))
+    hasher.update(b"\0")
+    hasher.update(__version__.encode("utf-8"))
+    return f"{HASH_PREFIX}{hasher.hexdigest()}"

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -319,6 +319,7 @@ class Simulation(BaseModel):
     # Cloud job state (set by upload/run)
     _job_id: str | None = PrivateAttr(default=None)
     _config_dir: Path | None = PrivateAttr(default=None)
+    _input_hash: str | None = PrivateAttr(default=None)
 
     # PDK overlay (foundry-specific material values, loaded from YAML)
     _pdk_overlay: dict[str, Any] | None = PrivateAttr(default=None)
@@ -1548,6 +1549,19 @@ class Simulation(BaseModel):
     # Cloud: fine-grained control
     # -------------------------------------------------------------------------
 
+    def _prepare_upload_dir(self) -> Path:
+        """Write the config files to a fresh temp directory for upload.
+
+        Returns:
+            Path to the temp directory, also recorded on ``_config_dir``.
+        """
+        import tempfile
+
+        tmp = Path(tempfile.mkdtemp(prefix="meep_"))
+        self.write_config(tmp)
+        self._config_dir = tmp
+        return tmp
+
     def upload(self, *, verbose: bool = True) -> str:
         """Write config and upload to the cloud. Does NOT start execution.
 
@@ -1558,14 +1572,14 @@ class Simulation(BaseModel):
             ``job_id`` string for use with :meth:`start`, :meth:`get_status`,
             or :func:`gsim.wait_for_results`.
         """
-        import tempfile
-
         from gsim import gcloud
+        from gsim.hashing import compute_input_hash
 
-        tmp = Path(tempfile.mkdtemp(prefix="meep_"))
-        self.write_config(tmp)
-        self._config_dir = tmp
-        self._job_id = gcloud.upload(tmp, "meep", verbose=verbose)
+        tmp = self._prepare_upload_dir()
+        self._input_hash = compute_input_hash(tmp, "meep")
+        self._job_id = gcloud.upload(
+            tmp, "meep", verbose=verbose, input_hash=self._input_hash
+        )
         return self._job_id
 
     def start(self, *, verbose: bool = True) -> None:
@@ -1633,6 +1647,7 @@ class Simulation(BaseModel):
         *,
         verbose: Literal["quiet", "status", "full"] = "status",
         wait: bool = True,
+        check_cache: bool = False,
     ) -> Any:
         """Run MEEP simulation on the cloud.
 
@@ -1643,13 +1658,32 @@ class Simulation(BaseModel):
                 ``"full"`` stream solver logs.
             wait: If ``True`` (default), block until results are ready.
                 If ``False``, upload + start and return the ``job_id``.
+            check_cache: If ``True``, look for a completed cloud job with
+                byte-identical inputs and reuse its results instead of
+                submitting. A lookup failure degrades to a normal submit.
 
         Returns:
             ``SParameterResult`` when ``wait=True``, or ``job_id`` string
             when ``wait=False``.
         """
+        from gsim import gcloud
+
         self._run_verbose = verbose
-        self.upload(verbose=False)
+        if check_cache:
+            tmp = self._prepare_upload_dir()
+            self._input_hash, cached_job_id = gcloud.check_cache_for_dir(tmp, "meep")
+            if cached_job_id is not None:
+                self._job_id = cached_job_id
+                if verbose != "quiet":
+                    print(f"Cache hit: reusing job {cached_job_id}")  # noqa: T201
+                if not wait:
+                    return self._job_id
+                return self.wait_for_results(verbose=verbose, parent_dir=parent_dir)
+            self._job_id = gcloud.upload(
+                tmp, "meep", verbose=False, input_hash=self._input_hash
+            )
+        else:
+            self.upload(verbose=False)
         self.start(verbose=verbose != "quiet")
         if not wait:
             return self._job_id

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -1399,6 +1399,8 @@ class Simulation(BaseModel):
         Raises:
             ValueError: If config is invalid.
         """
+        import klayout.db as kdb
+
         from gsim.meep.script import generate_meep_script
 
         output_dir = Path(output_dir)
@@ -1406,8 +1408,30 @@ class Simulation(BaseModel):
 
         result = self.build_config()
 
-        # Write extended component GDS
-        result.component.write_gds(output_dir / "layout.gds")
+        # The solver only consumes polygons, so write a canonical flattened
+        # layout without metadata, hierarchy names, or timestamps. Those GDS
+        # details do not affect the simulation but would change the cache key.
+        gds_path = output_dir / "layout.gds"
+        save_options = kdb.SaveLayoutOptions()
+        save_options.gds2_write_timestamps = False
+        result.component.write_gds(
+            gds_path,
+            save_options=save_options,
+            with_metadata=False,
+        )
+
+        canonical_layout = kdb.Layout()
+        canonical_layout.read(str(gds_path))
+        top_cells = canonical_layout.top_cells()
+        if len(top_cells) != 1:  # pragma: no cover - write_gds emits one top cell
+            raise RuntimeError(f"Expected one top GDS cell, found {len(top_cells)}")
+        top_cell = top_cells[0]
+        top_cell.flatten(True)
+        top_cell.name = "layout"
+        save_options.select_this_cell(top_cell.cell_index())
+        save_options.gds2_write_cell_properties = False
+        save_options.gds2_write_file_properties = False
+        canonical_layout.write(str(gds_path), save_options)
 
         # Write JSON config
         result.config.to_json(output_dir / "sim_config.json")

--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -59,6 +59,8 @@ class PalaceSimMixin:
     terminals: list[TerminalConfig]
     simulation_type: Literal["driven", "eigenmode", "electrostatic", "boundarymode"]
     _output_dir: Path | None
+    _job_id: str | None
+    _input_hash: str | None
     _stack_kwargs: dict[str, Any]
     _pec_blocks: list
     _hints: dict[str, Any]
@@ -1490,10 +1492,14 @@ class PalaceSimMixin:
             or :func:`gsim.wait_for_results`.
         """
         from gsim import gcloud
+        from gsim.hashing import compute_input_hash
 
         tmp = self._prepare_upload_dir()
         try:
-            self._job_id = gcloud.upload(tmp, "palace", verbose=verbose)
+            self._input_hash = compute_input_hash(tmp, "palace")
+            self._job_id = gcloud.upload(
+                tmp, "palace", verbose=verbose, input_hash=self._input_hash
+            )
         except Exception:
             import shutil
 
@@ -1565,6 +1571,7 @@ class PalaceSimMixin:
         *,
         verbose: Literal["quiet", "status", "full"] = "status",
         wait: bool = True,
+        check_cache: bool = False,
     ) -> SParams | dict[str, Path] | str:
         """Run simulation on GDSFactory+ cloud.
 
@@ -1576,6 +1583,9 @@ class PalaceSimMixin:
                 Defaults to the current working directory.
             verbose: ``"quiet"`` no output, ``"status"`` status line,
                 ``"full"`` stream solver logs.
+            check_cache: If ``True``, look for a completed cloud job with
+                byte-identical inputs and reuse its results instead of
+                submitting. A lookup failure degrades to a normal submit.
             wait: If ``True`` (default), block until results are ready.
                 If ``False``, upload + start and return the ``job_id``.
 
@@ -1599,7 +1609,23 @@ class PalaceSimMixin:
             >>> results = eigen_sim.run()  # returns dict[str, Path]
             >>> print(results["eig.csv"])
         """
-        self.upload(verbose=False)
+        from gsim import gcloud
+
+        if check_cache:
+            tmp = self._prepare_upload_dir()
+            self._input_hash, cached_job_id = gcloud.check_cache_for_dir(tmp, "palace")
+            if cached_job_id is not None:
+                self._job_id = cached_job_id
+                if verbose != "quiet":
+                    print(f"Cache hit: reusing job {cached_job_id}")  # noqa: T201
+                if not wait:
+                    return self._job_id
+                return self.wait_for_results(verbose=verbose, parent_dir=parent_dir)
+            self._job_id = gcloud.upload(
+                tmp, "palace", verbose=False, input_hash=self._input_hash
+            )
+        else:
+            self.upload(verbose=False)
         self.start(verbose=verbose != "quiet")
         if not wait:
             if self._job_id is None:

--- a/src/gsim/palace/driven.py
+++ b/src/gsim/palace/driven.py
@@ -113,6 +113,7 @@ class DrivenSim(PalaceSimMixin, BaseModel):
         *,
         verbose: Literal["quiet", "status", "full"] = "status",
         wait: bool = True,
+        check_cache: bool = False,
     ) -> SParams | str:
         """Run the driven sim on GDSFactory+ cloud.
 
@@ -127,7 +128,9 @@ class DrivenSim(PalaceSimMixin, BaseModel):
         """
         from gsim.palace.results import SParams as _SParams
 
-        result = super().run(parent_dir, verbose=verbose, wait=wait)
+        result = super().run(
+            parent_dir, verbose=verbose, wait=wait, check_cache=check_cache
+        )
         if isinstance(result, (_SParams, str)):
             return result
         msg = (

--- a/src/gsim/palace/eigenmode.py
+++ b/src/gsim/palace/eigenmode.py
@@ -102,6 +102,7 @@ class EigenmodeSim(PalaceSimMixin, BaseModel):
         *,
         verbose: Literal["quiet", "status", "full"] = "status",
         wait: bool = True,
+        check_cache: bool = False,
     ) -> dict[str, Path] | str:
         """Run the eigenmode sim on GDSFactory+ cloud.
 
@@ -112,7 +113,9 @@ class EigenmodeSim(PalaceSimMixin, BaseModel):
         """
         from gsim.palace.results import SParams
 
-        result = super().run(parent_dir, verbose=verbose, wait=wait)
+        result = super().run(
+            parent_dir, verbose=verbose, wait=wait, check_cache=check_cache
+        )
         if isinstance(result, SParams):
             msg = (
                 "EigenmodeSim.run got SParams from the cloud, but an "

--- a/tests/meep/test_workflow.py
+++ b/tests/meep/test_workflow.py
@@ -7,10 +7,12 @@ build_config -> write_config, stopping before cloud submission.
 from __future__ import annotations
 
 import json
+import time
 
 import gdsfactory as gf
 import pytest
 
+from gsim.hashing import compute_dir_digest
 from gsim.meep import Simulation
 
 # ---------------------------------------------------------------------------
@@ -178,6 +180,14 @@ class TestWriteConfig:
         assert (output_dir / "layout.gds").exists()
         assert (output_dir / "sim_config.json").exists()
         assert (output_dir / "run_meep.py").exists()
+
+    def test_output_is_byte_reproducible(self, configured_sim, tmp_path):
+        """Identical simulations produce the same cloud-cache input bytes."""
+        first = configured_sim.write_config(tmp_path / "first")
+        time.sleep(1.1)  # GDS timestamps have one-second resolution.
+        second = configured_sim.write_config(tmp_path / "second")
+
+        assert compute_dir_digest(first) == compute_dir_digest(second)
 
     def test_config_json_valid(self, configured_sim, tmp_path):
         output_dir = configured_sim.write_config(tmp_path / "sim_output")

--- a/tests/test_gcloud_cache.py
+++ b/tests/test_gcloud_cache.py
@@ -1,0 +1,136 @@
+"""Tests for the cloud result-cache lookup in gsim.gcloud."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, create_autospec, patch
+
+from gsim import gcloud
+
+
+@dataclass
+class FakeCacheResponse:
+    """Stand-in for the SDK CacheCheckResponse."""
+
+    cached: bool
+    job_id: str | None = None
+
+
+def _sim_dir(tmp_path):
+    """Create a minimal prepared input directory."""
+    (tmp_path / "config.json").write_text("{}", encoding="utf-8")
+    return tmp_path
+
+
+class TestSdkAccepts:
+    """Tests for the SDK feature-detection helper."""
+
+    def test_detects_present_param(self):
+        """Returns True for a parameter the function declares."""
+
+        def fn(path, *, input_hash=None):
+            """Fake SDK function."""
+
+        assert gcloud._sdk_accepts(fn, "input_hash") is True
+
+    def test_detects_absent_param(self):
+        """Returns False for a parameter the function does not declare."""
+
+        def fn(path):
+            """Fake SDK function."""
+
+        assert gcloud._sdk_accepts(fn, "input_hash") is False
+
+
+class TestCheckCache:
+    """Tests for gcloud.check_cache."""
+
+    def test_hit_returns_job_id(self):
+        """A cache hit yields the cached job id."""
+        fake = MagicMock(return_value=FakeCacheResponse(cached=True, job_id="job-1"))
+        with patch.object(gcloud.sim, "check_cache", fake, create=True):
+            assert gcloud.check_cache("meep", "sha256:abc") == "job-1"
+
+        assert fake.call_args.kwargs["input_hash"] == "sha256:abc"
+
+    def test_miss_returns_none(self):
+        """A cache miss yields None."""
+        fake = MagicMock(return_value=FakeCacheResponse(cached=False))
+        with patch.object(gcloud.sim, "check_cache", fake, create=True):
+            assert gcloud.check_cache("meep", "sha256:abc") is None
+
+    def test_unsupported_sdk_returns_none(self):
+        """An SDK without check_cache degrades to a miss."""
+        with patch.object(gcloud.sim, "check_cache", None, create=True):
+            assert gcloud.check_cache("meep", "sha256:abc") is None
+
+    def test_server_error_returns_none(self):
+        """A failing lookup degrades to a miss rather than raising."""
+        fake = MagicMock(side_effect=RuntimeError("boom"))
+        with patch.object(gcloud.sim, "check_cache", fake, create=True):
+            assert gcloud.check_cache("meep", "sha256:abc") is None
+
+    def test_unknown_job_type_returns_none(self):
+        """An unknown solver name degrades to a miss, not a crash."""
+        fake = MagicMock(return_value=FakeCacheResponse(cached=True, job_id="job-1"))
+        with patch.object(gcloud.sim, "check_cache", fake, create=True):
+            assert gcloud.check_cache("not-a-solver", "sha256:abc") is None
+
+
+class TestCheckCacheForDir:
+    """Tests for gcloud.check_cache_for_dir."""
+
+    def test_returns_hash_and_job_id(self, tmp_path):
+        """Returns the computed hash alongside the cached job id."""
+        input_dir = _sim_dir(tmp_path)
+        fake = MagicMock(return_value=FakeCacheResponse(cached=True, job_id="job-1"))
+
+        with patch.object(gcloud.sim, "check_cache", fake, create=True):
+            input_hash, job_id = gcloud.check_cache_for_dir(input_dir, "meep")
+
+        assert job_id == "job-1"
+        assert input_hash.startswith("sha256:")
+        assert fake.call_args.kwargs["input_hash"] == input_hash
+
+    def test_returns_hash_on_miss(self, tmp_path):
+        """The hash is returned on a miss so the caller can still upload."""
+        input_dir = _sim_dir(tmp_path)
+        fake = MagicMock(return_value=FakeCacheResponse(cached=False))
+
+        with patch.object(gcloud.sim, "check_cache", fake, create=True):
+            input_hash, job_id = gcloud.check_cache_for_dir(input_dir, "meep")
+
+        assert job_id is None
+        assert input_hash.startswith("sha256:")
+
+
+class TestUploadInputHash:
+    """Tests for input_hash passthrough on upload."""
+
+    def test_forwarded_when_sdk_supports_it(self, tmp_path):
+        """The hash reaches the SDK when the parameter exists."""
+        input_dir = _sim_dir(tmp_path)
+
+        def upload_simulation(path, job_definition, input_hash=None):  # noqa: ARG001
+            """Fake SDK upload accepting input_hash."""
+            return MagicMock(job_id="job-1", _input_hash=input_hash)
+
+        fake = create_autospec(upload_simulation, side_effect=upload_simulation)
+        with patch.object(gcloud.sim, "upload_simulation", fake):
+            gcloud.upload_simulation_dir(input_dir, "meep", input_hash="sha256:abc")
+
+        assert fake.call_args.kwargs["input_hash"] == "sha256:abc"
+
+    def test_dropped_when_sdk_lacks_param(self, tmp_path):
+        """Older SDKs are called without the unsupported keyword."""
+        input_dir = _sim_dir(tmp_path)
+
+        def upload_simulation(path, job_definition):  # noqa: ARG001
+            """Fake SDK upload predating the caching API."""
+            return MagicMock(job_id="job-1")
+
+        fake = create_autospec(upload_simulation, side_effect=upload_simulation)
+        with patch.object(gcloud.sim, "upload_simulation", fake):
+            gcloud.upload_simulation_dir(input_dir, "meep", input_hash="sha256:abc")
+
+        assert "input_hash" not in fake.call_args.kwargs

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,0 +1,117 @@
+"""Tests for deterministic input hashing used by the cloud result cache."""
+
+from __future__ import annotations
+
+import pytest
+
+from gsim.hashing import HASH_PREFIX, compute_dir_digest, compute_input_hash
+
+
+def _write(root, rel, content):
+    """Write *content* to ``root/rel``, creating parents as needed."""
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+class TestComputeDirDigest:
+    """Tests for compute_dir_digest."""
+
+    def test_deterministic(self, tmp_path):
+        """Same contents written twice produce the same digest."""
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        for root in (a, b):
+            _write(root, "config.json", '{"fmin": 1.0}')
+            _write(root, "run_meep.py", "print('hi')\n")
+
+        assert compute_dir_digest(a) == compute_dir_digest(b)
+
+    def test_content_change_changes_digest(self, tmp_path):
+        """Editing a file changes the digest."""
+        root = tmp_path / "sim"
+        _write(root, "config.json", '{"fmin": 1.0}')
+        before = compute_dir_digest(root)
+
+        _write(root, "config.json", '{"fmin": 2.0}')
+        assert compute_dir_digest(root) != before
+
+    def test_rename_changes_digest(self, tmp_path):
+        """File names participate in the digest, not just bytes."""
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        _write(a, "config.json", "same")
+        _write(b, "other.json", "same")
+
+        assert compute_dir_digest(a) != compute_dir_digest(b)
+
+    def test_nested_files_included(self, tmp_path):
+        """Files in subdirectories contribute to the digest."""
+        root = tmp_path / "sim"
+        _write(root, "config.json", "{}")
+        before = compute_dir_digest(root)
+
+        _write(root, "meshes/palace.msh", "mesh")
+        assert compute_dir_digest(root) != before
+
+    def test_ignores_droppings(self, tmp_path):
+        """Editor and interpreter droppings do not affect the digest."""
+        root = tmp_path / "sim"
+        _write(root, "config.json", "{}")
+        before = compute_dir_digest(root)
+
+        _write(root, ".DS_Store", "junk")
+        _write(root, "__pycache__/run.cpython-312.pyc", "junk")
+        assert compute_dir_digest(root) == before
+
+    def test_missing_dir(self, tmp_path):
+        """A missing directory is an error, not an empty digest."""
+        with pytest.raises(FileNotFoundError):
+            compute_dir_digest(tmp_path / "nope")
+
+    def test_empty_dir(self, tmp_path):
+        """An empty directory is an error — nothing to submit."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        with pytest.raises(ValueError, match="empty"):
+            compute_dir_digest(empty)
+
+
+class TestComputeInputHash:
+    """Tests for compute_input_hash."""
+
+    def test_prefix_and_shape(self, tmp_path):
+        """Returns a sha256-prefixed lowercase hex digest."""
+        _write(tmp_path, "config.json", "{}")
+        value = compute_input_hash(tmp_path, "meep")
+
+        assert value.startswith(HASH_PREFIX)
+        hex_part = value.removeprefix(HASH_PREFIX)
+        assert len(hex_part) == 64
+        assert hex_part == hex_part.lower()
+        int(hex_part, 16)  # valid hex
+
+    def test_job_type_participates(self, tmp_path):
+        """Identical inputs for different solvers hash differently."""
+        _write(tmp_path, "config.json", "{}")
+
+        assert compute_input_hash(tmp_path, "meep") != compute_input_hash(
+            tmp_path, "palace"
+        )
+
+    def test_job_type_case_insensitive(self, tmp_path):
+        """Solver name casing does not change the key."""
+        _write(tmp_path, "config.json", "{}")
+
+        assert compute_input_hash(tmp_path, "MEEP") == compute_input_hash(
+            tmp_path, "meep"
+        )
+
+    def test_tracks_contents(self, tmp_path):
+        """The key follows the directory contents."""
+        _write(tmp_path, "config.json", "{}")
+        before = compute_input_hash(tmp_path, "meep")
+
+        _write(tmp_path, "config.json", '{"n": 1}')
+        assert compute_input_hash(tmp_path, "meep") != before


### PR DESCRIPTION
## What

Adds an opt-in cloud result cache lookup, so an identical simulation can be served from a previous job instead of re-running it:

```python
sp = sim.run(check_cache=True)   # meep and palace
```

Closes the client side of #205.

## How the key is derived

The cache key comes from the **materialized inputs** — the files `write_config()` writes — not from the simulation object.

Hashing the pydantic model directly would be fragile: the sim models hold gdsfactory `Component` references, `LayerStack`/material objects, callables, and private path attributes that do not serialize stably across processes, and a model dump would miss the generated solver script, which does change results. The written config directory is exactly the set of bytes the solver consumes, and it is produced on every submit anyway.

```
digest = sha256 over sorted (relpath, sha256(file_bytes)) pairs
key    = sha256(digest || job_type || gsim_version)
```

Relative paths are POSIX-normalized so the key is stable across operating systems. The gsim version is folded in deliberately (gsim generates the solver driver script); that can be dropped once the server-side key includes the solver image version.

## Changes

- `gsim/hashing.py` — `compute_dir_digest` / `compute_input_hash`
- `gcloud.check_cache` and `gcloud.check_cache_for_dir` — the lookup **never raises**. An SDK without the API, a network error, or a server error all degrade to a miss and a normal submit.
- `gcloud.upload` / `upload_simulation_dir` — forward `input_hash` so the cache is populated on every run, not only when a lookup is requested
- `Simulation.run(check_cache=True)` for meep, and `PalaceSimMixin.run` plus the `DrivenSim` / `EigenmodeSim` overrides

## Compatibility

The caching API is not released yet — the SDK pinned in this repo (1.8.19) has neither `check_cache` nor the `input_hash` parameter. Everything is feature-detected at call time (`hasattr` for the endpoint, signature inspection for the parameter), so this merges and behaves as a no-op today and starts working when the SDK ships, with no further change here. Tests cover both the supported and unsupported SDK paths.

Default is `check_cache=False`. Flipping the default to `True` is a one-line change — worth doing once the server-side semantics in #205 are pinned down (in particular what a lookup returns for a failed or still-running job).

## Not included

`gcloud.run_simulation()` (the directory-based entry point) does not take `check_cache` yet. It moves the caller's config directory into `sim-data-*/input/` and deletes the original, so the cache-hit path needs its own decision about what happens to those files. Happy to add in a follow-up.

## Testing

- `tests/test_hashing.py` — determinism, sensitivity to content/name/nesting, ignored droppings, error cases
- `tests/test_gcloud_cache.py` — hit, miss, unsupported SDK, server error, unknown solver, and `input_hash` passthrough with both old and new SDK signatures
- `pre-commit run` passes clean on the changed files
- 22 new tests pass; `tests/test_gcloud_start.py`, `tests/meep/test_simulation.py` and `tests/meep/test_workflow.py` pass unchanged. The palace suite needs `libGLU`, which I could not install in my sandbox — relying on CI for those.

> [!NOTE]
> This PR was written by an AI agent. The code needs human review before merge.

Requested by @joamatab
