### PR TITLE
fix: add PyPI package description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gsim"
 version = "0.2.0"
-description = ""
+description = "Electromagnetic simulation for photonics and electronics, powered by GDSFactory."
 readme = "README.md"
 requires-python = "~=3.12.0"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
- add a concise project description to the package metadata
- make the PyPI package summary display instead of appearing blank

## Validation
- `git diff --check`
- pre-commit hooks