### PR TITLE
feat: add explicit MEEP Z bounds

### DIFF
--- a/src/gsim/meep/models/api.py
+++ b/src/gsim/meep/models/api.py
@@ -7,6 +7,7 @@ in ``Simulation.write_config()``.
 
 from __future__ import annotations
 
+import math
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -219,17 +220,34 @@ class Symmetry(BaseModel):
 
 
 class Domain(BaseModel):
-    """Computational domain sizing: PML + margins + symmetries."""
+    """Computational domain sizing: absolute bounds, PML, and symmetries.
+
+    ``z_bounds`` is the sole public control for an active Z axis. ``"auto"``
+    fits the drawn optical geometry with library-owned padding; a numeric pair
+    specifies the exact PML-inner interval in absolute micrometers.
+
+    ``z_ref`` and ``margin_z`` remain temporarily as input-compatibility fields
+    for existing code. They are deprecated and translated to concrete bounds
+    by :meth:`gsim.meep.Simulation.build_config`.
+    """
 
     model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
+    z_bounds: tuple[float, float] | Literal["auto"] = Field(
+        default="auto",
+        description=(
+            "PML-inner Z interval in absolute um, or 'auto' to fit the active "
+            "optical geometry with deterministic library padding."
+        ),
+    )
     z_ref: str | None = Field(
         default=None,
+        exclude=True,
         description=(
-            "Vertical crop reference: None = auto (highest-n layer actually "
+            "Deprecated vertical crop reference: None = auto (highest-n layer actually "
             "drawn by the component, i.e. the photonic core), 'stack' = full "
             "non-air material stack, or a specific layer name. "
-            "margin_z is measured from this reference."
+            "margin_z is measured from this reference. Use z_bounds instead."
         ),
     )
     pml: float = Field(default=1.0, ge=0, description="PML thickness in um")
@@ -249,9 +267,10 @@ class Domain(BaseModel):
     )
     margin_z: float | tuple[float, float] = Field(
         default=0.5,
+        exclude=True,
         description=(
-            "Vertical margin around the z_ref reference in um. Scalar = both "
-            "sides equal; (low, high) = (below, above)."
+            "Deprecated vertical margin around z_ref in um. Scalar = both "
+            "sides equal; (low, high) = (below, above). Use z_bounds instead."
         ),
     )
     port_margin: float = Field(
@@ -297,6 +316,42 @@ class Domain(BaseModel):
         if low < 0 or high < 0:
             raise ValueError("margin sides must be >= 0")
         return (float(low), float(high))
+
+    @field_validator("z_bounds", mode="before")
+    @classmethod
+    def _validate_z_bounds(cls, value: Any) -> Any:
+        """Accept ``"auto"`` or a finite, increasing absolute interval."""
+        if value == "auto":
+            return value
+        try:
+            low, high = value
+        except (TypeError, ValueError):
+            raise ValueError(
+                "z_bounds must be 'auto' or a (z_min, z_max) pair"
+            ) from None
+        low = float(low)
+        high = float(high)
+        if not math.isfinite(low) or not math.isfinite(high):
+            raise ValueError("z_bounds values must be finite")
+        if low >= high:
+            raise ValueError("z_bounds requires z_min < z_max")
+        return (low, high)
+
+    @model_validator(mode="after")
+    def _reject_competing_z_controls(self) -> Domain:
+        """Do not allow deprecated sizing inputs with explicit bounds."""
+        if self.z_bounds != "auto" and self.legacy_z_fields_used():
+            raise ValueError(
+                "Choose domain.z_bounds only; deprecated domain.z_ref and "
+                "domain.margin_z cannot be combined with explicit z_bounds."
+            )
+        return self
+
+    def legacy_z_fields_used(self) -> tuple[str, ...]:
+        """Return deprecated vertical fields explicitly set by the caller."""
+        return tuple(
+            name for name in ("z_ref", "margin_z") if name in self.model_fields_set
+        )
 
     @staticmethod
     def _as_pair(v: float | tuple[float, float]) -> tuple[float, float]:

--- a/src/gsim/meep/models/config.py
+++ b/src/gsim/meep/models/config.py
@@ -7,10 +7,18 @@ that gets written as JSON and consumed by the cloud MEEP runner script.
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, computed_field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    computed_field,
+    field_validator,
+)
 
 
 class SymmetryEntry(BaseModel):
@@ -23,13 +31,14 @@ class SymmetryEntry(BaseModel):
 
 
 class DomainConfig(BaseModel):
