### PR TITLE
feat: add auto aspect to MEEP 2D plots

### DIFF
--- a/src/gsim/common/viz/render2d.py
+++ b/src/gsim/common/viz/render2d.py
@@ -11,7 +11,7 @@ When a ``SimOverlay`` is provided, the plot also draws:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,6 +33,7 @@ def plot_prism_slices(
     legend: bool = True,
     slices: str = "z",
     *,
+    aspect: Literal["equal", "auto"] = "equal",
     overlay: Any | None = None,
 ) -> plt.Axes | None:
     """Plot cross sections of a GeometryModel with multi-view support.
@@ -46,12 +47,17 @@ def plot_prism_slices(
         legend: Whether to show the legend.
         slices: Which slice(s) to plot -- "x", "y", "z", or combinations
             like "xy", "xz", "yz", "xyz".
+        aspect: Axis aspect ratio. Use ``"equal"`` to preserve physical
+            proportions or ``"auto"`` to fill the available plotting area.
         overlay: Optional SimOverlay with sim cell / PML / port metadata.
 
     Returns:
         ``plt.Axes`` when *ax* was provided, otherwise ``None``
         (the figure is shown directly).
     """
+    if aspect not in {"equal", "auto"}:
+        raise ValueError(f"aspect must be 'equal' or 'auto'. Got: {aspect!r}")
+
     slices_to_plot = sorted(set(slices.lower()))
     if not all(s in "xyz" for s in slices_to_plot):
         raise ValueError(f"slices must only contain 'x', 'y', 'z'. Got: {slices}")
@@ -69,6 +75,7 @@ def plot_prism_slices(
                 z=None,
                 ax=ax,
                 legend=legend,
+                aspect=aspect,
                 overlay=overlay,
             )
         if slice_axis == "y":
@@ -80,6 +87,7 @@ def plot_prism_slices(
                 z=None,
                 ax=ax,
                 legend=legend,
+                aspect=aspect,
                 overlay=overlay,
             )
         if slice_axis == "z":
@@ -90,6 +98,7 @@ def plot_prism_slices(
                 z=z,
                 ax=ax,
                 legend=legend,
+                aspect=aspect,
                 overlay=overlay,
             )
 
@@ -100,6 +109,7 @@ def plot_prism_slices(
         y,
         z,
         show_legend=legend,
+        aspect=aspect,
         overlay=overlay,
     )
     return None
@@ -117,6 +127,7 @@ def _plot_multi_view(
     y: float | str | None,
     z: float | str | None,
     show_legend: bool = True,
+    aspect: Literal["equal", "auto"] = "equal",
     overlay: Any | None = None,
 ) -> None:
     """Create multi-view plot with a shared legend panel."""
@@ -136,6 +147,7 @@ def _plot_multi_view(
                 z=None,
                 ax=ax_i,
                 legend=False,
+                aspect=aspect,
                 overlay=overlay,
             )
         elif slice_axis == "y":
@@ -147,6 +159,7 @@ def _plot_multi_view(
                 z=None,
                 ax=ax_i,
                 legend=False,
+                aspect=aspect,
                 overlay=overlay,
             )
         elif slice_axis == "z":
@@ -157,6 +170,7 @@ def _plot_multi_view(
                 z=z,
                 ax=ax_i,
                 legend=False,
+                aspect=aspect,
                 overlay=overlay,
             )
 
@@ -194,6 +208,7 @@ def _plot_single_prism_slice(
     z: float | str | None = None,
     ax: plt.Axes | None = None,
     legend: bool = True,
+    aspect: Literal["equal", "auto"] = "equal",
     overlay: Any | None = None,
 ) -> plt.Axes:
     """Plot a single cross-section using generic Prisms."""
