### PR TITLE
chore: require cache-enabled gdsfactoryplus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 dependencies = [
   "gdsfactory>=9,<10",
-  "gdsfactoryplus>=1.6.4,<3",
+  "gdsfactoryplus>=1.8.20,<3",
   "gmsh",
   "meshio>=5.0.0",
   "nbformat>=4.2.0",


### PR DESCRIPTION
Require gdsfactoryplus 1.8.20 so installations include the SDK cache APIs used by the recently merged simulation cache support.\n\nValidated with 50 cache, hashing, and Meep workflow tests.