-    """Simulation domain sizing: margins around geometry + PML thickness.
+    """Resolved simulation domain sizing and PML thickness.
 
-    Margins control how much material (from the layer stack) is kept around
-    the vertical crop reference (``domain.z_ref``).  ``margin_z_low`` /
-    ``margin_z_high`` set the crop window below/above that reference.  Along
-    XY the margins are the per-side gaps between the geometry bounding-box and
-    the PML inner edge (``*_low`` = -axis side, ``*_high`` = +axis side).
+    ``z_bounds`` is the authoritative PML-inner Z interval for new configs.
+    The legacy ``margin_z_low`` / ``margin_z_high`` fields remain readable for
+    old generated configs and are omitted when concrete bounds are serialized.
+    Along XY the margins are the per-side gaps between the geometry bounding
+    box and the PML inner edge (``*_low`` = -axis side, ``*_high`` = +axis
+    side).
 
     Cell size formula:
         cell_x = bbox_width  + margin_x_low + margin_x_high + 2*dpml
@@ -41,6 +50,10 @@ class DomainConfig(BaseModel):
 
     model_config = ConfigDict(validate_assignment=True)
 
+    z_bounds: tuple[float, float] | None = Field(
+        default=None,
+        description="Resolved absolute PML-inner Z interval in um.",
+    )
     dpml: float = Field(ge=0, description="PML thickness in um")
     margin_x_low: float = Field(
         ge=0, description="XY margin on the -x side (geometry to PML) in um"
@@ -78,6 +91,21 @@ class DomainConfig(BaseModel):
         description="Distance between source and its port monitor (um). "
         "Source-port monitor is placed this far past the source into the device.",
     )
+
+    @field_validator("z_bounds")
+    @classmethod
+    def _validate_z_bounds(
+        cls, value: tuple[float, float] | None
+    ) -> tuple[float, float] | None:
+        """Require a finite, increasing resolved interval."""
+        if value is None:
+            return None
+        low, high = value
+        if not all(math.isfinite(bound) for bound in value):
+            raise ValueError("z_bounds values must be finite")
+        if low >= high:
+            raise ValueError("z_bounds requires z_min < z_max")
+        return (float(low), float(high))
 
 
 class StoppingConfig(BaseModel):
@@ -554,6 +582,10 @@ class SimConfig(BaseModel):
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         data = self.model_dump(by_alias=True)
+        domain_data = data.get("domain")
+        if isinstance(domain_data, dict) and domain_data.get("z_bounds") is not None:
+            domain_data.pop("margin_z_low", None)
+            domain_data.pop("margin_z_high", None)
         if self._hints:
             data.update(self._hints)
         path.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/src/gsim/meep/overlay.py
