### PR TITLE
Fix XZ geometry export and preview

### DIFF
--- a/src/gsim/common/polygon.py
+++ b/src/gsim/common/polygon.py
@@ -55,7 +55,26 @@ def fuse_polygons(
     Returns:
         Merged Shapely Polygon or MultiPolygon
     """
-    layer_region = layer.get_shapes(component)
+    source_layer = getattr(layer, "layer", layer)
+    derived_layer = getattr(layer, "derived_layer", None)
+
+    # Simulation export materializes derived layers onto their GDS targets.
+    # Prefer those polygons when present: re-evaluating the source Boolean
+    # expression loses LayerLevel.background semantics (notably full-height
+    # grating teeth). Fall back to evaluating the source expression for the
+    # ordinary, unmaterialized visualization path.
+    layer_region = None
+    if derived_layer is not None:
+        target = tuple(derived_layer.layer)
+        layer_index = component.kcl.layer(*target)
+        target_region = component.kdb_cell.begin_shapes_rec(layer_index)
+        if not target_region.at_end():
+            from kfactory import kdb
+
+            layer_region = kdb.Region(target_region)
+
+    if layer_region is None:
+        layer_region = source_layer.get_shapes(component)
 
     shapely_polygons = []
     for klayout_polygon in layer_region.each_merged():
@@ -100,15 +119,13 @@ def cleanup_component(
     Returns:
         Dict mapping layer name to merged Shapely polygon
     """
-    layer_stack_dict = layer_stack.to_dict()
-
     return {
         layername: fuse_polygons(
             component,
-            layer["layer"],
+            layer,
             round_tol=round_tol,
             simplify_tol=simplify_tol,
         )
-        for layername, layer in layer_stack_dict.items()
-        if layer["layer"] is not None
+        for layername, layer in layer_stack.layers.items()
+        if layer.layer is not None
     }

--- a/src/gsim/common/stack/extractor.py
+++ b/src/gsim/common/stack/extractor.py
@@ -491,6 +491,13 @@ def extract_layer_stack(
             if not _is_dielectric_material(material):
                 continue
             if not _looks_like_passivation(layer_name, material):
+                if material.strip().lower() in {
+                    "si",
+                    "silicon",
+                    "ge",
+                    "germanium",
+                }:
+                    continue
                 bulk_material = material
                 break
 
@@ -502,12 +509,18 @@ def extract_layer_stack(
 
     if bulk_material is None and sorted_dielectric_layers:
         for _zmin, _zmax, material, _layer_name in sorted_dielectric_layers:
-            if _is_dielectric_material(material):
+            # Silicon/Ge layers can be classified as dielectrics for geometry
+            # purposes, but they are not a suitable blanket cladding.  If a
+            # PDK has no oxide-like layer, use the explicit SiO2 fallback
+            # below rather than turning the synthetic BOX/cladding into Si.
+            if _is_dielectric_material(material) and material.strip().lower() not in {
+                "si",
+                "silicon",
+                "ge",
+                "germanium",
+            }:
                 bulk_material = material
                 break
-
-    if bulk_material is None and sorted_dielectric_layers:
-        bulk_material = sorted_dielectric_layers[0][2]
 
     if bulk_material is None:
         # Rare fallback when a PDK stack defines no dielectric layers.

--- a/src/gsim/meep/mode_solver.py
+++ b/src/gsim/meep/mode_solver.py
@@ -1270,7 +1270,7 @@ def refractive_index_profile(
         if layer.material == "air":
             continue
         gds_layer = getattr(layer, "gds_layer", None)
-        if gds_layer is None:
+        if not isinstance(gds_layer, tuple):
             continue
         intervals = interval_func(component, layer, cut_coord)
         if not intervals and not _layer_has_any_polygon(component, layer):
@@ -1292,6 +1292,8 @@ def refractive_index_profile(
         if eps <= 0:
             continue
         gds_layer = getattr(layer, "gds_layer", None)
+        if not isinstance(gds_layer, tuple):
+            continue
         h_mask = layer_h_masks.get(gds_layer)
         if h_mask is None:
             continue

--- a/src/gsim/meep/models/results.py
+++ b/src/gsim/meep/models/results.py
@@ -475,9 +475,9 @@ class ModeResult(BaseModel):
             raise ValueError(
                 "Ambiguous geometry: both x_grid and y_grid are populated."
             )
-        if has_y:
+        if self.y_grid is not None:
             return self.y_grid, "y (µm)"
-        if has_x:
+        if self.x_grid is not None:
             return self.x_grid, "x (µm)"
         raise ValueError(
             "No horizontal grid available. Set x_grid or y_grid on ModeResult."

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -553,7 +553,52 @@ class Simulation(BaseModel):
         if mz_high < needed:
             self.domain.margin_z = (mz_low, needed)
 
-    def _resolve_z_ref_extent(self) -> tuple[float, float, str, float | None, bool]:
+    def _component_with_derived_layers(self, component: Any) -> Any:
+        """Return *component* augmented with any active-PDK derived layers.
+
+        GDS stores source mask layers, whereas a gdsfactory ``LayerStack`` may
+        describe physical layers using boolean expressions and ``derived_layer``
+        targets.  MEEP needs both: the evaluated layers for the physical stack
+        and the original layers for stack entries that are not derived.
+        """
+        import gdsfactory as gf
+
+        pdk_layer_stack = gf.get_active_pdk().layer_stack
+        if pdk_layer_stack is None:
+            return component.copy()
+        if not any(
+            level.derived_layer is not None for level in pdk_layer_stack.layers.values()
+        ):
+            return component.copy()
+
+        derived = pdk_layer_stack.get_component_with_derived_layers(component)
+        # ``get_component_with_derived_layers`` evaluates each layer's
+        # Boolean expression but does not apply gdsfactory's ``background``
+        # semantics.  Recreate those physical layers from the component bbox
+        # and the declared etch exclusions, matching ``Component.to_3d()``.
+        # This keeps the hierarchy intact; no flattening is required.
+        from kfactory import kdb
+
+        for level in pdk_layer_stack.layers.values():
+            if not getattr(level, "background", False) or level.derived_layer is None:
+                continue
+
+            target_layer = gf.get_layer_tuple(level.derived_layer.layer)
+            background = kdb.Region(component.kdb_cell.bbox())
+            for excluded_layer in getattr(level, "background_exclude_layers", ()):
+                layer_index = component.kcl.layer(*tuple(excluded_layer))
+                background -= kdb.Region(
+                    component.kdb_cell.begin_shapes_rec(layer_index)
+                )
+            derived.remove_layers([target_layer])
+            derived.add_polygon(background, layer=target_layer)
+
+        derived.add_ref(component)
+        return derived
+
+    def _resolve_z_ref_extent(
+        self, component: Any | None = None
+    ) -> tuple[float, float, str, float | None, bool]:
         """Resolve ``domain.z_ref`` to a vertical reference window.
 
         Single source of truth for both the fiber-margin expansion and the
@@ -588,7 +633,8 @@ class Simulation(BaseModel):
 
         if z_ref is None:
             layer, n = _find_highest_n_layer_in_component(
-                self.geometry.component, stack
+                component if component is not None else self.geometry.component,
+                stack,
             )
             if layer is None:
                 extent = self._stack_material_extent()
@@ -1139,11 +1185,21 @@ class Simulation(BaseModel):
         if self.geometry.component is None:
             raise ValueError("No geometry set.")
 
+        # Materialize derived PDK layers before inspecting or exporting the
+        # geometry.  A number of PDKs define the physical core as a boolean
+        # expression of fabrication-mask layers; those derived polygons are
+        # not present in an imported GDS until the layer stack evaluates them.
+        original_component = self._component_with_derived_layers(
+            self.geometry.component
+        )
+
         # Apply z-crop for 3D and XZ 2D (both use the vertical dimension).
         # XY 2D collapses z entirely so cropping is meaningless. The crop
         # window comes from domain.z_ref (default: the drawn photonic core).
         if (is_3d or plane == "xz") and not self._z_cropped:
-            ref_zmin, ref_zmax, ref_name, ref_n, is_auto = self._resolve_z_ref_extent()
+            ref_zmin, ref_zmax, ref_name, ref_n, is_auto = self._resolve_z_ref_extent(
+                component=original_component
+            )
             # When a fiber source is configured in XZ mode, expand the
             # above (high) side of margin_z so the cropped stack still
             # contains the beam plane (and PML headroom) — from the ref top.
@@ -1152,7 +1208,6 @@ class Simulation(BaseModel):
 
         import gdsfactory as gf
 
-        original_component = self.geometry.component.copy()
         stack = self.geometry.stack
 
         # Resolve the XZ cut Y-coordinate ('auto'/None -> bbox center).

--- a/src/gsim/meep/viz.py
+++ b/src/gsim/meep/viz.py
@@ -254,9 +254,8 @@ def build_cross_section_rectangles(
     directly so cross-section geometry for custom material stacks
     (e.g. TFLN) is rendered correctly.
 
-    Layers that have no GDS polygons at all (``_layer_has_any_polygon``
-    returns ``False``) are skipped, since their boundaries are already
-    implicit from adjacent layers.
+    Layers that have no GDS polygons are skipped, since their boundaries are
+    already implicit from adjacent layers.
 
     Args:
         component: gdsfactory Component with GDS polygons.
@@ -274,23 +273,6 @@ def build_cross_section_rectangles(
 
     if not stack.layers:
         return []
-
-    def _has_any_polygon(layer: object) -> bool:
-        gds = getattr(layer, "gds_layer", None)
-        if gds is None:
-            return False
-        try:
-            polys = component.get_polygons_points(layers=(gds,), merge=True)
-        except Exception:
-            return False
-        else:
-            if not isinstance(polys, dict):
-                return False
-            for v in polys.values():
-                items = v if isinstance(v, list) else [v]
-                if len(items) > 0:
-                    return True
-            return False
 
     if slice_axis == "y":
         cut_line = LineString([(-1e6, slice_coord), (1e6, slice_coord)])
@@ -327,21 +309,9 @@ def build_cross_section_rectangles(
                 poly_items.extend(items)
 
         if not poly_items:
-            if _has_any_polygon(layer):
-                continue
-            rectangles.append(
-                {
-                    "h_min": -float("inf"),
-                    "h_max": float("inf"),
-                    "z_min": layer.zmin,
-                    "z_max": layer.zmax,
-                    "layer_name": layer.name,
-                    "material": layer.material,
-                    "sidewall_angle": float(
-                        getattr(layer, "sidewall_angle", 0.0) or 0.0
-                    ),
-                }
-            )
+            # The component does not draw this stack layer.  Do not turn it
+            # into an infinite slab: the runner likewise emits no geometry
+            # for a layer with no GDS polygons.
             continue
 
         for poly in poly_items:

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -645,6 +645,31 @@ def _xz_trivial_stack():
 class TestXZBuildConfig:
     """Tests for XZ 2D fields wired through Simulation.build_config()."""
 
+    def test_materializes_active_pdk_derived_layers(self):
+        """Derived physical layers are retained alongside source mask layers."""
+        import gdsfactory as gf
+
+        from gsim.meep.simulation import Simulation
+
+        c = gf.Component()
+        c.add_polygon(
+            [(0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0)],
+            layer=gf.gpdk.LAYER.WG,
+        )
+        c.add_polygon(
+            [(0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0)],
+            layer=gf.gpdk.LAYER.SHALLOW_ETCH,
+        )
+
+        materialized = Simulation()._component_with_derived_layers(c)
+        pdk_layer_stack = gf.get_active_pdk().layer_stack
+        assert pdk_layer_stack is not None
+        derived_layer = pdk_layer_stack.layers["shallow_etch"].derived_layer
+        assert derived_layer is not None
+
+        assert tuple(gf.gpdk.LAYER.SHALLOW_ETCH) in materialized.layers
+        assert tuple(derived_layer.layer) in materialized.layers
+
     def test_y_cut_defaults_to_bbox_center(self):
         from gsim.meep.simulation import Simulation
 

--- a/tests/meep/test_viz_xz.py
+++ b/tests/meep/test_viz_xz.py
@@ -77,3 +77,30 @@ class TestPlot2DXZ:
         result = sim.plot_2d(ax=ax)
         assert result is ax
         plt.close(fig)
+
+    def test_cross_section_omits_undrawn_stack_layers(self):
+        """Absent GDS layers must not appear as full-width slabs."""
+        from gsim.common.stack import Layer
+        from gsim.meep.viz import build_cross_section_rectangles
+
+        sim = _xz_sim_for_viz()
+        assert sim.geometry.component is not None
+        assert sim.geometry.stack is not None
+        sim.geometry.stack.layers["undrawn_metal"] = Layer(
+            name="undrawn_metal",
+            gds_layer=(99, 0),
+            zmin=1.0,
+            zmax=3.0,
+            thickness=2.0,
+            material="aluminum",
+            layer_type="conductor",
+        )
+
+        rectangles = build_cross_section_rectangles(
+            sim.geometry.component,
+            sim.geometry.stack,
+            slice_axis="y",
+            slice_coord=0.0,
+        )
+
+        assert [rectangle["layer_name"] for rectangle in rectangles] == ["core"]

--- a/tests/palace/test_patterned_dielectrics.py
+++ b/tests/palace/test_patterned_dielectrics.py
@@ -47,6 +47,14 @@ def test_extract_layer_stack_defaults_keep_synthetic_dielectrics():
     assert "air_box" not in names
 
 
+def test_synthetic_oxide_does_not_use_silicon_as_cladding():
+    """A silicon core is not a valid fallback material for blanket oxide."""
+    stack = extract_layer_stack(_fake_gf_stack(), pdk_name="test-pdk")
+
+    oxide = next(d for d in stack.dielectrics if d["name"] == "oxide")
+    assert oxide["material"] == "SiO2"
+
+
 def test_build_entities_prioritizes_patterned_dielectrics_over_background_boxes():
     """Patterned dielectric volumes must be cut before blanket boxes."""
     stack_layers = {


### PR DESCRIPTION
## Summary
- materialize active-PDK derived layers before MEEP exports geometry
- use SiO2, rather than Si/Ge, as the synthetic cladding fallback
- omit undrawn stack layers from XZ cross-section overlays

## Validation
- `pytest tests/meep/test_viz_xz.py tests/meep/test_simulation.py tests/meep/test_xz_2d.py tests/palace/test_patterned_dielectrics.py -q` (81 passed, 1 skipped)
- `pre-commit run --all-files` passes except three existing `ty` diagnostics in `mode_solver.py` and `models/results.py`
- checked the Intel grating-coupler configuration through `Simulation.build_config()`