@@ -455,7 +470,7 @@ def _plot_single_prism_slice(
     ax.set_ylabel(ylabel)
     ax.set_xlim(xmin, xmax)
     ax.set_ylim(ymin, ymax)
-    ax.set_aspect("equal")
+    ax.set_aspect(aspect)
 
     if legend:
         ax.legend(fancybox=True, framealpha=1.0)

--- a/src/gsim/common/viz/render2d_interactive.py
+++ b/src/gsim/common/viz/render2d_interactive.py
@@ -7,7 +7,7 @@ and toggle individual layers/materials on and off via the legend.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from gsim.common.geometry_model import GeometryModel
 
@@ -62,6 +62,7 @@ def plot_prism_slices_interactive(
     y: float | str | None = None,
     z: float | str | None = None,
     *,
+    aspect: Literal["equal", "auto"] = "equal",
     overlay: Any | None = None,
 ) -> Any:
     """Plot an interactive 2D cross-section using Plotly.
@@ -74,12 +75,17 @@ def plot_prism_slices_interactive(
         x: X-coordinate (or layer name) for the slice plane.
         y: Y-coordinate (or layer name) for the slice plane.
         z: Z-coordinate (or layer name) for the slice plane.
+        aspect: Axis aspect ratio. Use ``"equal"`` to preserve physical
+            proportions or ``"auto"`` to fill the available plotting area.
         overlay: Optional SimOverlay with sim cell / PML / port metadata.
 
     Returns:
         ``plotly.graph_objects.Figure``.
     """
     import plotly.graph_objects as go
+
+    if aspect not in {"equal", "auto"}:
+        raise ValueError(f"aspect must be 'equal' or 'auto'. Got: {aspect!r}")
 
     x_resolved, y_resolved, z_resolved = (
         geometry_model.get_layer_center(c)[i] if isinstance(c, str) else c
@@ -211,12 +217,18 @@ def plot_prism_slices_interactive(
         xlabel, ylabel = "x (um)", "z (um)"
         title = f"XZ cross section at y={y_resolved:.2f}"
 
+    xaxis: dict[str, Any] = dict(showgrid=False, zeroline=False)
+    yaxis: dict[str, Any] = dict(showgrid=False, zeroline=False)
+    if aspect == "equal":
+        xaxis.update(scaleanchor="y", scaleratio=1)
+        yaxis["constrain"] = "domain"
+
     fig.update_layout(
         title=title,
         xaxis_title=xlabel,
         yaxis_title=ylabel,
-        xaxis=dict(scaleanchor="y", scaleratio=1, showgrid=False, zeroline=False),
-        yaxis=dict(constrain="domain", showgrid=False, zeroline=False),
+        xaxis=xaxis,
+        yaxis=yaxis,
         legend=dict(
             title="Layers / Materials",
             itemclick="toggle",

--- a/src/gsim/meep/viz.py
+++ b/src/gsim/meep/viz.py
@@ -7,7 +7,7 @@ Called directly by ``Simulation.plot_2d()`` / ``plot_3d()`` — no legacy
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import matplotlib.pyplot as plt
 
@@ -435,6 +435,7 @@ def plot_2d_interactive(
     component_bbox: list[float] | tuple[float, ...] | None = None,
     fiber_source: Any = None,
     monitor_z_span: float | None = None,
+    aspect: Literal["equal", "auto"] = "equal",
 ) -> Any:
     """Plot an interactive 2D cross-section using Plotly.
 
@@ -462,6 +463,8 @@ def plot_2d_interactive(
             (for correct cell boundary computation with extended ports).
         fiber_source: Pre-computed fiber source config (for overlay).
         monitor_z_span: Port monitor z-span override.
+        aspect: Axis aspect ratio. Use ``"equal"`` to preserve physical
+            proportions or ``"auto"`` to fill the available plotting area.
 
     Returns:
         ``plotly.graph_objects.Figure``.
@@ -498,7 +501,7 @@ def plot_2d_interactive(
     else:
         kw["z"] = z if z is not None else "core"
 
-    return plot_prism_slices_interactive(gm, overlay=overlay, **kw)
+    return plot_prism_slices_interactive(gm, aspect=aspect, overlay=overlay, **kw)
 
 
 def plot_2d(
@@ -517,6 +520,7 @@ def plot_2d(
     component_bbox: list[float] | tuple[float, ...] | None = None,
     fiber_source: Any = None,
     monitor_z_span: float | None = None,
+    aspect: Literal["equal", "auto"] = "equal",
 ) -> plt.Axes | None:
     """Plot 2D cross-sections of the MEEP geometry.
 
@@ -536,6 +540,10 @@ def plot_2d(
         port_data: Pre-computed port data (skips re-extraction).
         component_bbox: Original component bbox ``[xmin, ymin, xmax, ymax]``
             (for correct cell boundary computation with extended ports).
+        fiber_source: Pre-computed fiber source config (for overlay).
+        monitor_z_span: Port monitor z-span override.
+        aspect: Axis aspect ratio. Use ``"equal"`` to preserve physical
+            proportions or ``"auto"`` to fill the available plotting area.
 
     Returns:
         ``plt.Axes`` when *ax* was provided, otherwise ``None``.
@@ -556,4 +564,6 @@ def plot_2d(
         fiber_source=fiber_source,
         monitor_z_span=monitor_z_span,
     )
-    return plot_prism_slices(gm, x, y, z, ax, legend, slices, overlay=overlay)
+    return plot_prism_slices(
+        gm, x, y, z, ax, legend, slices, aspect=aspect, overlay=overlay
+    )

--- a/tests/meep/test_viz_interactive.py
+++ b/tests/meep/test_viz_interactive.py
@@ -77,6 +77,31 @@ class TestPlot2DInteractive:
         assert isinstance(fig, go.Figure)
         assert "XY cross section" in fig.layout.title.text
 
+    def test_auto_aspect(self):
+        sim = _xz_sim_for_viz()
+
+        fig = sim.plot_2d_interactive(aspect="auto")
+
+        assert fig.layout.xaxis.scaleanchor is None
+        assert fig.layout.yaxis.constrain is None
+
+    def test_equal_aspect_is_default(self):
+        sim = _xz_sim_for_viz()
+
+        fig = sim.plot_2d_interactive()
+
+        assert fig.layout.xaxis.scaleanchor == "y"
+        assert fig.layout.xaxis.scaleratio == 1
+        assert fig.layout.yaxis.constrain == "domain"
+
+    def test_invalid_aspect_raises(self):
+        import pytest
+
+        sim = _xz_sim_for_viz()
+
+        with pytest.raises(ValueError, match="aspect must be"):
+            sim.plot_2d_interactive(aspect="invalid")
+
     def test_multi_slice_raises(self):
         import pytest
 

--- a/tests/meep/test_viz_xz.py
+++ b/tests/meep/test_viz_xz.py
@@ -78,6 +78,26 @@ class TestPlot2DXZ:
         assert result is ax
         plt.close(fig)
 
+    def test_auto_aspect(self):
+        sim = _xz_sim_for_viz()
+        fig, ax = plt.subplots()
+
+        sim.plot_2d(ax=ax, aspect="auto")
+
+        assert ax.get_aspect() == "auto"
+        plt.close(fig)
+
+    def test_invalid_aspect_raises(self):
+        import pytest
+
+        sim = _xz_sim_for_viz()
+        fig, ax = plt.subplots()
+
+        with pytest.raises(ValueError, match="aspect must be"):
+            sim.plot_2d(ax=ax, aspect="invalid")
+
+        plt.close(fig)
+
     def test_cross_section_omits_undrawn_stack_layers(self):
         """Absent GDS layers must not appear as full-width slabs."""
         from gsim.common.stack import Layer


### PR DESCRIPTION
Adds `aspect="auto"` support to `plot_2d` and `plot_2d_interactive` for easier inspection of long, thin geometries. The default remains `aspect="equal"`.