+++ b/src/gsim/meep/overlay.py
@@ -136,18 +136,22 @@ def build_sim_overlay(
         xy_min_x, xy_min_y = gmin[0], gmin[1]
         xy_max_x, xy_max_y = gmax[0], gmax[1]
 
-    # XY: per-side margins are the gap between geometry bbox and PML
-    # Z: margin_z_low/high is already baked into the geometry bbox via set_z_crop(),
-    #    so only add dpml beyond the geometry z-extent
+    # XY: per-side margins are the gap between geometry bbox and PML.
+    # Z: new configs carry authoritative PML-inner bounds. Fall back to the
+    # cropped geometry extent for legacy configs.
+    if domain_config.z_bounds is not None:
+        z_inner_low, z_inner_high = domain_config.z_bounds
+    else:
+        z_inner_low, z_inner_high = gmin[2], gmax[2]
     cell_min = (
         xy_min_x - mx_lo - dpml,
         xy_min_y - my_lo - dpml,
-        gmin[2] - dpml,
+        z_inner_low - dpml,
     )
     cell_max = (
         xy_max_x + mx_hi + dpml,
         xy_max_y + my_hi + dpml,
-        gmax[2] + dpml,
+        z_inner_high + dpml,
     )
 
     if z_span is None:

--- a/src/gsim/meep/script.py
+++ b/src/gsim/meep/script.py
@@ -1527,6 +1527,26 @@ def save_epsilon_raw(sim, config, cell_center):
 # Main
 # ---------------------------------------------------------------------------
 
+def resolve_z_cell(domain, z_min, z_max, is_3d, is_xz):
+    """Return ``(cell_span, center)`` for the active Z axis.
+
+    New configs provide exact PML-inner bounds. The material-extent branches
+    remain only for previously generated JSON that predates ``z_bounds``.
+    """
+    dpml = domain["dpml"]
+    resolved_z_bounds = domain.get("z_bounds")
+    if (is_3d or is_xz) and resolved_z_bounds is not None:
+        z_lo, z_hi = resolved_z_bounds
+        return (z_hi - z_lo) + 2 * dpml, (z_hi + z_lo) / 2
+    if is_3d:
+        return (z_max - z_min) + 2 * dpml, (z_max + z_min) / 2
+    if is_xz:
+        z_lo = z_min - domain.get("margin_z_low", 0.0)
+        z_hi = z_max + domain.get("margin_z_high", 0.0)
+        return (z_hi - z_lo) + 2 * dpml, (z_hi + z_lo) / 2
+    return 0.0, 0.0
+
+
 def main():
     """Run MEEP simulation."""
     config_path = "%%CONFIG_FILENAME%%"
@@ -1600,37 +1620,14 @@ def main():
     else:
         z_min, z_max = 0.0, 0.0
 
-    margin_z_below = domain["margin_z_low"]
-    margin_z_above = domain["margin_z_high"]
-
-    if is_3d:
-        # 3D: z-margins are already baked via z_crop; just add dpml.
-        cell_z = (z_max - z_min) + 2 * dpml
-        cell_center = mp.Vector3(
-            center_x,
-            center_y,
-            (z_max + z_min) / 2,
-        )
-    elif is_xz:
-        # XZ 2D: cell_y collapsed; cell_z spans the full stack with
-        # z-margins and PML added (there is no z_crop in 2D).
+    cell_z, center_z = resolve_z_cell(domain, z_min, z_max, is_3d, is_xz)
+    if is_xz:
         cell_y = 0.0
-        z_lo = z_min - margin_z_below
-        z_hi = z_max + margin_z_above
-        cell_z = (z_hi - z_lo) + 2 * dpml
-        cell_center = mp.Vector3(
-            center_x,
-            0.0,
-            (z_hi + z_lo) / 2,
-        )
-    else:
-        # XY 2D: collapse z-dimension entirely.
-        cell_z = 0
-        cell_center = mp.Vector3(
-            center_x,
-            center_y,
-            0,
-        )
+    cell_center = mp.Vector3(
+        center_x,
+        0.0 if is_xz else center_y,
+        center_z,
+    )
 
     logger.info(
         "Cell size: %.2f x %.2f x %.2f um (%s)",

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -7,6 +7,7 @@ Translates the user-facing declarative API objects into the existing
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -24,6 +25,9 @@ from gsim.meep.models.api import (
 )
 
 logger = logging.getLogger(__name__)
+
+_AUTO_Z_PADDING = 0.5
+_FIBER_FLUX_OFFSET = 0.3
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +316,9 @@ class Simulation(BaseModel):
     # Private: guards against double vertical-cropping when build_config()
     # is called more than once (e.g. plot_2d then run) on the same sim.
     _z_cropped: bool = PrivateAttr(default=False)
+    _z_crop_source_stack: Any | None = PrivateAttr(default=None)
+    _last_cropped_stack: Any | None = PrivateAttr(default=None)
+    _resolved_z_bounds: tuple[float, float] | None = PrivateAttr(default=None)
 
     # Extra hints forwarded into the config JSON (not part of the schema).
     _hints: dict[str, Any] = PrivateAttr(default_factory=dict)
@@ -530,28 +537,121 @@ class Simulation(BaseModel):
             return None
         return min(zmins), max(zmaxs)
 
-    def _expand_margin_z_above_for_fiber(self, ref_top: float) -> None:
-        """Bump the above (high) side of ``margin_z`` to include the fiber plane.
+    def _resolve_mode_solver_z_window(
+        self,
+    ) -> tuple[tuple[float, float], tuple[float, float]]:
+        """Resolve mode-solver bounds and equivalent internal margins."""
+        extent = self._stack_material_extent()
+        if extent is None:
+            raise ValueError("Could not resolve a non-air Z extent for mode solving.")
+        stack_low, stack_high = extent
 
-        When the user configures ``sim.source_fiber(...)`` the Gaussian beam
-        sits at absolute z = ``fs.z``. The z-crop shrinks the stack around
-        the resolved ``z_ref`` top, so the above (high) side of ``margin_z``
-        must be large enough that ``ref_top + margin_z_high`` still sits above
-        the beam plane plus a waist-sized buffer (otherwise the fiber ends up
-        in PML).
+        if self.domain.z_bounds != "auto":
+            z_low, z_high = self.domain.z_bounds
+            if z_low > stack_low or z_high < stack_high:
+                raise ValueError(
+                    "Explicit domain.z_bounds must contain the modeled stack for "
+                    f"mode solving: requested ({z_low}, {z_high}), stack spans "
+                    f"({stack_low}, {stack_high})."
+                )
+            margins = (stack_low - z_low, z_high - stack_high)
+            self._resolved_z_bounds = (z_low, z_high)
+            return (z_low, z_high), margins
 
-        Args:
-            ref_top: Top (zmax) of the resolved vertical-crop reference (um).
+        legacy_fields = self.domain.legacy_z_fields_used()
+        if legacy_fields:
+            margin_low, margin_high = self.domain.resolved_margin_z()
+        else:
+            margin_low = margin_high = _AUTO_Z_PADDING
+        bounds = (stack_low - margin_low, stack_high + margin_high)
+        self._resolved_z_bounds = bounds
+
+        if legacy_fields:
+            field_names = " and ".join(f"domain.{name}" for name in legacy_fields)
+            warnings.warn(
+                f"Use of {field_names} is deprecated and will be removed in a "
+                f"future release; replace it with domain.z_bounds={bounds!r}.",
+                FutureWarning,
+                stacklevel=3,
+            )
+        return bounds, (margin_low, margin_high)
+
+    def _resolve_active_z_bounds(
+        self, component: Any
+    ) -> tuple[tuple[float, float], str, float | None, bool]:
+        """Resolve the public Z-domain setting to one concrete inner window.
+
+        Returns:
+            ``(bounds, reference_name, reference_n, is_auto)``. Explicit bounds
+            are returned unchanged. ``"auto"`` fits the drawn optical layer
+            with deterministic padding and may add fiber-source headroom.
         """
+        if self.domain.z_bounds != "auto":
+            z_low, z_high = self.domain.z_bounds
+            self._validate_fiber_z_bounds(z_low, z_high)
+            return (z_low, z_high), "explicit", None, False
+
+        ref_zmin, ref_zmax, ref_name, ref_n, is_auto_ref = self._resolve_z_ref_extent(
+            component=component
+        )
+        legacy_fields = self.domain.legacy_z_fields_used()
+        if legacy_fields:
+            margin_low, margin_high = self.domain.resolved_margin_z()
+        else:
+            margin_low = margin_high = _AUTO_Z_PADDING
+
+        z_low = ref_zmin - margin_low
+        z_high = ref_zmax + margin_high
+
+        if self.fiber_source is not None:
+            fiber_headroom = max(self.fiber_source.waist / 2.0, _AUTO_Z_PADDING)
+            z_high = max(z_high, self.fiber_source.z + fiber_headroom)
+
+        bounds = (float(z_low), float(z_high))
+        if legacy_fields:
+            field_names = " and ".join(f"domain.{name}" for name in legacy_fields)
+            warnings.warn(
+                f"Use of {field_names} is deprecated and will be removed in a "
+                f"future release; replace it with domain.z_bounds={bounds!r}.",
+                FutureWarning,
+                stacklevel=3,
+            )
+
+        return bounds, ref_name, ref_n, is_auto_ref
+
+    def _validate_fiber_z_bounds(self, z_low: float, z_high: float) -> None:
+        """Require an explicit window to contain all fiber-source headroom."""
         if self.fiber_source is None:
             return
-        fs = self.fiber_source
-        # Room for the beam plane + beam-half-waist so the Gaussian tail
-        # is inside the sim cell before PML.
-        mz_low, mz_high = self.domain.resolved_margin_z()
-        needed = (fs.z - ref_top) + max(fs.waist / 2.0, 0.5)
-        if mz_high < needed:
-            self.domain.margin_z = (mz_low, needed)
+        source = self.fiber_source
+        required_low = source.z - _FIBER_FLUX_OFFSET
+        required_high = source.z + max(source.waist / 2.0, _AUTO_Z_PADDING)
+        if z_low <= required_low and z_high >= required_high:
+            return
+        raise ValueError(
+            "Explicit domain.z_bounds does not contain the fiber source and "
+            f"monitor headroom: requested ({z_low}, {z_high}), requires at "
+            f"least ({required_low}, {required_high}). Expand z_bounds or use "
+            "z_bounds='auto'."
+        )
+
+    def _prepare_stack_for_z_crop(self) -> None:
+        """Restore a fresh stack before resolving and applying each Z crop."""
+        stack = self.geometry.stack
+        if stack is None:
+            raise ValueError("No stack configured for z-crop.")
+
+        if (
+            self._z_cropped
+            and stack is self._last_cropped_stack
+            and self._z_crop_source_stack is not None
+        ):
+            self.geometry.stack = self._z_crop_source_stack.model_copy(deep=True)
+        else:
+            self._z_crop_source_stack = stack.model_copy(deep=True)
+
+        self._z_cropped = False
+        self._last_cropped_stack = None
 
     def _component_with_derived_layers(self, component: Any) -> Any:
         """Return *component* augmented with any active-PDK derived layers.
@@ -660,34 +760,28 @@ class Simulation(BaseModel):
 
     def _apply_z_crop(
         self,
-        ref_zmin: float,
-        ref_zmax: float,
+        z_lo: float,
+        z_hi: float,
         ref_name: str,
         ref_n: float | None,
         is_auto: bool,
     ) -> None:
-        """Crop the stack vertically around the resolved ``z_ref`` window.
+        """Crop the stack to authoritative PML-inner Z bounds.
 
-        Preserves ``[ref_zmin - margin_z_low, ref_zmax + margin_z_high]``
-        and trims/removes layers and dielectrics outside it. Guarded by
-        ``_z_cropped`` so repeat ``build_config`` calls don't re-crop.
+        Trims/removes layers and dielectrics outside the exact interval.
 
         Args:
-            ref_zmin: Bottom of the reference window (um).
-            ref_zmax: Top of the reference window (um).
+            z_lo: Lower PML-inner Z bound (um).
+            z_hi: Upper PML-inner Z bound (um).
             ref_name: Name of the reference ('stack' or a layer name).
             ref_n: Refractive index of the reference layer (or None).
-            is_auto: Whether the reference was auto-detected (``z_ref=None``).
+            is_auto: Whether the reference was auto-detected.
         """
         from gsim.common.stack.extractor import Layer, LayerStack
 
         stack = self.geometry.stack
         if stack is None:
             raise ValueError("No stack configured for z-crop.")
-
-        mz_low, mz_high = self.domain.resolved_margin_z()
-        z_lo = ref_zmin - mz_low
-        z_hi = ref_zmax + mz_high
 
         # Filter and clip layers
         cropped: dict[str, Layer] = {}
@@ -722,6 +816,12 @@ class Simulation(BaseModel):
                 }
             )
 
+        if not cropped and not cropped_dielectrics:
+            raise ValueError(
+                f"domain.z_bounds=({z_lo}, {z_hi}) does not intersect any "
+                "layer or dielectric in the resolved stack."
+            )
+
         self.geometry.stack = LayerStack(
             pdk_name=stack.pdk_name,
             units=stack.units,
@@ -733,12 +833,9 @@ class Simulation(BaseModel):
         if is_auto:
             n_str = f"n={ref_n:.2f}, " if ref_n is not None else ""
             logger.info(
-                "z-crop reference auto-detected: %r (%sz=[%.4g, %.4g]); "
-                "window z=[%.4g, %.4g]",
+                "z-crop reference auto-detected: %r (%swindow z=[%.4g, %.4g])",
                 ref_name,
                 n_str,
-                ref_zmin,
-                ref_zmax,
                 z_lo,
                 z_hi,
             )
@@ -756,6 +853,7 @@ class Simulation(BaseModel):
         # Guard against re-cropping an already-cropped stack on repeat
         # build_config() calls (e.g. plot_2d then run).
         self._z_cropped = True
+        self._last_cropped_stack = self.geometry.stack
 
     # -------------------------------------------------------------------------
     # Internal: translate to config objects
@@ -797,14 +895,15 @@ class Simulation(BaseModel):
             wall_time_max=s.wall_time_max,
         )
 
-    def _domain_config(self) -> Any:
-        """Translate Domain -> DomainConfig."""
+    def _domain_config(self, z_bounds: tuple[float, float] | None = None) -> Any:
+        """Translate Domain to config with optional resolved Z bounds."""
         from gsim.meep.models.config import DomainConfig
 
         mx = self.domain.resolved_margin_x()
         my = self.domain.resolved_margin_y()
         mz = self.domain.resolved_margin_z()
         return DomainConfig(
+            z_bounds=z_bounds,
             dpml=self.domain.pml,
             margin_x_low=mx[0],
             margin_x_high=mx[1],
@@ -953,7 +1052,7 @@ class Simulation(BaseModel):
 
         stack = self.geometry.stack
         component = self.geometry.component
-        domain_cfg = self._domain_config()
+        domain_cfg = self._domain_config(z_bounds=self._resolved_z_bounds)
         port = self.mode_solver.port
         position = self.mode_solver.position
         port_or_pos = port if port is not None else position
@@ -1002,7 +1101,6 @@ class Simulation(BaseModel):
 
         resolution = self.solver.resolution
         pml_thickness = self.domain.pml
-        z_margin = self.domain.resolved_margin_z()
 
         component = self.geometry.component
         where = ms.where
@@ -1040,6 +1138,7 @@ class Simulation(BaseModel):
         stack = self.geometry.stack
         if stack is None:
             raise ValueError("Stack resolution failed.")
+        mode_z_bounds, z_margin = self._resolve_mode_solver_z_window()
 
         background_material = ms.background_material
 
@@ -1133,7 +1232,7 @@ class Simulation(BaseModel):
                     )
                     results.append(mode_result)
 
-        domain_cfg = self._domain_config()
+        domain_cfg = self._domain_config(z_bounds=mode_z_bounds)
         for r in results:
             r.domain_config = domain_cfg
 
@@ -1193,18 +1292,33 @@ class Simulation(BaseModel):
             self.geometry.component
         )
 
-        # Apply z-crop for 3D and XZ 2D (both use the vertical dimension).
-        # XY 2D collapses z entirely so cropping is meaningless. The crop
-        # window comes from domain.z_ref (default: the drawn photonic core).
-        if (is_3d or plane == "xz") and not self._z_cropped:
-            ref_zmin, ref_zmax, ref_name, ref_n, is_auto = self._resolve_z_ref_extent(
-                component=original_component
+        # Resolve one authoritative PML-inner Z interval for every simulation
+        # with an active Z axis. XY 2D collapses Z and therefore rejects an
+        # explicit interval.
+        resolved_z_bounds: tuple[float, float] | None = None
+        if is_3d or plane == "xz":
+            self._prepare_stack_for_z_crop()
+            (
+                resolved_z_bounds,
+                ref_name,
+                ref_n,
+                is_auto,
+            ) = self._resolve_active_z_bounds(original_component)
+            self._resolved_z_bounds = resolved_z_bounds
+            self._apply_z_crop(
+                resolved_z_bounds[0],
+                resolved_z_bounds[1],
+                ref_name,
+                ref_n,
+                is_auto,
             )
-            # When a fiber source is configured in XZ mode, expand the
-            # above (high) side of margin_z so the cropped stack still
-            # contains the beam plane (and PML headroom) — from the ref top.
-            self._expand_margin_z_above_for_fiber(ref_zmax)
-            self._apply_z_crop(ref_zmin, ref_zmax, ref_name, ref_n, is_auto)
+        else:
+            self._resolved_z_bounds = None
+            if self.domain.z_bounds != "auto":
+                raise ValueError(
+                    "Explicit domain.z_bounds requires an active Z axis (3D or "
+                    "XZ 2D). Use solver.z_cut to choose an XY slice."
+                )
 
         import gdsfactory as gf
 
@@ -1222,7 +1336,7 @@ class Simulation(BaseModel):
             y_cut = None
 
         # Build config objects
-        domain_cfg = self._domain_config()
+        domain_cfg = self._domain_config(z_bounds=resolved_z_bounds)
         wl_cfg = self._wavelength_config()
         source_cfg = self._source_config()
         stopping_cfg = self._stopping_config()
@@ -1537,7 +1651,6 @@ class Simulation(BaseModel):
 
         resolution = self.solver.resolution
         pml_thickness = self.domain.pml
-        z_margin = self.domain.resolved_margin_z()
 
         first_wavelength = ms.wavelengths[0]
         _stack, material_data = self._resolve_stack_and_materials(
@@ -1548,6 +1661,7 @@ class Simulation(BaseModel):
             raise ValueError(
                 "Stack resolution failed — set a geometry with stack first"
             )
+        _mode_z_bounds, z_margin = self._resolve_mode_solver_z_window()
 
         if stack.dielectrics:
             dielectrics = [

--- a/tests/meep/test_meep_models.py
+++ b/tests/meep/test_meep_models.py
@@ -582,6 +582,51 @@ class TestPublicDomainMargins:
         assert above == 1.1
 
 
+class TestPublicDomainZBounds:
+    """Test the canonical public Z-domain control."""
+
+    def test_default_is_auto(self):
+        from gsim.meep.models.api import Domain
+
+        assert Domain().z_bounds == "auto"
+
+    def test_explicit_bounds_are_normalized(self):
+        from gsim.meep.models.api import Domain
+
+        assert Domain(z_bounds=[-1, 3]).z_bounds == (-1.0, 3.0)  # ty: ignore[invalid-argument-type]
+
+    @pytest.mark.parametrize(
+        "bounds",
+        [(-1.0, -1.0), (2.0, 1.0), (float("nan"), 1.0), (0.0, float("inf"))],
+    )
+    def test_invalid_bounds_rejected(self, bounds):
+        from gsim.meep.models.api import Domain
+
+        with pytest.raises(ValidationError):
+            Domain(z_bounds=bounds)
+
+    def test_explicit_bounds_reject_legacy_inputs(self):
+        from gsim.meep.models.api import Domain
+
+        with pytest.raises(ValidationError, match="cannot be combined"):
+            Domain(z_bounds=(-1.0, 3.0), margin_z=0.5)
+
+    def test_assignment_rejects_legacy_input_after_bounds(self):
+        from gsim.meep.models.api import Domain
+
+        domain = Domain(z_bounds=(-1.0, 3.0))
+        with pytest.raises(ValidationError, match="cannot be combined"):
+            domain.margin_z = (0.2, 0.3)
+
+    def test_legacy_fields_are_not_dumped(self):
+        from gsim.meep.models.api import Domain
+
+        dumped = Domain().model_dump()
+        assert "z_bounds" in dumped
+        assert "z_ref" not in dumped
+        assert "margin_z" not in dumped
+
+
 class TestSimConfigComponentBbox:
     """Test SimConfig.component_bbox field."""
 

--- a/tests/meep/test_script_template.py
+++ b/tests/meep/test_script_template.py
@@ -30,6 +30,30 @@ def test_runner_has_fiber_source_path():
     assert "GaussianBeamSource" in _MEEP_RUNNER_TEMPLATE
 
 
+def test_resolved_z_bounds_are_identical_in_3d_and_xz():
+    """Canonical bounds must bypass the legacy XZ margin path."""
+    resolve_z_cell = _extract_runner_func("resolve_z_cell")
+    domain = {
+        "dpml": 1.0,
+        "z_bounds": [-1.0, 3.0],
+        # Deliberately large legacy values: canonical bounds must win.
+        "margin_z_low": 10.0,
+        "margin_z_high": 20.0,
+    }
+
+    assert resolve_z_cell(domain, -0.5, 0.22, True, False) == (6.0, 1.0)
+    assert resolve_z_cell(domain, -0.5, 0.22, False, True) == (6.0, 1.0)
+
+
+def test_legacy_xz_margins_are_applied_once():
+    """Old configs retain one margin expansion, not the new canonical path."""
+    resolve_z_cell = _extract_runner_func("resolve_z_cell")
+    domain = {"dpml": 1.0, "margin_z_low": 0.5, "margin_z_high": 1.0}
+
+    # Inner bounds are [-1, 3], outer bounds are [-2, 4].
+    assert resolve_z_cell(domain, -0.5, 2.0, False, True) == (6.0, 1.0)
+
+
 def _extract_runner_func(name: str):
     """Exec a single pure-Python helper from the runner template in isolation.
 

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -835,7 +835,8 @@ class TestXZAutoCrop:
         sim = self._base_sim()
         sim.domain(z_ref="stack")
         sim.source_fiber(x=0.0, z=1.22, waist=5.4)
-        sim.build_config()
+        with pytest.warns(FutureWarning, match="domain.z_bounds"):
+            sim.build_config()
 
         assert sim.geometry.stack is not None
         box = next(d for d in sim.geometry.stack.dielectrics if d["name"] == "box")
@@ -847,10 +848,91 @@ class TestXZAutoCrop:
         # Reference is the drawn core (zmax=0.22). Beam plane at z=1.42.
         sim.source_fiber(x=0.0, z=1.42, waist=5.4, angle_deg=14.5)
 
-        initial_margin = sim.domain.resolved_margin_z()[1]
+        result = sim.build_config()
+
+        # Auto bounds grow to fiber z + half-waist without mutating the public
+        # setting: 1.42 + 5.4/2 = 4.12.
+        assert sim.domain.z_bounds == "auto"
+        assert result.config.domain.z_bounds == pytest.approx((-0.5, 4.12))
+
+    def test_explicit_xz_bounds_are_preserved(self):
+        sim = self._base_sim()
+        sim.domain(z_bounds=(-1.0, 5.0))
+        sim.source_fiber(x=0.0, z=1.22, waist=5.4)
+
+        result = sim.build_config()
+
+        assert result.config.domain.z_bounds == (-1.0, 5.0)
+
+    def test_explicit_bounds_reject_missing_fiber_headroom(self):
+        sim = self._base_sim()
+        sim.domain(z_bounds=(-1.0, 3.0))
+        sim.source_fiber(x=0.0, z=1.22, waist=5.4)
+
+        with pytest.raises(ValueError, match="fiber source and monitor headroom"):
+            sim.build_config()
+
+    def test_legacy_z_sizing_warns_with_exact_replacement(self):
+        sim = self._base_sim()
+        sim.domain(z_ref="stack")
+        sim.source_fiber(x=0.0, z=1.22, waist=5.4)
+
+        with pytest.warns(FutureWarning, match=r"domain\.z_bounds=\("):
+            result = sim.build_config()
+
+        assert result.config.domain.z_bounds is not None
+
+    def test_legacy_margin_assignment_still_works(self):
+        sim = self._base_sim()
+        sim.domain.margin_z = (0.8, 1.0)
+
+        with pytest.warns(
+            FutureWarning,
+            match=r"domain\.z_bounds=\(-0\.8, 1\.22\)",
+        ):
+            result = sim.build_config()
+
+        assert result.config.domain.z_bounds == pytest.approx((-0.8, 1.22))
+
+    def test_explicit_bounds_rejected_for_xy_2d(self):
+        sim = self._base_sim()
+        sim.solver(mode="2d", y_cut=None, z_cut="auto")
+        sim.domain(z_bounds=(-1.0, 3.0))
+
+        with pytest.raises(ValueError, match="requires an active Z axis"):
+            sim.build_config()
+
+    def test_explicit_3d_bounds_are_preserved(self):
+        sim = self._base_sim()
+        sim.solver(mode="3d", y_cut=None)
+        sim.domain(z_bounds=(-1.0, 3.0))
+
+        result = sim.build_config()
+
+        assert result.config.domain.z_bounds == (-1.0, 3.0)
+
+    def test_new_json_omits_legacy_z_margins(self, tmp_path):
+        import json
+
+        sim = self._base_sim()
+        sim.domain(z_bounds=(-1.0, 3.0))
+        result = sim.build_config()
+        config_path = result.config.to_json(tmp_path / "sim_config.json")
+
+        domain_data = json.loads(config_path.read_text())["domain"]
+        assert domain_data["z_bounds"] == [-1.0, 3.0]
+        assert "margin_z_low" not in domain_data
+        assert "margin_z_high" not in domain_data
+
+    def test_changing_bounds_after_build_recrops_from_original_stack(self):
+        sim = self._base_sim()
+        sim.domain(z_bounds=(-1.0, 3.0))
         sim.build_config()
-        # Margin grows to (z - core_top) + waist/2 so the beam plane sits
-        # inside the cell: (1.42 - 0.22) + 5.4/2 = 3.9.
-        expected = (1.42 - 0.22) + 5.4 / 2
-        assert sim.domain.resolved_margin_z()[1] == pytest.approx(expected)
-        assert sim.domain.resolved_margin_z()[1] > initial_margin
+
+        sim.domain.z_bounds = (-2.0, 4.0)
+        result = sim.build_config()
+
+        assert result.config.domain.z_bounds == (-2.0, 4.0)
+        assert sim.geometry.stack is not None
+        box = next(d for d in sim.geometry.stack.dielectrics if d["name"] == "box")
+        assert box["zmin"] == -2.0


### PR DESCRIPTION
## Summary
- add Domain.z_bounds as the sole public Z-domain control, with deterministic auto sizing or exact PML-inner bounds
- keep z_ref and margin_z as a one-release compatibility shim that warns with the exact replacement tuple and rejects mixed configuration
- resolve and serialize one canonical Z interval for 3D, XZ, overlays, and mode solvers
- fix XZ simulations applying vertical margins twice and preserve legacy runner fallback
- validate fiber-source headroom and stable recropping across repeated builds

Validation: 882 passed, 1 skipped, 23 deselected, 4 xpassed; all commit hooks passed.