### PR TITLE
feat: extend Meep background dielectrics into PML

### DIFF
--- a/src/gsim/meep/models/api.py
+++ b/src/gsim/meep/models/api.py
@@ -252,7 +252,7 @@ class Domain(BaseModel):
     )
     pml: float = Field(default=1.0, ge=0, description="PML thickness in um")
     extend_into_pml: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Extend background dielectric slabs touching an active Z boundary "
             "through the adjacent PML. Patterned layers and ports are unchanged."

--- a/src/gsim/meep/models/api.py
+++ b/src/gsim/meep/models/api.py
@@ -251,6 +251,13 @@ class Domain(BaseModel):
         ),
     )
     pml: float = Field(default=1.0, ge=0, description="PML thickness in um")
+    extend_into_pml: bool = Field(
+        default=False,
+        description=(
+            "Extend background dielectric slabs touching an active Z boundary "
+            "through the adjacent PML. Patterned layers and ports are unchanged."
+        ),
+    )
     margin_x: float | tuple[float, float] = Field(
         default=0.5,
         description=(

--- a/src/gsim/meep/models/config.py
+++ b/src/gsim/meep/models/config.py
@@ -56,7 +56,7 @@ class DomainConfig(BaseModel):
     )
     dpml: float = Field(ge=0, description="PML thickness in um")
     extend_into_pml: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Whether boundary-adjacent background dielectrics were extended "
             "through active Z PML regions."

--- a/src/gsim/meep/models/config.py
+++ b/src/gsim/meep/models/config.py
@@ -55,6 +55,13 @@ class DomainConfig(BaseModel):
         description="Resolved absolute PML-inner Z interval in um.",
     )
     dpml: float = Field(ge=0, description="PML thickness in um")
+    extend_into_pml: bool = Field(
+        default=False,
+        description=(
+            "Whether boundary-adjacent background dielectrics were extended "
+            "through active Z PML regions."
+        ),
+    )
     margin_x_low: float = Field(
         ge=0, description="XY margin on the -x side (geometry to PML) in um"
     )

