### PR TITLE
fix: prevent MEEP derived layer aliasing

### DIFF
--- a/src/gsim/meep/physical_layers.py
+++ b/src/gsim/meep/physical_layers.py
@@ -1,0 +1,185 @@
+"""Materialize simulation layers without GDS target-layer aliasing.
+
+GDS stores concrete mask polygons, while a GDSFactory ``LayerStack`` can
+describe physical layers with Boolean expressions.  Multiple physical levels
+may share the same declared output tuple, so materializing them onto those
+targets loses their identities.  This module evaluates each level separately
+and writes it to a deterministic, simulation-only GDS tuple.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PhysicalLayerExport:
+    """A component and stack pair with one GDS tuple per physical level."""
+
+    component: Any
+    stack: Any
+    gdsfactory_stack: Any
+    layer_map: dict[str, tuple[int, int]]
+
+
+def _temporary_layer_candidates() -> Iterator[tuple[int, int]]:
+    """Yield valid GDS tuples in a stable order from the top of the range."""
+    for datatype in range(65_536):
+        for layer_number in range(65_535, -1, -1):
+            yield layer_number, datatype
+
+
+def allocate_physical_layers(
+    level_names: list[str],
+    used_layers: set[tuple[int, int]],
+) -> dict[str, tuple[int, int]]:
+    """Allocate deterministic tuples that do not collide with source masks."""
+    candidates = _temporary_layer_candidates()
+    unavailable = set(used_layers)
+    allocated: dict[str, tuple[int, int]] = {}
+
+    for level_name in level_names:
+        target = next(
+            candidate for candidate in candidates if candidate not in unavailable
+        )
+        allocated[level_name] = target
+        unavailable.add(target)
+
+    return allocated
+
+
+def _active_gdsfactory_stack(stack: Any) -> Any | None:
+    """Return the matching active-PDK stack, if *stack* came from that PDK."""
+    import gdsfactory as gf
+
+    try:
+        pdk = gf.get_active_pdk()
+    except ValueError:
+        return None
+
+    if getattr(stack, "pdk_name", None) != getattr(pdk, "name", None):
+        return None
+    return getattr(pdk, "layer_stack", None)
+
+
+def _matching_layer_level(
+    layer_name: str,
+    layer: Any,
+    gdsfactory_stack: Any | None,
+) -> Any | None:
+    """Find the authoritative GDSFactory level corresponding to a gsim layer."""
+    if gdsfactory_stack is None:
+        return None
+
+    level = gdsfactory_stack.layers.get(layer_name)
+    if level is None:
+        return None
+
+    from gsim.common.stack._layer_utils import get_gds_layer_tuple
+
+    if get_gds_layer_tuple(level) != tuple(layer.gds_layer):
+        return None
+    return level
+
+
+def _evaluate_level_region(component: Any, level: Any) -> Any:
+    """Evaluate one GDSFactory physical level from its source expression."""
+    import gdsfactory as gf
+    from kfactory import kdb
+
+    if getattr(level, "background", False):
+        background = kdb.Region(component.kdb_cell.bbox())
+        for excluded_layer in getattr(level, "background_exclude_layers", ()):
+            layer_tuple = gf.get_layer_tuple(excluded_layer)
+            layer_index = component.kcl.layer(*layer_tuple)
+            background -= kdb.Region(component.kdb_cell.begin_shapes_rec(layer_index))
+        return background
+
+    return level.layer.get_shapes(component)
+
+
+def _source_layer_region(component: Any, gds_layer: tuple[int, int]) -> Any:
+    """Read one concrete source-mask layer recursively from *component*."""
+    from kfactory import kdb
+
+    layer_index = component.kcl.layer(*gds_layer)
+    return kdb.Region(component.kdb_cell.begin_shapes_rec(layer_index))
+
+
+def _build_gdsfactory_stack(
+    stack: Any,
+    layer_map: dict[str, tuple[int, int]],
+    source_stack: Any | None,
+) -> Any:
+    """Create a direct-layer GDSFactory stack for the materialized component."""
+    from gdsfactory.technology import LayerLevel, LayerStack
+
+    levels = {}
+    for layer_name, layer in stack.layers.items():
+        source_level = (
+            source_stack.layers.get(layer_name) if source_stack is not None else None
+        )
+        mesh_order = getattr(source_level, "mesh_order", 3)
+        levels[layer_name] = LayerLevel(
+            layer=layer_map[layer_name],
+            thickness=layer.thickness,
+            zmin=layer.zmin,
+            material=layer.material,
+            sidewall_angle=layer.sidewall_angle,
+            mesh_order=mesh_order,
+        )
+    return LayerStack(layers=levels)
+
+
+def materialize_physical_layers(component: Any, stack: Any) -> PhysicalLayerExport:
+    """Evaluate every simulation layer onto its own native GDS tuple.
+
+    Layers originating in the active PDK are evaluated from their authoritative
+    ``LogicalLayer`` or ``DerivedLayer`` expression.  Custom/YAML stack entries
+    fall back to reading their concrete ``gds_layer`` directly.  The returned
+    component and both returned stacks must be consumed together.
+    """
+    import gdsfactory as gf
+
+    source_stack = _active_gdsfactory_stack(stack)
+    used_layers = {tuple(layer) for layer in component.layers}
+    layer_map = allocate_physical_layers(list(stack.layers), used_layers)
+
+    materialized = gf.Component()
+    remapped_stack = stack.model_copy(deep=True)
+
+    for layer_name, layer in stack.layers.items():
+        source_level = _matching_layer_level(layer_name, layer, source_stack)
+        if source_level is None:
+            region = _source_layer_region(component, tuple(layer.gds_layer))
+        else:
+            region = _evaluate_level_region(component, source_level)
+
+        target = layer_map[layer_name]
+        target_index = materialized.kcl.layer(*target)
+        materialized.shapes(target_index).insert(region)
+        remapped_stack.layers[layer_name].gds_layer = target
+
+    materialized.add_ports(component.ports)
+    materialized.copy_child_info(component)
+
+    physical_gdsfactory_stack = _build_gdsfactory_stack(
+        remapped_stack,
+        layer_map,
+        source_stack,
+    )
+    return PhysicalLayerExport(
+        component=materialized,
+        stack=remapped_stack,
+        gdsfactory_stack=physical_gdsfactory_stack,
+        layer_map=layer_map,
+    )
+
+
+__all__ = [
+    "PhysicalLayerExport",
+    "allocate_physical_layers",
+    "materialize_physical_layers",
+]

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -43,11 +43,15 @@ class BuildResult:
         config: Full serializable SimConfig.
         component: Extended component (what meep actually simulates).
         original_component: Original component before port extension.
+        stack: Simulation stack remapped to the component's physical layers.
+        gdsfactory_stack: Direct-layer stack used to visualize the component.
     """
 
     config: Any  # SimConfig
     component: Any  # gdsfactory Component (extended)
     original_component: Any  # gdsfactory Component (original)
