### PR TITLE
feat: add Meep refractive index plots

### DIFF
--- a/src/gsim/meep/index_overlay.py
+++ b/src/gsim/meep/index_overlay.py
@@ -1,0 +1,310 @@
+"""Simulation annotations drawn over refractive-index maps."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+from matplotlib.patches import Rectangle
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+_PML_EDGE = (0.0, 0.0, 0.0, 1.0)
+_PML_HATCH = "////"
+_SOURCE_COLOR = "red"
+_MONITOR_COLOR = "royalblue"
+_FIBER_ARROW_LENGTH = 0.6
+
+
+def draw_index_overlay(
+    ax: Axes,
+    overlay: Any,
+    slice_axis: str,
+    coordinate: float,
+) -> None:
+    """Draw PML, source, and monitor annotations."""
+    view_min, view_max = _view_bounds(overlay, slice_axis)
+    _draw_pml(ax, view_min, view_max, overlay.dpml)
+
+    labeled: set[str] = set()
+    for source in getattr(overlay, "sources", []):
+        drawn = _draw_port_plane(
+            ax,
+            source,
+            slice_axis,
+            coordinate,
+            color=_SOURCE_COLOR,
+            label="Source" if "Source" not in labeled else None,
+        )
+        if drawn:
+            labeled.add("Source")
+    for monitor in getattr(overlay, "monitors", []):
+        drawn = _draw_port_plane(
+            ax,
+            monitor,
+            slice_axis,
+            coordinate,
+            color=_MONITOR_COLOR,
+            label="Monitor" if "Monitor" not in labeled else None,
+        )
+        if drawn:
+            labeled.add("Monitor")
+    if slice_axis == "y":
+        _draw_fiber_planes(ax, overlay, labeled)
+
+
+def _view_bounds(
+    overlay: Any,
+    slice_axis: str,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return the displayed coordinate bounds for a slice axis."""
+    axes = {"x": (1, 2), "y": (0, 2), "z": (0, 1)}[slice_axis]
+    return (
+        (overlay.cell_min[axes[0]], overlay.cell_min[axes[1]]),
+        (overlay.cell_max[axes[0]], overlay.cell_max[axes[1]]),
+    )
+
+
+def _draw_pml(
+    ax: Axes,
+    view_min: tuple[float, float],
+    view_max: tuple[float, float],
+    thickness: float,
+) -> None:
+    """Draw hatched PML strips around the material view."""
+    width = view_max[0] - view_min[0]
+    height = view_max[1] - view_min[1]
+    _add_pml(ax, view_min[0], view_min[1], thickness, height, label="PML")
+    _add_pml(ax, view_max[0] - thickness, view_min[1], thickness, height)
+    _add_pml(
+        ax,
+        view_min[0] + thickness,
+        view_min[1],
+        width - 2 * thickness,
+        thickness,
+    )
+    _add_pml(
+        ax,
+        view_min[0] + thickness,
+        view_max[1] - thickness,
+        width - 2 * thickness,
+        thickness,
+    )
+
+
+def _add_pml(
+    ax: Axes,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    label: str | None = None,
+) -> None:
+    """Add one unfilled hatched PML rectangle."""
+    if width <= 0 or height <= 0:
+        return
+    patch = Rectangle(
+        (x, y),
+        width,
+        height,
+        facecolor="none",
+        edgecolor=_PML_EDGE,
+        hatch=_PML_HATCH,
+        linewidth=0.0,
+        label=label,
+        zorder=80,
+    )
+    patch.set_hatch_linewidth(0.6)
+    ax.add_patch(patch)
+
+
+def _draw_port_plane(
+    ax: Axes,
+    port: Any,
+    slice_axis: str,
+    coordinate: float,
+    *,
+    color: str,
+    label: str | None,
+) -> bool:
+    """Draw a source or monitor plane when it intersects the slice."""
+    cx, cy, _ = port.center
+    half_width = port.width / 2
+    drawn = False
+    if slice_axis == "z":
+        if port.normal_axis == 0:
+            ax.plot(
+                [cx, cx],
+                [cy - half_width, cy + half_width],
+                color=color,
+                linewidth=2,
+                zorder=95,
+                label=label,
+            )
+        else:
+            ax.plot(
+                [cx - half_width, cx + half_width],
+                [cy, cy],
+                color=color,
+                linewidth=2,
+                zorder=95,
+                label=label,
+            )
+        drawn = True
+    elif slice_axis == "y":
+        drawn = _draw_xz_port_plane(
+            ax,
+            port,
+            coordinate,
+            color=color,
+            label=label,
+        )
+    else:
+        drawn = _draw_yz_port_plane(
+            ax,
+            port,
+            coordinate,
+            color=color,
+            label=label,
+        )
+
+    if drawn:
+        ax.annotate(
+            port.name,
+            _port_label_position(port, slice_axis),
+            fontsize=7,
+            color=color,
+            ha="center",
+            va="bottom",
+            zorder=96,
+        )
+    return drawn
+
+
+def _draw_xz_port_plane(
+    ax: Axes,
+    port: Any,
+    y_slice: float,
+    *,
+    color: str,
+    label: str | None,
+) -> bool:
+    """Draw a port plane on an XZ slice."""
+    cx, cy, cz = port.center
+    half_width = port.width / 2
+    half_z = port.z_span / 2
+    if port.normal_axis == 0 and abs(cy - y_slice) <= half_width + 1e-9:
+        ax.plot(
+            [cx, cx],
+            [cz - half_z, cz + half_z],
+            color=color,
+            linewidth=2,
+            zorder=95,
+            label=label,
+        )
+        return True
+    if port.normal_axis == 1 and abs(cy - y_slice) <= 1e-9:
+        ax.add_patch(
+            Rectangle(
+                (cx - half_width, cz - half_z),
+                port.width,
+                port.z_span,
+                facecolor="none",
+                edgecolor=color,
+                linewidth=1.5,
+                zorder=95,
+                label=label,
+            )
+        )
+        return True
+    return False
+
+
+def _draw_yz_port_plane(
+    ax: Axes,
+    port: Any,
+    x_slice: float,
+    *,
+    color: str,
+    label: str | None,
+) -> bool:
+    """Draw a port plane on a YZ slice."""
+    cx, cy, cz = port.center
+    half_width = port.width / 2
+    half_z = port.z_span / 2
+    if port.normal_axis == 1 and abs(cx - x_slice) <= half_width + 1e-9:
+        ax.plot(
+            [cy, cy],
+            [cz - half_z, cz + half_z],
+            color=color,
+            linewidth=2,
+            zorder=95,
+            label=label,
+        )
+        return True
+    if port.normal_axis == 0 and abs(cx - x_slice) <= 1e-9:
+        ax.add_patch(
+            Rectangle(
+                (cy - half_width, cz - half_z),
+                port.width,
+                port.z_span,
+                facecolor="none",
+                edgecolor=color,
+                linewidth=1.5,
+                zorder=95,
+                label=label,
+            )
+        )
+        return True
+    return False
+
+
+def _port_label_position(port: Any, slice_axis: str) -> tuple[float, float]:
+    """Return the label position for a rendered port plane."""
+    cx, cy, cz = port.center
+    if slice_axis == "z":
+        return cx, cy
+    horizontal = cy if slice_axis == "x" else cx
+    return horizontal, cz + port.z_span / 2
+
+
+def _draw_fiber_planes(ax: Axes, overlay: Any, labeled: set[str]) -> None:
+    """Draw the fiber source plane and its propagation direction."""
+    fiber = getattr(overlay, "fiber", None)
+    if fiber is not None:
+        theta = math.radians(fiber.angle_deg)
+        perpendicular_x = math.cos(theta)
+        perpendicular_z = math.sin(theta)
+        half_span = fiber.waist
+        ax.plot(
+            [
+                fiber.x - perpendicular_x * half_span,
+                fiber.x + perpendicular_x * half_span,
+            ],
+            [
+                fiber.z - perpendicular_z * half_span,
+                fiber.z + perpendicular_z * half_span,
+            ],
+            color=_SOURCE_COLOR,
+            linewidth=2,
+            zorder=95,
+            label="Source" if "Source" not in labeled else None,
+        )
+        direction_x = math.sin(theta)
+        direction_z = -math.cos(theta)
+        head_x = fiber.x + direction_x * _FIBER_ARROW_LENGTH
+        head_z = fiber.z + direction_z * _FIBER_ARROW_LENGTH
+        ax.annotate(
+            "",
+            xy=(head_x, head_z),
+            xytext=(fiber.x, fiber.z),
+            arrowprops={
+                "arrowstyle": "->",
+                "color": _SOURCE_COLOR,
+                "lw": 1.5,
+                "mutation_scale": 8,
+            },
+            zorder=96,
+        )
+        labeled.add("Source")

