### PR TITLE
chore: enable tbump for releases

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,19 +8,13 @@ dev:
   uvx pre-commit install
   git config diff.ipynb.textconv "jupyter nbconvert --to script --stdout"
 
-# Version bumping
-[linux,macos]
-bver:
-    curl -LsSf https://github.com/flaport/bver/releases/latest/download/install.sh | sh
-
-# Version bumping
-[windows]
-bver:
-    powershell -ExecutionPolicy ByPass -c "irm https://github.com/flaport/bver/releases/latest/download/install.ps1 | iex"
+# Install the release versioning tool.
+tbump:
+    uv tool install tbump
 
 # bump version
 bump version="patch":
-    bver bump "{{ version }}"
+    tbump "{{ version }}"
 
 uv:
   curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,18 +78,6 @@ test = [
 requires = ["build", "setuptools>=61", "uv", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[[tool.bver.file]]
-src = "README.md"
-
-[[tool.bver.file]]
-src = "pyproject.toml"
-
-[[tool.bver.file]]
-src = "src/gsim/__init__.py"
-
-[tool.bver.git]
-commit-template = "Release {new-version}"
-
 [tool.codespell]
 ignore-words-list = "doubleclick,euclidian,te"
 

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,25 @@
+[version]
+current = "0.1.0"
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  '''
+
+[git]
+message_template = "Release {new_version}"
+tag_template = "{new_version}"
+
+[[file]]
+src = "pyproject.toml"
+search = 'version = "{current_version}"'
+
+[[file]]
+src = "README.md"
+search = "# gsim {current_version}"
+
+[[file]]
+src = "src/gsim/__init__.py"
+search = '__version__ = "{current_version}"'


### PR DESCRIPTION
## Summary
- add a `tbump` configuration for the project version, README, and package version
- preserve release commit messages and unprefixed version tags
- replace the bver justfile recipes with tbump

## Validation
- `tbump current-version`
- `tbump --only-patch --dry-run 0.2.0`
- pre-commit hooks