+    stack: Any  # gsim LayerStack (cropped and remapped)
+    gdsfactory_stack: Any  # gdsfactory LayerStack (direct physical layers)
 
 
 # ---------------------------------------------------------------------------
@@ -512,7 +516,9 @@ class Simulation(BaseModel):
     # Internal: fiber-aware z margin
     # -------------------------------------------------------------------------
 
-    def _stack_material_extent(self) -> tuple[float, float] | None:
+    def _stack_material_extent(
+        self, stack: Any | None = None
+    ) -> tuple[float, float] | None:
         """Return (zmin, zmax) spanning all non-air layers and dielectrics.
 
         This is the reference used by auto z-crop and by the fiber-aware
@@ -520,7 +526,7 @@ class Simulation(BaseModel):
         core, cladding, passive, ...) and trims only the synthetic air
         padding added by the extractor.
         """
-        stack = self.geometry.stack
+        stack = stack if stack is not None else self.geometry.stack
         if stack is None:
             return None
         zmins: list[float] = []
@@ -577,7 +583,7 @@ class Simulation(BaseModel):
         return bounds, (margin_low, margin_high)
 
     def _resolve_active_z_bounds(
-        self, component: Any
+        self, component: Any, stack: Any | None = None
     ) -> tuple[tuple[float, float], str, float | None, bool]:
         """Resolve the public Z-domain setting to one concrete inner window.
 
@@ -592,7 +598,8 @@ class Simulation(BaseModel):
             return (z_low, z_high), "explicit", None, False
 
         ref_zmin, ref_zmax, ref_name, ref_n, is_auto_ref = self._resolve_z_ref_extent(
-            component=component
+            component=component,
+            stack=stack,
         )
         legacy_fields = self.domain.legacy_z_fields_used()
         if legacy_fields:
@@ -653,51 +660,10 @@ class Simulation(BaseModel):
         self._z_cropped = False
         self._last_cropped_stack = None
 
-    def _component_with_derived_layers(self, component: Any) -> Any:
-        """Return *component* augmented with any active-PDK derived layers.
-
-        GDS stores source mask layers, whereas a gdsfactory ``LayerStack`` may
-        describe physical layers using boolean expressions and ``derived_layer``
-        targets.  MEEP needs both: the evaluated layers for the physical stack
-        and the original layers for stack entries that are not derived.
-        """
-        import gdsfactory as gf
-
-        pdk_layer_stack = gf.get_active_pdk().layer_stack
-        if pdk_layer_stack is None:
-            return component.copy()
-        if not any(
-            level.derived_layer is not None for level in pdk_layer_stack.layers.values()
-        ):
-            return component.copy()
-
-        derived = pdk_layer_stack.get_component_with_derived_layers(component)
-        # ``get_component_with_derived_layers`` evaluates each layer's
-        # Boolean expression but does not apply gdsfactory's ``background``
-        # semantics.  Recreate those physical layers from the component bbox
-        # and the declared etch exclusions, matching ``Component.to_3d()``.
-        # This keeps the hierarchy intact; no flattening is required.
-        from kfactory import kdb
-
-        for level in pdk_layer_stack.layers.values():
-            if not getattr(level, "background", False) or level.derived_layer is None:
-                continue
-
-            target_layer = gf.get_layer_tuple(level.derived_layer.layer)
-            background = kdb.Region(component.kdb_cell.bbox())
-            for excluded_layer in getattr(level, "background_exclude_layers", ()):
-                layer_index = component.kcl.layer(*tuple(excluded_layer))
-                background -= kdb.Region(
-                    component.kdb_cell.begin_shapes_rec(layer_index)
-                )
-            derived.remove_layers([target_layer])
-            derived.add_polygon(background, layer=target_layer)
-
-        derived.add_ref(component)
-        return derived
-
     def _resolve_z_ref_extent(
-        self, component: Any | None = None
+        self,
+        component: Any | None = None,
+        stack: Any | None = None,
     ) -> tuple[float, float, str, float | None, bool]:
         """Resolve ``domain.z_ref`` to a vertical reference window.
 