--- a/src/gsim/meep/pml.py
+++ b/src/gsim/meep/pml.py
@@ -1,0 +1,45 @@
+"""Physical material handling at Meep absorbing boundaries."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gsim.common.stack import LayerStack
+    from gsim.meep.models.config import DomainConfig
+
+_BOUNDARY_TOLERANCE = 1e-9
+
+
+def extend_dielectrics_into_pml(
+    stack: LayerStack,
+    domain: DomainConfig,
+) -> LayerStack:
+    """Extend boundary-adjacent background dielectrics through the Z PML.
+
+    Dielectric slabs are already infinite along X and Y in the Meep runner, so
+    only the active Z boundaries require explicit extension. Patterned layers
+    remain unchanged.
+    """
+    if not domain.extend_into_pml or domain.dpml == 0 or domain.z_bounds is None:
+        return stack
+
+    z_low, z_high = domain.z_bounds
+    extended_stack = stack.model_copy(deep=True)
+    for dielectric in extended_stack.dielectrics:
+        if math.isclose(
+            dielectric["zmin"],
+            z_low,
+            rel_tol=0.0,
+            abs_tol=_BOUNDARY_TOLERANCE,
+        ):
+            dielectric["zmin"] = z_low - domain.dpml
+        if math.isclose(
+            dielectric["zmax"],
+            z_high,
+            rel_tol=0.0,
+            abs_tol=_BOUNDARY_TOLERANCE,
+        ):
+            dielectric["zmax"] = z_high + domain.dpml
+    return extended_stack

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -871,6 +871,7 @@ class Simulation(BaseModel):
         return DomainConfig(
             z_bounds=z_bounds,
             dpml=self.domain.pml,
+            extend_into_pml=self.domain.extend_into_pml,
             margin_x_low=mx[0],
             margin_x_high=mx[1],
             margin_y_low=my[0],
@@ -1349,7 +1350,12 @@ class Simulation(BaseModel):
             self.geometry.stack,
         )
         component = physical_export.component
-        stack = physical_export.stack
+        from gsim.meep.pml import extend_dielectrics_into_pml
+
+        stack = extend_dielectrics_into_pml(
+            physical_export.stack,
+            domain_cfg,
+        )
 
         # Build layer stack entries
         layer_stack_entries = []

--- a/tests/meep/test_pml.py
+++ b/tests/meep/test_pml.py
@@ -49,7 +49,7 @@ def test_extend_dielectrics_into_adjacent_pml_faces():
 
     extended = extend_dielectrics_into_pml(
         stack,
-        _domain_config(extend_into_pml=True),
+        _domain_config(),
     )
 
     by_name = {dielectric["name"]: dielectric for dielectric in extended.dielectrics}
@@ -63,11 +63,17 @@ def test_extend_dielectrics_into_adjacent_pml_faces():
     assert stack.dielectrics[0]["zmin"] == -1.0
 
 
-def test_extend_dielectrics_is_disabled_by_default():
-    """Preserve existing material extents unless explicitly enabled."""
+def test_extend_dielectrics_can_be_disabled():
+    """Preserve existing material extents when explicitly disabled."""
     stack = _background_stack()
 
-    assert extend_dielectrics_into_pml(stack, _domain_config()) is stack
+    assert (
+        extend_dielectrics_into_pml(
+            stack,
+            _domain_config(extend_into_pml=False),
+        )
+        is stack
+    )
     assert (
         extend_dielectrics_into_pml(
             stack,

--- a/tests/meep/test_pml.py
+++ b/tests/meep/test_pml.py
@@ -1,0 +1,77 @@
+"""Tests for material handling at Meep absorbing boundaries."""
+
+from __future__ import annotations
+
+from gsim.common.stack import LayerStack
+from gsim.meep.models.config import DomainConfig
+from gsim.meep.pml import extend_dielectrics_into_pml
+
+
+def _domain_config(**updates) -> DomainConfig:
+    """Build a minimal resolved domain for PML-extension tests."""
+    domain = DomainConfig(
+        z_bounds=(-1.0, 2.0),
+        dpml=0.5,
+        margin_x_low=0.0,
+        margin_x_high=0.0,
+        margin_y_low=0.0,
+        margin_y_high=0.0,
+        margin_z_low=0.0,
+        margin_z_high=0.0,
+        port_margin=0.0,
+        extend_ports=0.0,
+        source_port_offset=0.0,
+        distance_source_to_monitors=0.0,
+    )
+    return domain.model_copy(update=updates)
+
+
+def _background_stack() -> LayerStack:
+    """Build background slabs touching lower, upper, both, and neither side."""
+    return LayerStack(
+        dielectrics=[
+            {"name": "lower", "material": "lower", "zmin": -1.0, "zmax": 0.0},
+            {"name": "upper", "material": "upper", "zmin": 1.0, "zmax": 2.0},
+            {"name": "both", "material": "both", "zmin": -1.0, "zmax": 2.0},
+            {
+                "name": "interior",
+                "material": "interior",
+                "zmin": 0.25,
+                "zmax": 0.75,
+            },
+        ]
+    )
+
+
+def test_extend_dielectrics_into_adjacent_pml_faces():
+    """Extend only the faces that touch the PML-inner Z boundaries."""
+    stack = _background_stack()
+
+    extended = extend_dielectrics_into_pml(
+        stack,
+        _domain_config(extend_into_pml=True),
+    )
+
+    by_name = {dielectric["name"]: dielectric for dielectric in extended.dielectrics}
+    assert (by_name["lower"]["zmin"], by_name["lower"]["zmax"]) == (-1.5, 0.0)
+    assert (by_name["upper"]["zmin"], by_name["upper"]["zmax"]) == (1.0, 2.5)
+    assert (by_name["both"]["zmin"], by_name["both"]["zmax"]) == (-1.5, 2.5)
+    assert (by_name["interior"]["zmin"], by_name["interior"]["zmax"]) == (
+        0.25,
+        0.75,
+    )
+    assert stack.dielectrics[0]["zmin"] == -1.0
+
+
+def test_extend_dielectrics_is_disabled_by_default():
+    """Preserve existing material extents unless explicitly enabled."""
+    stack = _background_stack()
+
+    assert extend_dielectrics_into_pml(stack, _domain_config()) is stack
+    assert (
+        extend_dielectrics_into_pml(
+            stack,
+            _domain_config(extend_into_pml=True, dpml=0.0),
+        )
+        is stack
+    )

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -868,7 +868,7 @@ class TestXZAutoCrop:
     def test_extend_into_pml_resolves_runner_and_preview_stack(self):
         """Boundary background extents are shared by config and BuildResult."""
         sim = self._base_sim()
-        sim.domain(z_bounds=(-1.0, 3.0), extend_into_pml=True)
+        sim.domain(z_bounds=(-1.0, 3.0))
 
         result = sim.build_config()
 

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -865,6 +865,29 @@ class TestXZAutoCrop:
 
         assert result.config.domain.z_bounds == (-1.0, 5.0)
 
+    def test_extend_into_pml_resolves_runner_and_preview_stack(self):
+        """Boundary background extents are shared by config and BuildResult."""
+        sim = self._base_sim()
+        sim.domain(z_bounds=(-1.0, 3.0), extend_into_pml=True)
+
+        result = sim.build_config()
+
+        config_box = next(
+            dielectric
+            for dielectric in result.config.dielectrics
+            if dielectric["name"] == "box"
+        )
+        stack_box = next(
+            dielectric
+            for dielectric in result.stack.dielectrics
+            if dielectric["name"] == "box"
+        )
+        assert result.config.domain.extend_into_pml is True
+        assert result.config.domain.z_bounds == (-1.0, 3.0)
+        assert config_box["zmin"] == -2.0
+        assert stack_box["zmin"] == -2.0
+        assert config_box["zmax"] == stack_box["zmax"] == 0.0
+
     def test_explicit_bounds_reject_missing_fiber_headroom(self):
         sim = self._base_sim()
         sim.domain(z_bounds=(-1.0, 3.0))

--- a/tests/meep/test_viz_index.py
+++ b/tests/meep/test_viz_index.py
@@ -247,7 +247,6 @@ def test_interactive_index_plot_is_default():
 
 def test_extended_background_reaches_pml_in_both_index_plots():
     simulation = _xz_sim_for_index_plot()
-    simulation.domain(extend_into_pml=True)
     figure, ax = plt.subplots()
 
     simulation.plot_2d(ax=ax)

--- a/tests/meep/test_viz_index.py
+++ b/tests/meep/test_viz_index.py
@@ -245,6 +245,28 @@ def test_interactive_index_plot_is_default():
     assert "Sim cell" not in legend_names
 
 
+def test_extended_background_reaches_pml_in_both_index_plots():
+    simulation = _xz_sim_for_index_plot()
+    simulation.domain(extend_into_pml=True)
+    figure, ax = plt.subplots()
+
+    simulation.plot_2d(ax=ax)
+    silica_patches = cast(
+        list[Any],
+        [patch for patch in ax.patches if patch.get_gid() == "material:SiO2"],
+    )
+    assert min(patch.get_y() for patch in silica_patches) == pytest.approx(
+        ax.get_ylim()[0]
+    )
+    plt.close(figure)
+
+    interactive = simulation.plot_2d_interactive()
+    silica_traces = [trace for trace in interactive.data if trace.name == "SiO2"]
+    assert min(min(trace.y) for trace in silica_traces) == pytest.approx(
+        interactive.layout.yaxis.range[0]
+    )
+
+
 @pytest.mark.parametrize("angle_deg", [-30.0, -6.0, 25.0])
 def test_interactive_fiber_arrow_is_short_and_perpendicular(angle_deg):
     simulation = _xz_sim_for_index_plot(angle_deg)


### PR DESCRIPTION
Extends boundary-adjacent background dielectric slabs through active Z PML regions by default.

- resolves expanded extents once for runner and static/interactive preview consistency
- leaves patterned layers and ports unchanged
- supports opt-out with `sim.domain(extend_into_pml=False)`