### PR TITLE
fix: hide vertices in interactive 2D plots

### DIFF
--- a/src/gsim/common/viz/render2d_interactive.py
+++ b/src/gsim/common/viz/render2d_interactive.py
@@ -267,6 +267,7 @@ def _add_polygon_trace(
         go.Scatter(
             x=xs,
             y=ys,
+            mode="lines",
             fill="toself",
             fillcolor=_rgba(color, alpha),
             line=dict(color="black", width=0.5),
@@ -301,6 +302,7 @@ def _add_rect_trace(
         go.Scatter(
             x=xs,
             y=ys,
+            mode="lines",
             fill="toself",
             fillcolor=fillcolor,
             line=dict(color=line_color, width=0.5),

--- a/tests/meep/test_viz_interactive.py
+++ b/tests/meep/test_viz_interactive.py
@@ -69,6 +69,15 @@ class TestPlot2DInteractive:
         fig = sim.plot_2d_interactive()
         assert len(fig.data) > 0
 
+    def test_filled_shapes_do_not_show_vertex_markers(self):
+        sim = _xz_sim_for_viz()
+
+        fig = sim.plot_2d_interactive()
+
+        filled_shapes = [trace for trace in fig.data if trace.fill == "toself"]
+        assert filled_shapes
+        assert all(trace.mode == "lines" for trace in filled_shapes)
+
     def test_z_slice(self):
         import plotly.graph_objects as go
 


### PR DESCRIPTION
## Summary

- render filled polygon and rectangle traces in line-only mode to hide automatic Plotly vertex markers
- add regression coverage for filled interactive 2D shapes