--- a/src/gsim/meep/index_overlay_interactive.py
+++ b/src/gsim/meep/index_overlay_interactive.py
@@ -1,0 +1,307 @@
+"""Plotly annotations for interactive refractive-index maps."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+_SOURCE_COLOR = "red"
+_MONITOR_COLOR = "royalblue"
+_FIBER_ARROW_LENGTH = 0.6
+
+
+def draw_index_overlay_interactive(
+    figure: Any,
+    overlay: Any,
+    slice_axis: str,
+    coordinate: float,
+) -> None:
+    """Draw hatched PML, source, and monitor annotations."""
+    view_min, view_max = _view_bounds(overlay, slice_axis)
+    _add_pml_regions(figure, view_min, view_max, overlay.dpml)
+
+    labeled: set[str] = set()
+    for source in overlay.sources:
+        if _add_port_plane(
+            figure,
+            source,
+            slice_axis,
+            coordinate,
+            color=_SOURCE_COLOR,
+            legend_name="Source",
+            show_legend="Source" not in labeled,
+        ):
+            labeled.add("Source")
+    for monitor in overlay.monitors:
+        if _add_port_plane(
+            figure,
+            monitor,
+            slice_axis,
+            coordinate,
+            color=_MONITOR_COLOR,
+            legend_name="Monitor",
+            show_legend="Monitor" not in labeled,
+        ):
+            labeled.add("Monitor")
+    if slice_axis == "y" and overlay.fiber is not None:
+        _add_fiber_source(
+            figure,
+            overlay.fiber,
+            show_legend="Source" not in labeled,
+        )
+
+
+def _view_bounds(
+    overlay: Any,
+    slice_axis: str,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return the displayed coordinate bounds for a slice axis."""
+    axes = {"x": (1, 2), "y": (0, 2), "z": (0, 1)}[slice_axis]
+    return (
+        (overlay.cell_min[axes[0]], overlay.cell_min[axes[1]]),
+        (overlay.cell_max[axes[0]], overlay.cell_max[axes[1]]),
+    )
+
+
+def _add_pml_regions(
+    figure: Any,
+    view_min: tuple[float, float],
+    view_max: tuple[float, float],
+    thickness: float,
+) -> None:
+    """Add hatched PML strips around the material view."""
+    width = view_max[0] - view_min[0]
+    height = view_max[1] - view_min[1]
+    regions = [
+        (view_min[0], view_min[1], thickness, height),
+        (view_max[0] - thickness, view_min[1], thickness, height),
+        (view_min[0] + thickness, view_min[1], width - 2 * thickness, thickness),
+        (
+            view_min[0] + thickness,
+            view_max[1] - thickness,
+            width - 2 * thickness,
+            thickness,
+        ),
+    ]
+    show_legend = True
+    for x, y, region_width, region_height in regions:
+        if region_width <= 0 or region_height <= 0:
+            continue
+        _add_pml_rectangle(
+            figure,
+            x,
+            y,
+            region_width,
+            region_height,
+            show_legend=show_legend,
+        )
+        show_legend = False
+
+
+def _add_pml_rectangle(
+    figure: Any,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    *,
+    show_legend: bool,
+) -> None:
+    """Add one transparent hatched PML rectangle."""
+    import plotly.graph_objects as go
+
+    figure.add_trace(
+        go.Scatter(
+            x=[x, x + width, x + width, x, x],
+            y=[y, y, y + height, y + height, y],
+            mode="lines",
+            fill="toself",
+            fillcolor="rgba(0,0,0,0)",
+            fillpattern={
+                "shape": "/",
+                "fgcolor": "black",
+                "bgcolor": "rgba(0,0,0,0)",
+                "size": 10,
+                "solidity": 0.05,
+            },
+            line={"color": "rgba(0,0,0,0)", "width": 0},
+            name="PML",
+            legendgroup="PML",
+            showlegend=show_legend,
+            hoverinfo="text",
+            hovertext="PML",
+        )
+    )
+
+
+def _add_port_plane(
+    figure: Any,
+    port: Any,
+    slice_axis: str,
+    coordinate: float,
+    *,
+    color: str,
+    legend_name: str,
+    show_legend: bool,
+) -> bool:
+    """Add a source or monitor plane when it intersects the slice."""
+    cx, cy, _ = port.center
+    half_width = port.width / 2
+    if slice_axis == "z":
+        if port.normal_axis == 0:
+            points = ([cx, cx], [cy - half_width, cy + half_width])
+        else:
+            points = ([cx - half_width, cx + half_width], [cy, cy])
+    elif slice_axis == "y":
+        points = _xz_port_points(port, coordinate)
+    else:
+        points = _yz_port_points(port, coordinate)
+    if points is None:
+        return False
+
+    _add_plane_trace(
+        figure,
+        points[0],
+        points[1],
+        port.name,
+        color=color,
+        legend_name=legend_name,
+        show_legend=show_legend,
+    )
+    return True
+
+
+def _xz_port_points(
+    port: Any,
+    y_slice: float,
+) -> tuple[list[float], list[float]] | None:
+    """Return endpoints for a port plane on an XZ slice."""
+    cx, cy, cz = port.center
+    half_width = port.width / 2
+    half_z = port.z_span / 2
+    if port.normal_axis == 0 and abs(cy - y_slice) <= half_width + 1e-9:
+        return [cx, cx], [cz - half_z, cz + half_z]
+    if port.normal_axis == 1 and abs(cy - y_slice) <= 1e-9:
+        return (
+            [
+                cx - half_width,
+                cx + half_width,
+                cx + half_width,
+                cx - half_width,
+                cx - half_width,
+            ],
+            [cz - half_z, cz - half_z, cz + half_z, cz + half_z, cz - half_z],
+        )
+    return None
+
+
+def _yz_port_points(
+    port: Any,
+    x_slice: float,
+) -> tuple[list[float], list[float]] | None:
+    """Return endpoints for a port plane on a YZ slice."""
+    cx, cy, cz = port.center
+    half_width = port.width / 2
+    half_z = port.z_span / 2
+    if port.normal_axis == 1 and abs(cx - x_slice) <= half_width + 1e-9:
+        return [cy, cy], [cz - half_z, cz + half_z]
+    if port.normal_axis == 0 and abs(cx - x_slice) <= 1e-9:
+        return (
+            [
+                cy - half_width,
+                cy + half_width,
+                cy + half_width,
+                cy - half_width,
+                cy - half_width,
+            ],
+            [cz - half_z, cz - half_z, cz + half_z, cz + half_z, cz - half_z],
+        )
+    return None
+
+
+def _add_plane_trace(
+    figure: Any,
+    horizontal: list[float],
+    vertical: list[float],
+    annotation: str,
+    *,
+    color: str,
+    legend_name: str,
+    show_legend: bool,
+) -> None:
+    """Add a Plotly line trace for a source or monitor plane."""
+    import plotly.graph_objects as go
+
+    text = [""] * len(horizontal)
+    text[len(text) // 2] = annotation
+    figure.add_trace(
+        go.Scatter(
+            x=horizontal,
+            y=vertical,
+            mode="lines+text",
+            line={"color": color, "width": 2},
+            name=legend_name,
+            legendgroup=legend_name,
+            showlegend=show_legend,
+            text=text,
+            textposition="top center",
+            textfont={"size": 9, "color": color},
+            hoverinfo="text",
+            hovertext=f"{annotation} ({legend_name})",
+        )
+    )
+
+
+def _add_fiber_source(
+    figure: Any,
+    fiber: Any,
+    *,
+    show_legend: bool,
+) -> None:
+    """Add the fiber source plane and propagation arrow."""
+    import plotly.graph_objects as go
+
+    theta = math.radians(fiber.angle_deg)
+    perpendicular_x = math.cos(theta)
+    perpendicular_z = math.sin(theta)
+    half_span = fiber.waist
+    figure.add_trace(
+        go.Scatter(
+            x=[
+                fiber.x - perpendicular_x * half_span,
+                fiber.x + perpendicular_x * half_span,
+            ],
+            y=[
+                fiber.z - perpendicular_z * half_span,
+                fiber.z + perpendicular_z * half_span,
+            ],
+            mode="lines+text",
+            line={"color": _SOURCE_COLOR, "width": 2},
+            name="Source",
+            legendgroup="Source",
+            showlegend=show_legend,
+            text=["", "fiber"],
+            textposition="top center",
+            textfont={"size": 9, "color": _SOURCE_COLOR},
+            hoverinfo="text",
+            hovertext="fiber source",
+        )
+    )
+    direction_x = math.sin(theta)
+    direction_z = -math.cos(theta)
+    head_x = fiber.x + direction_x * _FIBER_ARROW_LENGTH
+    head_z = fiber.z + direction_z * _FIBER_ARROW_LENGTH
+    figure.add_annotation(
+        x=head_x,
+        y=head_z,
+        ax=fiber.x,
+        ay=fiber.z,
+        xref="x",
+        yref="y",
+        axref="x",
+        ayref="y",
+        showarrow=True,
+        arrowhead=2,
+        arrowsize=1,
+        arrowcolor=_SOURCE_COLOR,
+    )

--- a/src/gsim/meep/index_viz.py
+++ b/src/gsim/meep/index_viz.py
@@ -1,0 +1,453 @@
+"""Refractive-index maps for MEEP simulation previews."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.cm import ScalarMappable
+from matplotlib.colors import ListedColormap, Normalize
+from matplotlib.patches import Polygon, Rectangle
+
+from gsim.common.geometry_model import GeometryModel, Prism
+from gsim.meep.index_overlay import draw_index_overlay
+from gsim.meep.models.config import MaterialData
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+IndexComponent = Literal["mean", "x", "y", "z"]
+
+_AIR_INDEX = 1.0
+
+
+def material_refractive_indices(
+    material_data: Mapping[str, MaterialData],
+    component: IndexComponent = "mean",
+) -> dict[str, float]:
+    """Convert resolved material permittivity to scalar refractive indices.
+
+    ``component="mean"`` uses ``sqrt(mean(epsilon_diag))``. Axis-specific
+    values use the corresponding diagonal tensor component.
+    """
+    if component not in {"mean", "x", "y", "z"}:
+        raise ValueError(
+            f"index_component must be 'mean', 'x', 'y', or 'z'. Got: {component!r}"
+        )
+
+    component_index = {"x": 0, "y": 1, "z": 2}
+    indices: dict[str, float] = {}
+    for material_name, data in material_data.items():
+        if data.epsilon_diag is None:
+            continue
+        epsilon_values = [float(value) for value in data.epsilon_diag]
+        if not epsilon_values:
+            continue
+        if component == "mean":
+            epsilon = float(np.mean(epsilon_values))
+        else:
+            axis_index = component_index[component]
+            if axis_index >= len(epsilon_values):
+                raise ValueError(
+                    f"Material {material_name!r} has no epsilon {component}-component"
+                )
+            epsilon = epsilon_values[axis_index]
+        if epsilon <= 0 or not math.isfinite(epsilon):
+            raise ValueError(
+                f"Material {material_name!r} has non-positive or non-finite "
+                f"permittivity for index component {component!r}: {epsilon}"
+            )
+        indices[material_name] = math.sqrt(epsilon)
+    return indices
+
+
+def plot_refractive_index_slices(
+    geometry_model: GeometryModel,
+    material_data: Mapping[str, MaterialData],
+    *,
+    wavelength: float,
+    overlay: Any | None,
+    layer_order: Sequence[str] | None = None,
+    is_3d: bool = True,
+    plane: Literal["xy", "xz"] = "xy",
+    index_component: IndexComponent = "mean",
+    cmap: str = "Blues",
+    x: float | str | None = None,
+    y: float | str | None = None,
+    z: float | str = "core",
+    ax: Axes | None = None,
+    legend: bool = True,
+    slices: str = "z",
+    aspect: Literal["equal", "auto"] = "equal",
+) -> Axes | None:
+    """Plot ideal material-index cross-sections with simulation overlays."""
+    if aspect not in {"equal", "auto"}:
+        raise ValueError(f"aspect must be 'equal' or 'auto'. Got: {aspect!r}")
+
+    slices_to_plot = sorted(set(slices.lower()))
+    if not slices_to_plot or not all(axis in "xyz" for axis in slices_to_plot):
+        raise ValueError(f"slices must only contain 'x', 'y', 'z'. Got: {slices}")
+    if ax is not None and len(slices_to_plot) > 1:
+        raise ValueError("Cannot plot multiple slices when ax is provided")
+
+    indices = material_refractive_indices(material_data, index_component)
+    norm = index_normalization(indices)
+    colormap = air_white_colormap(cmap)
+    scalar_mappable = ScalarMappable(norm=norm, cmap=colormap)
+    ordered_layers = list(layer_order or geometry_model.layer_names)
+
+    if ax is not None:
+        _plot_single_index_slice(
+            ax,
+            geometry_model,
+            slices_to_plot[0],
+            x=x,
+            y=y,
+            z=z,
+            indices=indices,
+            norm=norm,
+            cmap=colormap,
+            overlay=overlay,
+            layer_order=ordered_layers,
+            include_dielectrics=is_3d or plane == "xz",
+            aspect=aspect,
+            legend=legend,
+        )
+        ax.figure.colorbar(
+            scalar_mappable,
+            ax=ax,
+            label=index_colorbar_label(index_component, wavelength),
+        )
+        return ax
+
+    figure, axes_array = plt.subplots(
+        len(slices_to_plot),
+        1,
+        constrained_layout=True,
+        squeeze=False,
+    )
+    axes = list(axes_array[:, 0])
+    for plot_axis, slice_axis in zip(axes, slices_to_plot, strict=True):
+        _plot_single_index_slice(
+            plot_axis,
+            geometry_model,
+            slice_axis,
+            x=x,
+            y=y,
+            z=z,
+            indices=indices,
+            norm=norm,
+            cmap=colormap,
+            overlay=overlay,
+            layer_order=ordered_layers,
+            include_dielectrics=is_3d or plane == "xz",
+            aspect=aspect,
+            legend=legend,
+        )
+    figure.colorbar(
+        scalar_mappable,
+        ax=axes,
+        label=index_colorbar_label(index_component, wavelength),
+    )
+    plt.show()
+    return None
+
+
+def index_normalization(indices: Mapping[str, float]) -> Normalize:
+    """Create shared normalization including air at n=1."""
+    values = [_AIR_INDEX, *indices.values()]
+    minimum = min(values)
+    maximum = max(values)
+    if math.isclose(minimum, maximum):
+        padding = max(0.05 * minimum, 0.05)
+        minimum -= padding
+        maximum += padding
+    return Normalize(vmin=minimum, vmax=maximum)
+
+
+def air_white_colormap(name: str) -> ListedColormap:
+    """Reserve the minimum colormap value for pure-white air."""
+    base_colormap = plt.colormaps.get_cmap(name).resampled(256)
+    colors = base_colormap(np.linspace(0.0, 1.0, 256))
+    colors[0] = (1.0, 1.0, 1.0, 1.0)
+    return ListedColormap(colors, name=f"air_white_{base_colormap.name}")
+
+
+def index_colorbar_label(component: IndexComponent, wavelength: float) -> str:
+    """Build the refractive-index colorbar label."""
+    suffix = "" if component == "mean" else f"_{component}"
+    return f"Refractive index n{suffix} at \u03bb={wavelength:g} µm"
+
+
+def _plot_single_index_slice(
+    ax: Axes,
+    geometry_model: GeometryModel,
+    slice_axis: str,
+    *,
+    x: float | str | None,
+    y: float | str | None,
+    z: float | str,
+    indices: Mapping[str, float],
+    norm: Normalize,
+    cmap: Any,
+    overlay: Any | None,
+    layer_order: Sequence[str],
+    include_dielectrics: bool,
+    aspect: Literal["equal", "auto"],
+    legend: bool,
+) -> None:
+    """Render one refractive-index slice on an axes."""
+    coordinate = resolve_slice_coordinate(geometry_model, slice_axis, x=x, y=y, z=z)
+    view_min, view_max = view_bounds(geometry_model, overlay, slice_axis)
+    _add_material_rectangle(
+        ax,
+        view_min[0],
+        view_min[1],
+        view_max[0] - view_min[0],
+        view_max[1] - view_min[1],
+        material="air",
+        refractive_index=_AIR_INDEX,
+        norm=norm,
+        cmap=cmap,
+        zorder=-20,
+    )
+    if include_dielectrics and overlay is not None:
+        _draw_dielectrics(
+            ax,
+            overlay,
+            slice_axis,
+            coordinate,
+            indices,
+            norm,
+            cmap,
+        )
+    _draw_prisms(
+        ax,
+        geometry_model,
+        slice_axis,
+        coordinate,
+        layer_order,
+        indices,
+        norm,
+        cmap,
+    )
+    if overlay is not None:
+        draw_index_overlay(ax, overlay, slice_axis, coordinate)
+
+    labels = {
+        "x": ("y (um)", "z (um)", "YZ", "x"),
+        "y": ("x (um)", "z (um)", "XZ", "y"),
+        "z": ("x (um)", "y (um)", "XY", "z"),
+    }
+    xlabel, ylabel, plane_name, coordinate_name = labels[slice_axis]
+    ax.set(
+        xlim=(view_min[0], view_max[0]),
+        ylim=(view_min[1], view_max[1]),
+        xlabel=xlabel,
+        ylabel=ylabel,
+        title=(
+            f"Refractive index · {plane_name} cross section at "
+            f"{coordinate_name}={coordinate:.2f}"
+        ),
+    )
+    ax.set_aspect(aspect)
+    if legend:
+        handles, labels_found = ax.get_legend_handles_labels()
+        unique = dict(zip(labels_found, handles, strict=False))
+        if unique:
+            ax.legend(unique.values(), unique.keys(), fancybox=True, framealpha=1.0)
+
+
+def resolve_slice_coordinate(
+    geometry_model: GeometryModel,
+    slice_axis: str,
+    *,
+    x: float | str | None,
+    y: float | str | None,
+    z: float | str,
+) -> float:
+    """Resolve a numeric or named slice coordinate."""
+    requested = {"x": x, "y": y, "z": z}[slice_axis]
+    if requested is None:
+        requested = "core"
+    if isinstance(requested, str):
+        axis_index = {"x": 0, "y": 1, "z": 2}[slice_axis]
+        return float(geometry_model.get_layer_center(requested)[axis_index])
+    return float(requested)
+
+
+def view_bounds(
+    geometry_model: GeometryModel,
+    overlay: Any | None,
+    slice_axis: str,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return the two-dimensional plot bounds for a slice."""
+    cell_min = overlay.cell_min if overlay is not None else geometry_model.bbox[0]
+    cell_max = overlay.cell_max if overlay is not None else geometry_model.bbox[1]
+    axes = {"x": (1, 2), "y": (0, 2), "z": (0, 1)}[slice_axis]
+    return (
+        (cell_min[axes[0]], cell_min[axes[1]]),
+        (cell_max[axes[0]], cell_max[axes[1]]),
+    )
+
+
+def _material_index(material: str, indices: Mapping[str, float]) -> float:
+    """Return a material index, falling back to air."""
+    return indices.get(material, _AIR_INDEX)
+
+
+def _add_material_rectangle(
+    ax: Axes,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    *,
+    material: str,
+    refractive_index: float,
+    norm: Normalize,
+    cmap: Any,
+    zorder: float,
+) -> None:
+    """Add a material-colored rectangle to an axes."""
+    if width <= 0 or height <= 0:
+        return
+    patch = Rectangle(
+        (x, y),
+        width,
+        height,
+        facecolor=cmap(norm(refractive_index)),
+        edgecolor="none",
+        zorder=zorder,
+    )
+    patch.set_gid(f"material:{material}")
+    ax.add_patch(patch)
+
+
+def _draw_dielectrics(
+    ax: Axes,
+    overlay: Any,
+    slice_axis: str,
+    coordinate: float,
+    indices: Mapping[str, float],
+    norm: Normalize,
+    cmap: Any,
+) -> None:
+    """Draw background dielectric slabs that intersect the slice."""
+    dielectrics = sorted(overlay.dielectrics, key=lambda dielectric: dielectric.zmin)
+    for order, dielectric in enumerate(dielectrics):
+        refractive_index = indices.get(dielectric.material)
+        if refractive_index is None:
+            continue
+        if slice_axis == "z":
+            if not dielectric.zmin <= coordinate <= dielectric.zmax:
+                continue
+            x0, y0 = overlay.cell_min[0], overlay.cell_min[1]
+            width = overlay.cell_max[0] - x0
+            height = overlay.cell_max[1] - y0
+        else:
+            horizontal_axis = 1 if slice_axis == "x" else 0
+            x0, y0 = overlay.cell_min[horizontal_axis], dielectric.zmin
+            width = overlay.cell_max[horizontal_axis] - x0
+            height = dielectric.zmax - dielectric.zmin
+        _add_material_rectangle(
+            ax,
+            x0,
+            y0,
+            width,
+            height,
+            material=dielectric.material,
+            refractive_index=refractive_index,
+            norm=norm,
+            cmap=cmap,
+            zorder=-10 + order * 0.01,
+        )
+
+
+def _draw_prisms(
+    ax: Axes,
+    geometry_model: GeometryModel,
+    slice_axis: str,
+    coordinate: float,
+    layer_order: Sequence[str],
+    indices: Mapping[str, float],
+    norm: Normalize,
+    cmap: Any,
+) -> None:
+    """Draw geometry prisms that intersect the slice."""
+    for layer_index, layer_name in enumerate(layer_order):
+        for prism in geometry_model.prisms.get(layer_name, []):
+            refractive_index = _material_index(prism.material, indices)
+            color = cmap(norm(refractive_index))
+            zorder = 10 + layer_index
+            if slice_axis == "z":
+                if prism.z_base <= coordinate <= prism.z_top:
+                    patch = Polygon(
+                        prism.vertices,
+                        closed=True,
+                        facecolor=color,
+                        edgecolor="none",
+                        zorder=zorder,
+                    )
+                    patch.set_gid(f"material:{prism.material or 'air'}")
+                    ax.add_patch(patch)
+                continue
+            for low, high in prism_intervals(prism, slice_axis, coordinate):
+                _add_material_rectangle(
+                    ax,
+                    low,
+                    prism.z_base,
+                    high - low,
+                    prism.z_top - prism.z_base,
+                    material=prism.material or "air",
+                    refractive_index=refractive_index,
+                    norm=norm,
+                    cmap=cmap,
+                    zorder=zorder,
+                )
+
+
+def prism_intervals(
+    prism: Prism,
+    slice_axis: str,
+    coordinate: float,
+) -> list[tuple[float, float]]:
+    """Intersect a prism with an x- or y-normal slice line."""
+    from shapely.geometry import (  # type: ignore[import-untyped]
+        LineString,
+        MultiLineString,
+    )
+    from shapely.geometry import (
+        Polygon as ShapelyPolygon,
+    )
+
+    polygon = ShapelyPolygon(prism.vertices)
+    if polygon.is_empty or not polygon.is_valid:
+        return []
+    xmin, ymin, xmax, ymax = polygon.bounds
+    if slice_axis == "x":
+        line = LineString([(coordinate, ymin - 1.0), (coordinate, ymax + 1.0)])
+        coordinate_index = 1
+    else:
+        line = LineString([(xmin - 1.0, coordinate), (xmax + 1.0, coordinate)])
+        coordinate_index = 0
+    intersection = polygon.intersection(line)
+    if isinstance(intersection, LineString):
+        segments = [intersection]
+    elif isinstance(intersection, MultiLineString):
+        segments = list(intersection.geoms)
+    else:
+        segments = [
+            geometry
+            for geometry in getattr(intersection, "geoms", [])
+            if isinstance(geometry, LineString)
+        ]
+    intervals = []
+    for segment in segments:
+        values = [point[coordinate_index] for point in segment.coords]
+        if values and max(values) - min(values) > 1e-9:
+            intervals.append((min(values), max(values)))
+    return intervals

--- a/src/gsim/meep/index_viz_interactive.py
+++ b/src/gsim/meep/index_viz_interactive.py
@@ -1,0 +1,334 @@
+"""Interactive Plotly refractive-index maps for MEEP previews."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+import numpy as np
+from matplotlib.colors import to_hex
+
+from gsim.common.geometry_model import GeometryModel
+from gsim.meep.index_overlay_interactive import draw_index_overlay_interactive
+from gsim.meep.index_viz import (
+    IndexComponent,
+    air_white_colormap,
+    index_colorbar_label,
+    index_normalization,
+    material_refractive_indices,
+    prism_intervals,
+    resolve_slice_coordinate,
+    view_bounds,
+)
+from gsim.meep.models.config import MaterialData
+
+_AIR_INDEX = 1.0
+
+
+def plot_refractive_index_interactive(
+    geometry_model: GeometryModel,
+    material_data: Mapping[str, MaterialData],
+    *,
+    wavelength: float,
+    overlay: Any | None,
+    slice_axis: Literal["x", "y", "z"],
+    layer_order: Sequence[str] | None = None,
+    is_3d: bool = True,
+    plane: Literal["xy", "xz"] = "xy",
+    index_component: IndexComponent = "mean",
+    cmap: str = "Blues",
+    x: float | str | None = None,
+    y: float | str | None = None,
+    z: float | str = "core",
+    aspect: Literal["equal", "auto"] = "equal",
+) -> Any:
+    """Create an interactive refractive-index cross-section."""
+    import plotly.graph_objects as go
+
+    if aspect not in {"equal", "auto"}:
+        raise ValueError(f"aspect must be 'equal' or 'auto'. Got: {aspect!r}")
+
+    coordinate = resolve_slice_coordinate(
+        geometry_model,
+        slice_axis,
+        x=x,
+        y=y,
+        z=z,
+    )
+    indices = material_refractive_indices(material_data, index_component)
+    normalization = index_normalization(indices)
+    colormap = air_white_colormap(cmap)
+    plot_min, plot_max = view_bounds(geometry_model, overlay, slice_axis)
+    figure = go.Figure()
+
+    _add_material_rectangle(
+        figure,
+        plot_min[0],
+        plot_min[1],
+        plot_max[0] - plot_min[0],
+        plot_max[1] - plot_min[1],
+        material="air",
+        refractive_index=_AIR_INDEX,
+        normalization=normalization,
+        colormap=colormap,
+    )
+    if (is_3d or plane == "xz") and overlay is not None:
+        _add_dielectrics(
+            figure,
+            overlay,
+            slice_axis,
+            coordinate,
+            indices,
+            normalization,
+            colormap,
+        )
+    _add_prisms(
+        figure,
+        geometry_model,
+        slice_axis,
+        coordinate,
+        list(layer_order or geometry_model.layer_names),
+        indices,
+        normalization,
+        colormap,
+    )
+    if overlay is not None:
+        draw_index_overlay_interactive(figure, overlay, slice_axis, coordinate)
+
+    _add_colorbar(
+        figure,
+        normalization,
+        colormap,
+        index_colorbar_label(index_component, wavelength),
+    )
+    _configure_layout(
+        figure,
+        slice_axis,
+        coordinate,
+        plot_min,
+        plot_max,
+        aspect,
+    )
+    return figure
+
+
+def _color(refractive_index: float, normalization: Any, colormap: Any) -> str:
+    """Map a refractive index to a hexadecimal color."""
+    return to_hex(colormap(normalization(refractive_index)), keep_alpha=False)
+
+
+def _add_material_rectangle(
+    figure: Any,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+    *,
+    material: str,
+    refractive_index: float,
+    normalization: Any,
+    colormap: Any,
+) -> None:
+    """Add a material-colored rectangle to a Plotly figure."""
+    if width <= 0 or height <= 0:
+        return
+    _add_filled_trace(
+        figure,
+        [x, x + width, x + width, x, x],
+        [y, y, y + height, y + height, y],
+        material=material,
+        refractive_index=refractive_index,
+        fillcolor=_color(refractive_index, normalization, colormap),
+    )
+
+
+def _add_filled_trace(
+    figure: Any,
+    horizontal: list[float],
+    vertical: list[float],
+    *,
+    material: str,
+    refractive_index: float,
+    fillcolor: str,
+) -> None:
+    """Add a filled material polygon with hover metadata."""
+    import plotly.graph_objects as go
+
+    figure.add_trace(
+        go.Scatter(
+            x=horizontal,
+            y=vertical,
+            mode="lines",
+            fill="toself",
+            fillcolor=fillcolor,
+            line={"color": "rgba(0,0,0,0)", "width": 0},
+            showlegend=False,
+            name=material,
+            legendgroup=f"material:{material}",
+            hovertemplate=(f"{material}<br>n={refractive_index:.4g}<extra></extra>"),
+        )
+    )
+
+
+def _add_dielectrics(
+    figure: Any,
+    overlay: Any,
+    slice_axis: str,
+    coordinate: float,
+    indices: Mapping[str, float],
+    normalization: Any,
+    colormap: Any,
+) -> None:
+    """Add background dielectric slabs that intersect the slice."""
+    dielectrics = sorted(overlay.dielectrics, key=lambda dielectric: dielectric.zmin)
+    for dielectric in dielectrics:
+        refractive_index = indices.get(dielectric.material)
+        if refractive_index is None:
+            continue
+        if slice_axis == "z":
+            if not dielectric.zmin <= coordinate <= dielectric.zmax:
+                continue
+            x, y = overlay.cell_min[0], overlay.cell_min[1]
+            width = overlay.cell_max[0] - x
+            height = overlay.cell_max[1] - y
+        else:
+            horizontal_axis = 1 if slice_axis == "x" else 0
+            x, y = overlay.cell_min[horizontal_axis], dielectric.zmin
+            width = overlay.cell_max[horizontal_axis] - x
+            height = dielectric.zmax - dielectric.zmin
+        _add_material_rectangle(
+            figure,
+            x,
+            y,
+            width,
+            height,
+            material=dielectric.material,
+            refractive_index=refractive_index,
+            normalization=normalization,
+            colormap=colormap,
+        )
+
+
+def _add_prisms(
+    figure: Any,
+    geometry_model: GeometryModel,
+    slice_axis: str,
+    coordinate: float,
+    layer_order: Sequence[str],
+    indices: Mapping[str, float],
+    normalization: Any,
+    colormap: Any,
+) -> None:
+    """Add geometry prisms that intersect the slice."""
+    for layer_name in layer_order:
+        for prism in geometry_model.prisms.get(layer_name, []):
+            refractive_index = indices.get(prism.material, _AIR_INDEX)
+            fillcolor = _color(refractive_index, normalization, colormap)
+            material = prism.material or "air"
+            if slice_axis == "z":
+                if not prism.z_base <= coordinate <= prism.z_top:
+                    continue
+                vertices = prism.vertices.tolist()
+                _add_filled_trace(
+                    figure,
+                    [float(vertex[0]) for vertex in vertices] + [float(vertices[0][0])],
+                    [float(vertex[1]) for vertex in vertices] + [float(vertices[0][1])],
+                    material=material,
+                    refractive_index=refractive_index,
+                    fillcolor=fillcolor,
+                )
+                continue
+            for low, high in prism_intervals(prism, slice_axis, coordinate):
+                _add_material_rectangle(
+                    figure,
+                    low,
+                    prism.z_base,
+                    high - low,
+                    prism.z_top - prism.z_base,
+                    material=material,
+                    refractive_index=refractive_index,
+                    normalization=normalization,
+                    colormap=colormap,
+                )
+
+
+def _plotly_colorscale(colormap: Any) -> list[list[Any]]:
+    """Sample a Matplotlib colormap into a Plotly colorscale."""
+    return [
+        [fraction, to_hex(colormap(fraction), keep_alpha=False)]
+        for fraction in np.linspace(0.0, 1.0, 33)
+    ]
+
+
+def _add_colorbar(
+    figure: Any,
+    normalization: Any,
+    colormap: Any,
+    title: str,
+) -> None:
+    """Add the continuous refractive-index colorbar."""
+    import plotly.graph_objects as go
+
+    figure.add_trace(
+        go.Scatter(
+            x=[None],
+            y=[None],
+            mode="markers",
+            marker={
+                "color": [normalization.vmin],
+                "cmin": normalization.vmin,
+                "cmax": normalization.vmax,
+                "colorscale": _plotly_colorscale(colormap),
+                "showscale": True,
+                "colorbar": {"title": title},
+            },
+            showlegend=False,
+            hoverinfo="skip",
+        )
+    )
+
+
+def _configure_layout(
+    figure: Any,
+    slice_axis: str,
+    coordinate: float,
+    plot_min: tuple[float, float],
+    plot_max: tuple[float, float],
+    aspect: Literal["equal", "auto"],
+) -> None:
+    """Configure axes, title, legend, and aspect ratio."""
+    labels = {
+        "x": ("y (um)", "z (um)", "YZ", "x"),
+        "y": ("x (um)", "z (um)", "XZ", "y"),
+        "z": ("x (um)", "y (um)", "XY", "z"),
+    }
+    xlabel, ylabel, plane_name, coordinate_name = labels[slice_axis]
+    xaxis: dict[str, Any] = {
+        "title": xlabel,
+        "range": [plot_min[0], plot_max[0]],
+        "showgrid": False,
+        "zeroline": False,
+    }
+    yaxis: dict[str, Any] = {
+        "title": ylabel,
+        "range": [plot_min[1], plot_max[1]],
+        "showgrid": False,
+        "zeroline": False,
+    }
+    if aspect == "equal":
+        xaxis.update({"scaleanchor": "y", "scaleratio": 1})
+        yaxis["constrain"] = "domain"
+    figure.update_layout(
+        title=(
+            f"Refractive index · {plane_name} cross section at "
+            f"{coordinate_name}={coordinate:.2f}"
+        ),
+        xaxis=xaxis,
+        yaxis=yaxis,
+        legend={
+            "title": "Simulation",
+            "itemclick": "toggle",
+            "itemdoubleclick": "toggleothers",
+        },
+        hovermode="closest",
+    )

--- a/src/gsim/meep/overlay.py
+++ b/src/gsim/meep/overlay.py
@@ -17,12 +17,12 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class PortOverlay:
-    """Port location metadata for 2D overlay rendering.
+    """Waveguide-plane metadata for 2D overlay rendering.
 
     Attributes:
         name: Port name (e.g. "o1").
-        center: (x, y, z) center of the port monitor.
-        width: Transverse width of the port monitor in um.
+        center: (x, y, z) center of the source or monitor plane.
+        width: Transverse width of the plane in um.
         normal_axis: 0 for x-normal, 1 for y-normal.
         direction: "+" or "-" along the normal axis.
         is_source: Whether this port is the excitation source.
@@ -82,7 +82,9 @@ class SimOverlay:
         cell_min: (xmin, ymin, zmin) of the full simulation cell.
         cell_max: (xmax, ymax, zmax) of the full simulation cell.
         dpml: PML absorber thickness in um.
-        ports: List of port overlays for rendering.
+        ports: Legacy port-center overlays for the layer view.
+        sources: Source planes at the positions used by the runner.
+        monitors: Monitor planes at the positions used by the runner.
         dielectrics: List of background dielectric slabs for rendering.
         fiber: Optional Gaussian-beam fiber source overlay (XZ 2D only).
     """
@@ -91,8 +93,33 @@ class SimOverlay:
     cell_max: tuple[float, float, float]
     dpml: float
     ports: list[PortOverlay] = field(default_factory=list)
+    sources: list[PortOverlay] = field(default_factory=list)
+    monitors: list[PortOverlay] = field(default_factory=list)
     dielectrics: list[DielectricOverlay] = field(default_factory=list)
     fiber: FiberOverlay | None = None
+
+
+def _shifted_port_overlay(
+    port: PortData,
+    *,
+    offset: float,
+    width: float,
+    z_span: float,
+    is_source: bool,
+) -> PortOverlay:
+    """Create a source/monitor overlay shifted into the device."""
+    center = [float(value) for value in port.center]
+    direction_sign = 1.0 if port.direction == "+" else -1.0
+    center[port.normal_axis] += direction_sign * offset
+    return PortOverlay(
+        name=port.name,
+        center=(center[0], center[1], center[2]),
+        width=width,
+        normal_axis=port.normal_axis,
+        direction=port.direction,
+        is_source=is_source,
+        z_span=z_span,
+    )
 
 
 def build_sim_overlay(
@@ -172,6 +199,33 @@ def build_sim_overlay(
         for p in port_data
     ]
 
+    sources = [
+        _shifted_port_overlay(
+            port,
+            offset=domain_config.source_port_offset,
+            width=port.width + 2 * port_margin,
+            z_span=z_span,
+            is_source=True,
+        )
+        for port in port_data
+        if port.is_source
+    ]
+    monitors = [
+        _shifted_port_overlay(
+            port,
+            offset=(
+                domain_config.source_port_offset
+                + domain_config.distance_source_to_monitors
+                if port.is_source
+                else domain_config.source_port_offset
+            ),
+            width=port.width + 2 * port_margin,
+            z_span=z_span,
+            is_source=False,
+        )
+        for port in port_data
+    ]
+
     diel_overlays: list[DielectricOverlay] = []
     if dielectrics:
         diel_overlays.extend(
@@ -199,6 +253,8 @@ def build_sim_overlay(
         cell_max=cell_max,
         dpml=dpml,
         ports=ports,
+        sources=sources,
+        monitors=monitors,
         dielectrics=diel_overlays,
         fiber=fiber_overlay,
     )

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -1977,6 +1977,30 @@ class Simulation(BaseModel):
     # Visualization
     # -------------------------------------------------------------------------
 
+    def _add_index_plot_context(
+        self,
+        result: BuildResult,
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Add center-wavelength material and simulation context to a plot."""
+        from gsim.meep.materials import resolve_materials
+
+        used_materials = {entry.material for entry in result.config.layer_stack} | {
+            dielectric["material"] for dielectric in result.config.dielectrics
+        }
+        kwargs["material_data"] = resolve_materials(
+            used_materials,
+            overrides=self._material_overrides(),
+            wavelength_um=result.config.wavelength.wavelength,
+            overlay=self._pdk_overlay,
+        )
+        kwargs["wavelength"] = result.config.wavelength.wavelength
+        kwargs["is_3d"] = result.config.is_3d
+        kwargs["plane"] = result.config.plane
+        kwargs["layer_order"] = [
+            entry.layer_name for entry in result.config.layer_stack
+        ]
+
     def plot_2d(self, **kwargs: Any) -> Any:
         """Plot 2D cross-sections of the geometry.
 
@@ -1985,6 +2009,11 @@ class Simulation(BaseModel):
 
         In XZ 2D mode (``solver.mode='2d'`` with ``y_cut`` set), ``slices``
         defaults to ``"y"`` and ``y`` defaults to the resolved ``y_cut``.
+
+        The default ``kind="index"`` colors resolved material geometry by
+        refractive index at the simulation center wavelength and shows PML,
+        source, and monitor annotations. Pass ``kind="layers"`` for the
+        categorical legacy view.
 
         Accepts the same keyword arguments as :func:`gsim.meep.viz.plot_2d`.
         """
@@ -1996,6 +2025,9 @@ class Simulation(BaseModel):
             kwargs.setdefault("slices", "y")
             if kwargs.get("slices") == "y":
                 kwargs.setdefault("y", result.config.y_cut)
+
+        if kwargs.get("kind", "index") == "index":
+            self._add_index_plot_context(result, kwargs)
 
         return plot_2d(
             component=result.component,
@@ -2024,6 +2056,10 @@ class Simulation(BaseModel):
         In XZ 2D mode (``solver.mode='2d'`` with ``y_cut`` set), ``slices``
         defaults to ``"y"`` and ``y`` defaults to the resolved ``y_cut``.
 
+        The default ``kind="index"`` uses the same refractive-index map and
+        simulation annotations as :meth:`plot_2d`. Pass ``kind="layers"`` for
+        the categorical legacy view.
+
         Accepts the same keyword arguments as
         :func:`gsim.meep.viz.plot_2d_interactive`.
 
@@ -2038,6 +2074,9 @@ class Simulation(BaseModel):
             kwargs.setdefault("slices", "y")
             if kwargs.get("slices") == "y":
                 kwargs.setdefault("y", result.config.y_cut)
+
+        if kwargs.get("kind", "index") == "index":
+            self._add_index_plot_context(result, kwargs)
 
         return plot_2d_interactive(
             component=result.component,

--- a/src/gsim/meep/viz.py
+++ b/src/gsim/meep/viz.py
@@ -7,7 +7,8 @@ Called directly by ``Simulation.plot_2d()`` / ``plot_3d()`` — no legacy
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import matplotlib.pyplot as plt
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
 
     from gsim.common import LayerStack
     from gsim.common.geometry_model import GeometryModel
-    from gsim.meep.models.config import DomainConfig
+    from gsim.meep.models.config import DomainConfig, MaterialData
 
 
 # ---------------------------------------------------------------------------
@@ -448,6 +449,14 @@ def plot_2d_interactive(
     monitor_z_span: float | None = None,
     aspect: Literal["equal", "auto"] = "equal",
     gdsfactory_stack: Any | None = None,
+    kind: Literal["layers", "index"] = "index",
+    index_component: Literal["mean", "x", "y", "z"] = "mean",
+    cmap: str = "Blues",
+    material_data: Mapping[str, MaterialData] | None = None,
+    wavelength: float | None = None,
+    is_3d: bool = True,
+    plane: Literal["xy", "xz"] = "xy",
+    layer_order: Sequence[str] | None = None,
 ) -> Any:
     """Plot an interactive 2D cross-section using Plotly.
 
@@ -478,10 +487,22 @@ def plot_2d_interactive(
         aspect: Axis aspect ratio. Use ``"equal"`` to preserve physical
             proportions or ``"auto"`` to fill the available plotting area.
         gdsfactory_stack: Optional direct-layer stack matching *component*.
+        kind: ``"index"`` for the refractive-index map or ``"layers"`` for
+            the categorical legacy view.
+        index_component: Permittivity tensor component used by the index view.
+        cmap: Matplotlib colormap used to build the interactive color scale.
+        material_data: Center-wavelength material data for the index view.
+        wavelength: Wavelength represented by the index view in um.
+        is_3d: Whether background slabs follow 3D simulation semantics.
+        plane: Resolved 2D simulation plane.
+        layer_order: Geometry precedence order used by the MEEP runner.
 
     Returns:
         ``plotly.graph_objects.Figure``.
     """
+    if kind not in {"layers", "index"}:
+        raise ValueError(f"kind must be 'layers' or 'index'. Got: {kind!r}")
+
     from gsim.common.viz import plot_prism_slices_interactive
 
     slices_to_plot = sorted(set(slices.lower()))
@@ -509,7 +530,7 @@ def plot_2d_interactive(
         monitor_z_span=monitor_z_span,
     )
 
-    slice_dir = slices_to_plot[0]
+    slice_dir = cast(Literal["x", "y", "z"], slices_to_plot[0])
     kw: dict[str, Any] = {}
     if slice_dir == "x":
         kw["x"] = x if x is not None else "core"
@@ -517,6 +538,32 @@ def plot_2d_interactive(
         kw["y"] = y if y is not None else "core"
     else:
         kw["z"] = z if z is not None else "core"
+
+    if kind == "index":
+        if material_data is None or wavelength is None:
+            raise ValueError(
+                "kind='index' requires center-wavelength material_data and wavelength"
+            )
+        from gsim.meep.index_viz_interactive import (
+            plot_refractive_index_interactive,
+        )
+
+        return plot_refractive_index_interactive(
+            gm,
+            material_data,
+            wavelength=wavelength,
+            overlay=overlay,
+            slice_axis=slice_dir,
+            layer_order=layer_order,
+            is_3d=is_3d,
+            plane=plane,
+            index_component=index_component,
+            cmap=cmap,
+            x=x,
+            y=y,
+            z=z if z is not None else "core",
+            aspect=aspect,
+        )
 
     return plot_prism_slices_interactive(gm, aspect=aspect, overlay=overlay, **kw)
 
@@ -539,6 +586,14 @@ def plot_2d(
     monitor_z_span: float | None = None,
     aspect: Literal["equal", "auto"] = "equal",
     gdsfactory_stack: Any | None = None,
+    kind: Literal["layers", "index"] = "index",
+    index_component: Literal["mean", "x", "y", "z"] = "mean",
+    cmap: str = "Blues",
+    material_data: Mapping[str, MaterialData] | None = None,
+    wavelength: float | None = None,
+    is_3d: bool = True,
+    plane: Literal["xy", "xz"] = "xy",
+    layer_order: Sequence[str] | None = None,
 ) -> plt.Axes | None:
     """Plot 2D cross-sections of the MEEP geometry.
 
@@ -562,10 +617,23 @@ def plot_2d(
         monitor_z_span: Port monitor z-span override.
         aspect: Axis aspect ratio. Use ``"equal"`` to preserve physical
             proportions or ``"auto"`` to fill the available plotting area.
+        kind: ``"layers"`` for the existing categorical layer view or
+            ``"index"`` for a refractive-index map.
+        index_component: Permittivity tensor component used by the index view.
+            ``"mean"`` plots ``sqrt(mean(epsilon_diag))``.
+        cmap: Matplotlib colormap for the index view.
+        material_data: Center-wavelength material data for the index view.
+        wavelength: Wavelength represented by the index view in um.
+        is_3d: Whether background slabs follow 3D simulation semantics.
+        plane: Resolved 2D simulation plane.
+        layer_order: Geometry precedence order used by the MEEP runner.
 
     Returns:
         ``plt.Axes`` when *ax* was provided, otherwise ``None``.
     """
+    if kind not in {"layers", "index"}:
+        raise ValueError(f"kind must be 'layers' or 'index'. Got: {kind!r}")
+
     from gsim.common.viz import plot_prism_slices
 
     gm = build_geometry_model(
@@ -586,6 +654,31 @@ def plot_2d(
         fiber_source=fiber_source,
         monitor_z_span=monitor_z_span,
     )
+    if kind == "index":
+        if material_data is None or wavelength is None:
+            raise ValueError(
+                "kind='index' requires center-wavelength material_data and wavelength"
+            )
+        from gsim.meep.index_viz import plot_refractive_index_slices
+
+        return plot_refractive_index_slices(
+            gm,
+            material_data,
+            wavelength=wavelength,
+            overlay=overlay,
+            layer_order=layer_order,
+            is_3d=is_3d,
+            plane=plane,
+            index_component=index_component,
+            cmap=cmap,
+            x=x,
+            y=y,
+            z=z,
+            ax=ax,
+            legend=legend,
+            slices=slices,
+            aspect=aspect,
+        )
     return plot_prism_slices(
         gm, x, y, z, ax, legend, slices, aspect=aspect, overlay=overlay
     )

--- a/tests/meep/test_viz_index.py
+++ b/tests/meep/test_viz_index.py
@@ -1,0 +1,290 @@
+"""Tests for refractive-index simulation previews."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, cast
+
+import matplotlib as mpl
+import numpy as np
+import pytest
+
+mpl.use("Agg")
+
+import matplotlib.pyplot as plt
+
+
+def _xz_sim_for_index_plot(angle_deg: float = -6.0):
+    import gdsfactory as gf
+
+    from gsim.common.stack import Layer, LayerStack
+    from gsim.meep.simulation import Simulation
+
+    component = gf.Component()
+    component.add_polygon(
+        [(-5, -0.25), (5, -0.25), (5, 0.25), (-5, 0.25)],
+        layer=(1, 0),
+    )
+    component.add_port(
+        name="o1",
+        center=(5.0, 0.0),
+        orientation=0.0,
+        width=0.5,
+        layer=(1, 0),
+    )
+    stack = LayerStack(
+        pdk_name="test",
+        units="um",
+        layers={
+            "core": Layer(
+                name="core",
+                gds_layer=(1, 0),
+                zmin=0.0,
+                zmax=0.22,
+                thickness=0.22,
+                material="si",
+                layer_type="dielectric",
+            ),
+        },
+        dielectrics=[
+            {"name": "box", "zmin": -2.0, "zmax": 0.0, "material": "SiO2"},
+            {"name": "clad", "zmin": 0.22, "zmax": 1.0, "material": "SiO2"},
+        ],
+    )
+    simulation = Simulation()
+    simulation.geometry.component = component
+    simulation.geometry.stack = stack
+    simulation.materials = {"si": 12.0, "SiO2": 2.1}
+    simulation.solver(mode="2d", y_cut="auto")
+    simulation.source_fiber(x=0.0, z=1.22, angle_deg=angle_deg, waist=5.4)
+    return simulation
+
+
+def test_material_refractive_indices_support_tensor_components():
+    from gsim.meep.index_viz import material_refractive_indices
+    from gsim.meep.models.config import MaterialData
+
+    materials = {"anisotropic": MaterialData(epsilon_diag=[1.0, 4.0, 9.0])}
+
+    mean_index = material_refractive_indices(materials)["anisotropic"]
+    x_index = material_refractive_indices(materials, "x")["anisotropic"]
+    z_index = material_refractive_indices(materials, "z")["anisotropic"]
+
+    assert mean_index == pytest.approx(math.sqrt(14.0 / 3.0))
+    assert x_index == pytest.approx(1.0)
+    assert z_index == pytest.approx(3.0)
+
+
+def test_build_overlay_resolves_source_and_monitor_offsets():
+    import numpy as np
+
+    from gsim.common.geometry_model import GeometryModel
+    from gsim.meep.models.config import DomainConfig, PortData
+    from gsim.meep.overlay import build_sim_overlay
+
+    geometry_model = GeometryModel(
+        prisms={},
+        bbox=((-2.0, -1.0, 0.0), (2.0, 1.0, 0.22)),
+    )
+    domain = DomainConfig(
+        dpml=1.0,
+        margin_x_low=0.5,
+        margin_x_high=0.5,
+        margin_y_low=0.5,
+        margin_y_high=0.5,
+        margin_z_low=0.0,
+        margin_z_high=0.0,
+        port_margin=0.5,
+        extend_ports=0.0,
+        source_port_offset=0.1,
+        distance_source_to_monitors=0.2,
+    )
+    ports = [
+        PortData(
+            name="source",
+            center=[-2.0, 0.0, 0.11],
+            orientation=0.0,
+            width=0.5,
+            normal_axis=0,
+            direction="+",
+            is_source=True,
+        ),
+        PortData(
+            name="output",
+            center=[2.0, 0.0, 0.11],
+            orientation=180.0,
+            width=0.5,
+            normal_axis=0,
+            direction="-",
+            is_source=False,
+        ),
+    ]
+
+    overlay = build_sim_overlay(geometry_model, domain, ports)
+
+    assert len(overlay.sources) == 1
+    assert len(overlay.monitors) == 2
+    assert overlay.sources[0].center[0] == pytest.approx(-1.9)
+    assert overlay.monitors[0].center[0] == pytest.approx(-1.7)
+    assert overlay.monitors[1].center[0] == pytest.approx(1.9)
+    assert np.isclose(overlay.sources[0].width, 1.5)
+
+
+def test_index_plot_is_default_with_material_map_colorbar_and_overlays():
+    simulation = _xz_sim_for_index_plot()
+    figure, ax = plt.subplots()
+
+    result = simulation.plot_2d(ax=ax)
+
+    assert result is ax
+    assert len(figure.axes) == 2
+    assert "Refractive index" in figure.axes[1].get_ylabel()
+    material_ids = {patch.get_gid() for patch in ax.patches if patch.get_gid()}
+    assert {"material:air", "material:SiO2", "material:si"} <= material_ids
+    air_patch = next(patch for patch in ax.patches if patch.get_gid() == "material:air")
+    silicon_patch = next(
+        patch for patch in ax.patches if patch.get_gid() == "material:si"
+    )
+    assert sum(air_patch.get_facecolor()[:3]) > sum(silicon_patch.get_facecolor()[:3])
+    assert air_patch.get_facecolor() == (1.0, 1.0, 1.0, 1.0)
+    assert len({round(channel, 3) for channel in silicon_patch.get_facecolor()[:3]}) > 1
+    _, labels = ax.get_legend_handles_labels()
+    assert {"PML", "Source", "Monitor"} <= set(labels)
+    assert "Sim cell" not in labels
+    pml_patch = next(patch for patch in ax.patches if patch.get_label() == "PML")
+    assert pml_patch.get_facecolor()[3] == 0.0
+    assert pml_patch.get_edgecolor() == (0.0, 0.0, 0.0, 1.0)
+    assert pml_patch.get_hatch() == "////"
+    assert pml_patch.get_hatch_linewidth() == pytest.approx(0.6)
+    plt.close(figure)
+
+
+def test_index_plot_uses_requested_tensor_component():
+    simulation = _xz_sim_for_index_plot()
+    figure, ax = plt.subplots()
+
+    simulation.plot_2d(kind="index", index_component="z", ax=ax)
+
+    assert "n_z" in figure.axes[1].get_ylabel()
+    plt.close(figure)
+
+
+@pytest.mark.parametrize("angle_deg", [-30.0, -6.0, 25.0])
+def test_index_plot_draws_fiber_waist_at_configured_angle(angle_deg):
+    simulation = _xz_sim_for_index_plot(angle_deg)
+    figure, ax = plt.subplots()
+
+    simulation.plot_2d(kind="index", ax=ax)
+
+    source_line = next(line for line in ax.lines if line.get_label() == "Source")
+    x_coordinates = np.asarray(source_line.get_xdata(), dtype=float)
+    z_coordinates = np.asarray(source_line.get_ydata(), dtype=float)
+    rendered_slope = (z_coordinates[1] - z_coordinates[0]) / (
+        x_coordinates[1] - x_coordinates[0]
+    )
+    assert rendered_slope == pytest.approx(math.tan(math.radians(angle_deg)))
+    assert not any(line.get_linestyle() == "--" for line in ax.lines)
+    arrow = cast(
+        Any,
+        next(
+            annotation
+            for annotation in ax.texts
+            if getattr(annotation, "arrow_patch", None) is not None
+        ),
+    )
+    arrow_head = arrow.xy
+    arrow_tail = arrow.xyann
+    arrow_vector = (
+        arrow_head[0] - arrow_tail[0],
+        arrow_head[1] - arrow_tail[1],
+    )
+    theta = math.radians(angle_deg)
+    assert arrow_vector == pytest.approx(
+        (0.6 * math.sin(theta), -0.6 * math.cos(theta))
+    )
+    source_vector = (
+        x_coordinates[1] - x_coordinates[0],
+        z_coordinates[1] - z_coordinates[0],
+    )
+    assert math.hypot(*arrow_vector) == pytest.approx(0.6)
+    assert sum(
+        source_component * arrow_component
+        for source_component, arrow_component in zip(
+            source_vector, arrow_vector, strict=True
+        )
+    ) == pytest.approx(0.0, abs=1e-12)
+    plt.close(figure)
+
+
+def test_layer_plot_remains_available_explicitly():
+    simulation = _xz_sim_for_index_plot()
+    figure, ax = plt.subplots()
+
+    simulation.plot_2d(kind="layers", ax=ax)
+
+    assert len(figure.axes) == 1
+    assert "Refractive index" not in ax.get_title()
+    plt.close(figure)
+
+
+def test_interactive_index_plot_is_default():
+    simulation = _xz_sim_for_index_plot()
+
+    figure = simulation.plot_2d_interactive()
+
+    assert "Refractive index" in figure.layout.title.text
+    assert next(trace for trace in figure.data if trace.name == "air").fillcolor == (
+        "#ffffff"
+    )
+    assert any(trace.marker.showscale for trace in figure.data)
+    pml_trace = next(trace for trace in figure.data if trace.name == "PML")
+    assert pml_trace.fillpattern.shape == "/"
+    assert pml_trace.fillpattern.bgcolor == "rgba(0,0,0,0)"
+    legend_names = {trace.name for trace in figure.data if trace.showlegend}
+    assert {"PML", "Source", "Monitor"} <= legend_names
+    assert "Sim cell" not in legend_names
+
+
+@pytest.mark.parametrize("angle_deg", [-30.0, -6.0, 25.0])
+def test_interactive_fiber_arrow_is_short_and_perpendicular(angle_deg):
+    simulation = _xz_sim_for_index_plot(angle_deg)
+
+    figure = simulation.plot_2d_interactive()
+
+    source_trace = next(
+        trace for trace in figure.data if trace.name == "Source" and trace.text
+    )
+    source_vector = (
+        source_trace.x[1] - source_trace.x[0],
+        source_trace.y[1] - source_trace.y[0],
+    )
+    arrow = figure.layout.annotations[0]
+    arrow_vector = (arrow.x - arrow.ax, arrow.y - arrow.ay)
+    theta = math.radians(angle_deg)
+    assert arrow_vector == pytest.approx(
+        (0.6 * math.sin(theta), -0.6 * math.cos(theta))
+    )
+    assert math.hypot(*arrow_vector) == pytest.approx(0.6)
+    assert sum(
+        source_component * arrow_component
+        for source_component, arrow_component in zip(
+            source_vector, arrow_vector, strict=True
+        )
+    ) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_interactive_layer_plot_remains_available_explicitly():
+    simulation = _xz_sim_for_index_plot()
+
+    figure = simulation.plot_2d_interactive(kind="layers")
+
+    assert "Refractive index" not in figure.layout.title.text
+    assert any(trace.name == "core" for trace in figure.data)
+    assert not any(trace.marker.showscale for trace in figure.data)
+
+
+def test_invalid_plot_kind_raises():
+    simulation = _xz_sim_for_index_plot()
+
+    with pytest.raises(ValueError, match="kind must be"):
+        simulation.plot_2d(kind="epsilon")


### PR DESCRIPTION
Adds refractive-index views as the default for static and interactive Meep 2D plots while retaining `kind="layers"`.

- resolves material index at the simulation center wavelength
- uses a Blues scale with white air and overlays hatched PML, source, and monitor geometry
- keeps fiber-source geometry angle-aware and adds regression coverage