@@ -716,14 +682,14 @@ class Simulation(BaseModel):
         """
         from gsim.meep.ports import _find_highest_n_layer_in_component
 
-        stack = self.geometry.stack
+        stack = stack if stack is not None else self.geometry.stack
         if stack is None:
             raise ValueError("No stack configured for z-crop.")
 
         z_ref = self.domain.z_ref
 
         if z_ref == "stack":
-            extent = self._stack_material_extent()
+            extent = self._stack_material_extent(stack)
             if extent is None:
                 raise ValueError(
                     "Could not detect any non-air layers/dielectrics for "
@@ -737,7 +703,7 @@ class Simulation(BaseModel):
                 stack,
             )
             if layer is None:
-                extent = self._stack_material_extent()
+                extent = self._stack_material_extent(stack)
                 if extent is None:
                     raise ValueError(
                         "Could not detect any drawn optical layer or non-air "
@@ -1284,13 +1250,12 @@ class Simulation(BaseModel):
         if self.geometry.component is None:
             raise ValueError("No geometry set.")
 
-        # Materialize derived PDK layers before inspecting or exporting the
-        # geometry.  A number of PDKs define the physical core as a boolean
-        # expression of fabrication-mask layers; those derived polygons are
-        # not present in an imported GDS until the layer stack evaluates them.
-        original_component = self._component_with_derived_layers(
-            self.geometry.component
-        )
+        from gsim.meep.physical_layers import materialize_physical_layers
+
+        # Keep the fabrication-mask component authoritative until after port
+        # extension. Physical layers are evaluated onto unique simulation-only
+        # tuples so two LayerLevels can never alias through a shared GDS target.
+        original_component = self.geometry.component
 
         # Resolve one authoritative PML-inner Z interval for every simulation
         # with an active Z axis. XY 2D collapses Z and therefore rejects an
@@ -1298,12 +1263,21 @@ class Simulation(BaseModel):
         resolved_z_bounds: tuple[float, float] | None = None
         if is_3d or plane == "xz":
             self._prepare_stack_for_z_crop()
+            if self.geometry.stack is None:  # pragma: no cover - guarded above
+                raise ValueError("Stack resolution failed.")
+            reference_export = materialize_physical_layers(
+                original_component,
+                self.geometry.stack,
+            )
             (
                 resolved_z_bounds,
                 ref_name,
                 ref_n,
                 is_auto,
-            ) = self._resolve_active_z_bounds(original_component)
+            ) = self._resolve_active_z_bounds(
+                reference_export.component,
+                reference_export.stack,
+            )
             self._resolved_z_bounds = resolved_z_bounds
             self._apply_z_crop(
                 resolved_z_bounds[0],
@@ -1321,8 +1295,6 @@ class Simulation(BaseModel):
                 )
 
         import gdsfactory as gf
-
-        stack = self.geometry.stack
 
         # Resolve the XZ cut Y-coordinate ('auto'/None -> bbox center).
         cut = self.solver.resolved_cut()
@@ -1357,16 +1329,27 @@ class Simulation(BaseModel):
                 + domain_cfg.dpml
             )
 
-        # Extend waveguide ports into PML region
+        # Extend source-mask waveguide ports before evaluating physical layers.
+        # Extending an already-materialized component would draw onto the source
+        # tuple and leave the remapped physical core unextended.
         original_bbox: list[float] | None = None
         if extend_length > 0:
             bbox = original_component.dbbox()
             original_bbox = [bbox.left, bbox.bottom, bbox.right, bbox.top]
-            component = gf.components.extend_ports(
+            extended_source_component = gf.components.extend_ports(
                 original_component, length=extend_length
             )
         else:
-            component = original_component
+            extended_source_component = original_component
+
+        if self.geometry.stack is None:  # pragma: no cover - guarded above
+            raise ValueError("Stack resolution failed.")
+        physical_export = materialize_physical_layers(
+            extended_source_component,
+            self.geometry.stack,
+        )
+        component = physical_export.component
+        stack = physical_export.stack
 
         # Build layer stack entries
         layer_stack_entries = []
@@ -1547,6 +1530,8 @@ class Simulation(BaseModel):
             config=sim_config,
             component=component,
             original_component=original_component,
+            stack=stack,
+            gdsfactory_stack=physical_export.gdsfactory_stack,
         )
 
     # -------------------------------------------------------------------------
@@ -2014,10 +1999,11 @@ class Simulation(BaseModel):
 
         return plot_2d(
             component=result.component,
-            stack=self.geometry.stack,
+            stack=result.stack,
             domain_config=result.config.domain,
             source_port=result.config.source.port,
             extend_ports_length=0,
+            gdsfactory_stack=result.gdsfactory_stack,
             port_data=result.config.ports,
             component_bbox=result.config.component_bbox,
             fiber_source=result.config.fiber_source,
@@ -2055,10 +2041,11 @@ class Simulation(BaseModel):
 
         return plot_2d_interactive(
             component=result.component,
-            stack=self.geometry.stack,
+            stack=result.stack,
             domain_config=result.config.domain,
             source_port=result.config.source.port,
             extend_ports_length=0,
+            gdsfactory_stack=result.gdsfactory_stack,
             port_data=result.config.ports,
             component_bbox=result.config.component_bbox,
             fiber_source=result.config.fiber_source,
@@ -2080,8 +2067,9 @@ class Simulation(BaseModel):
 
         return plot_3d(
             component=result.component,
-            stack=self.geometry.stack,
+            stack=result.stack,
             domain_config=result.config.domain,
             extend_ports_length=0,
+            gdsfactory_stack=result.gdsfactory_stack,
             **kwargs,
         )

--- a/src/gsim/meep/viz.py
+++ b/src/gsim/meep/viz.py
@@ -29,12 +29,13 @@ def build_geometry_model(
     stack: LayerStack | None,
     domain_config: DomainConfig,
     extend_ports_length: float | None = None,
+    gdsfactory_stack: Any | None = None,
 ) -> GeometryModel:
     """Build a GeometryModel from a component + stack for visualization.
 
-    Uses the gdsfactory LayerStack from the active PDK (not the gsim
-    LayerStack), because ``LayeredComponentBase`` needs gdsfactory's
-    ``LayerStack`` for polygon extraction via ``DerivedLayer.get_shapes()``.
+    ``Simulation.build_config`` supplies a direct-layer GDSFactory stack that
+    is remapped to the materialized component. Standalone callers fall back to
+    the active PDK stack for backward compatibility.
 
     When ``domain_config.extend_ports`` is configured, the waveguide
     ports are extended into the PML region so the visualization matches
@@ -48,6 +49,7 @@ def build_geometry_model(
             when the component has already been extended by
             :meth:`Simulation.build_config`. ``None`` (default) computes
             the length from *domain_config* as before.
+        gdsfactory_stack: Optional direct-layer stack matching *component*.
 
     Returns:
         GeometryModel ready for visualization.
@@ -60,8 +62,11 @@ def build_geometry_model(
     from gsim.common.geometry_model import extract_geometry_model
     from gsim.common.layered_component import LayeredComponentBase
 
-    pdk = gf.get_active_pdk()
-    gf_layer_stack = pdk.layer_stack
+    if gdsfactory_stack is not None:
+        gf_layer_stack = gdsfactory_stack
+    else:
+        pdk = gf.get_active_pdk()
+        gf_layer_stack = pdk.layer_stack
     if gf_layer_stack is None:
         raise ValueError(
             "Active PDK has no layer_stack. Activate a PDK with a layer stack first."
@@ -393,6 +398,7 @@ def plot_3d(
     domain_config: DomainConfig,
     backend: str = "open3d",
     extend_ports_length: float | None = None,
+    gdsfactory_stack: Any | None = None,
     **kwargs: Any,
 ) -> Any:
     """Create interactive 3D visualization of MEEP geometry.
@@ -404,6 +410,7 @@ def plot_3d(
         backend: "open3d" (Jupyter/VS Code) or "pyvista" (desktop).
         extend_ports_length: Override port extension length (pass 0 if
             the component is already extended).
+        gdsfactory_stack: Optional direct-layer stack matching *component*.
         **kwargs: Extra args forwarded to the backend renderer.
 
     Returns:
@@ -412,7 +419,11 @@ def plot_3d(
     from gsim.common.viz import plot_prisms_3d, plot_prisms_3d_open3d
 
     gm = build_geometry_model(
-        component, stack, domain_config, extend_ports_length=extend_ports_length
+        component,
+        stack,
+        domain_config,
+        extend_ports_length=extend_ports_length,
+        gdsfactory_stack=gdsfactory_stack,
     )
     if backend == "pyvista":
         return plot_prisms_3d(gm, **kwargs)
@@ -436,6 +447,7 @@ def plot_2d_interactive(
     fiber_source: Any = None,
     monitor_z_span: float | None = None,
     aspect: Literal["equal", "auto"] = "equal",
+    gdsfactory_stack: Any | None = None,
 ) -> Any:
     """Plot an interactive 2D cross-section using Plotly.
 
@@ -465,6 +477,7 @@ def plot_2d_interactive(
         monitor_z_span: Port monitor z-span override.
         aspect: Axis aspect ratio. Use ``"equal"`` to preserve physical
             proportions or ``"auto"`` to fill the available plotting area.
+        gdsfactory_stack: Optional direct-layer stack matching *component*.
 
     Returns:
         ``plotly.graph_objects.Figure``.
@@ -478,7 +491,11 @@ def plot_2d_interactive(
         )
 
     gm = build_geometry_model(
-        component, stack, domain_config, extend_ports_length=extend_ports_length
+        component,
+        stack,
+        domain_config,
+        extend_ports_length=extend_ports_length,
+        gdsfactory_stack=gdsfactory_stack,
     )
     overlay = build_overlay(
         gm,
@@ -521,6 +538,7 @@ def plot_2d(
     fiber_source: Any = None,
     monitor_z_span: float | None = None,
     aspect: Literal["equal", "auto"] = "equal",
+    gdsfactory_stack: Any | None = None,
 ) -> plt.Axes | None:
     """Plot 2D cross-sections of the MEEP geometry.
 
@@ -551,7 +569,11 @@ def plot_2d(
     from gsim.common.viz import plot_prism_slices
 
     gm = build_geometry_model(
-        component, stack, domain_config, extend_ports_length=extend_ports_length
+        component,
+        stack,
+        domain_config,
+        extend_ports_length=extend_ports_length,
+        gdsfactory_stack=gdsfactory_stack,
     )
     overlay = build_overlay(
         gm,

--- a/tests/meep/test_physical_layers.py
+++ b/tests/meep/test_physical_layers.py
@@ -1,0 +1,152 @@
+"""Regression tests for collision-free physical-layer materialization."""
+
+from __future__ import annotations
+
+import json
+
+import gdsfactory as gf
+from kfactory import kdb
+
+from gsim.common.cross_section import extract_xz_rectangles
+from gsim.common.stack import get_stack
+from gsim.meep.physical_layers import (
+    allocate_physical_layers,
+    materialize_physical_layers,
+)
+
+
+def _region(component, layer: tuple[int, int]) -> kdb.Region:
+    layer_index = component.kcl.layer(*layer)
+    return kdb.Region(component.kdb_cell.begin_shapes_rec(layer_index))
+
+
+def test_allocator_is_deterministic_and_skips_source_layers():
+    used_layers = {(65_535, 0), (65_534, 0)}
+
+    first = allocate_physical_layers(["core", "slab"], used_layers)
+    second = allocate_physical_layers(["core", "slab"], used_layers)
+
+    assert first == second
+    assert first == {"core": (65_533, 0), "slab": (65_532, 0)}
+
+
+def test_direct_slab_does_not_create_shallow_etch():
+    component = gf.Component()
+    component.add_polygon(
+        [(0, 0), (10, 0), (10, 2), (0, 2)],
+        layer=gf.gpdk.LAYER.WG,
+    )
+    component.add_polygon(
+        [(0, 0), (10, 0), (10, 2), (0, 2)],
+        layer=gf.gpdk.LAYER.SLAB150,
+    )
+
+    physical = materialize_physical_layers(component, get_stack())
+    core = _region(physical.component, physical.layer_map["core"])
+    shallow = _region(physical.component, physical.layer_map["shallow_etch"])
+    slab = _region(physical.component, physical.layer_map["slab150"])
+
+    assert not core.is_empty()
+    assert shallow.is_empty()
+    assert not slab.is_empty()
+    assert physical.layer_map["shallow_etch"] != physical.layer_map["slab150"]
+
+
+def test_real_shallow_etch_stays_separate_from_direct_slab():
+    component = gf.Component()
+    component.add_polygon(
+        [(0, 0), (10, 0), (10, 2), (0, 2)],
+        layer=gf.gpdk.LAYER.WG,
+    )
+    component.add_polygon(
+        [(4, 0.5), (6, 0.5), (6, 1.5), (4, 1.5)],
+        layer=gf.gpdk.LAYER.SHALLOW_ETCH,
+    )
+    component.add_polygon(
+        [(8, 3), (10, 3), (10, 4), (8, 4)],
+        layer=gf.gpdk.LAYER.SLAB150,
+    )
+
+    physical = materialize_physical_layers(component, get_stack())
+    shallow = _region(physical.component, physical.layer_map["shallow_etch"])
+    slab = _region(physical.component, physical.layer_map["slab150"])
+
+    assert shallow.area() == 2_000_000
+    assert slab.area() == 2_000_000
+    assert physical.stack.layers["shallow_etch"].gds_layer != (
+        physical.stack.layers["slab150"].gds_layer
+    )
+
+
+def test_build_config_and_xz_geometry_omit_false_shallow_etch(tmp_path):
+    from gsim.meep import Simulation
+    from gsim.meep.viz import build_geometry_model
+
+    component = gf.Component()
+    component.add_polygon(
+        [(0, -0.25), (10, -0.25), (10, 0.25), (0, 0.25)],
+        layer=gf.gpdk.LAYER.WG,
+    )
+    component.add_polygon(
+        [(0, -0.25), (10, -0.25), (10, 0.25), (0, 0.25)],
+        layer=gf.gpdk.LAYER.SLAB150,
+    )
+    component.add_port(
+        name="o1",
+        center=(0, 0),
+        orientation=180,
+        width=0.5,
+        layer=gf.gpdk.LAYER.WG,
+    )
+
+    simulation = Simulation()
+    simulation.geometry(component=component, stack=get_stack())
+    simulation.materials = {"si": 12.0, "SiO2": 2.1}
+    simulation.solver(mode="2d", y_cut=0.0)
+    simulation.source_fiber(x=5.0, z=1.0, waist=2.0)
+
+    result = simulation.build_config()
+    entries = {entry.layer_name: entry for entry in result.config.layer_stack}
+    rectangles = extract_xz_rectangles(
+        result.component,
+        result.stack,
+        y_cut=0.0,
+    )
+    rectangle_names = {rectangle.layer_name for rectangle in rectangles}
+    geometry_model = build_geometry_model(
+        result.component,
+        result.stack,
+        result.config.domain,
+        extend_ports_length=0,
+        gdsfactory_stack=result.gdsfactory_stack,
+    )
+
+    assert tuple(entries["shallow_etch"].gds_layer) != tuple(
+        entries["slab150"].gds_layer
+    )
+    assert "shallow_etch" not in rectangle_names
+    assert {"core", "slab150"} <= rectangle_names
+    assert "shallow_etch" not in geometry_model.prisms
+    assert geometry_model.prisms["slab150"]
+
+    output_directory = simulation.write_config(tmp_path / "simulation")
+    serialized = json.loads(
+        (output_directory / "sim_config.json").read_text(encoding="utf-8")
+    )
+    serialized_entries = {
+        entry["layer_name"]: tuple(entry["gds_layer"])
+        for entry in serialized["layer_stack"]
+    }
+    written_component = gf.import_gds(
+        output_directory / "layout.gds",
+        rename_duplicated_cells=True,
+    )
+
+    assert _region(
+        written_component,
+        serialized_entries["shallow_etch"],
+    ).is_empty()
+    assert not _region(
+        written_component,
+        serialized_entries["slab150"],
+    ).is_empty()

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -645,11 +645,12 @@ def _xz_trivial_stack():
 class TestXZBuildConfig:
     """Tests for XZ 2D fields wired through Simulation.build_config()."""
 
-    def test_materializes_active_pdk_derived_layers(self):
-        """Derived physical layers are retained alongside source mask layers."""
+    def test_materializes_derived_layers_without_target_alias(self):
+        """Derived and direct physical levels receive independent GDS tuples."""
         import gdsfactory as gf
 
-        from gsim.meep.simulation import Simulation
+        from gsim.common.stack import get_stack
+        from gsim.meep.physical_layers import materialize_physical_layers
 
         c = gf.Component()
         c.add_polygon(
@@ -661,14 +662,14 @@ class TestXZBuildConfig:
             layer=gf.gpdk.LAYER.SHALLOW_ETCH,
         )
 
-        materialized = Simulation()._component_with_derived_layers(c)
-        pdk_layer_stack = gf.get_active_pdk().layer_stack
-        assert pdk_layer_stack is not None
-        derived_layer = pdk_layer_stack.layers["shallow_etch"].derived_layer
-        assert derived_layer is not None
+        materialized = materialize_physical_layers(c, get_stack())
+        core_layer = materialized.layer_map["core"]
+        shallow_layer = materialized.layer_map["shallow_etch"]
+        slab_layer = materialized.layer_map["slab150"]
 
-        assert tuple(gf.gpdk.LAYER.SHALLOW_ETCH) in materialized.layers
-        assert tuple(derived_layer.layer) in materialized.layers
+        assert len({core_layer, shallow_layer, slab_layer}) == 3
+        assert shallow_layer in materialized.component.layers
+        assert slab_layer not in materialized.component.layers
 
     def test_y_cut_defaults_to_bbox_center(self):
         from gsim.meep.simulation import Simulation


### PR DESCRIPTION
Fix physical-layer collisions when derived and direct GDSFactory LayerLevels share a GDS target, as with GPDK shallow_etch and slab150.

- materialize each physical level onto a deterministic simulation-only GDS tuple after port extension
- carry the matching component and remapped stack through MEEP config generation and previews
- add regressions for absent and real shallow etches, XZ geometry, preview geometry, and written-GDS round trips

Validated with the full non-cloud MEEP suite (426 passed, 1 skipped) and all pre-commit hooks.