### PR TITLE
fix: surface cache-lookup and failed-job diagnostics

### DIFF
--- a/src/gsim/gcloud.py
+++ b/src/gsim/gcloud.py
@@ -26,6 +26,7 @@ Usage:
 from __future__ import annotations
 
 import contextlib
+import functools
 import importlib
 import io
 import logging
@@ -190,6 +191,19 @@ def _flatten_results(raw_results: dict) -> dict[str, Path]:
     return flat
 
 
+# Container exit codes in the 128+N range mean the process died on signal N.
+# Worth spelling out: these look like solver errors but are usually resource
+# limits, and the solver rarely gets a chance to write a log.
+_SIGNAL_EXIT_CODES = {
+    134: "exit 134 is SIGABRT — an assertion failure or out-of-memory abort. "
+    "Try a coarser mesh, fewer frequency points, or a larger instance.",
+    137: "exit 137 is SIGKILL — almost always the container hitting its "
+    "memory limit. Try a coarser mesh or a larger instance.",
+    139: "exit 139 is SIGSEGV — a solver crash. Please report the mesh and "
+    "config that reproduce it.",
+}
+
+
 def _handle_failed_job(job, output_dir: Path, verbose: bool) -> None:
     """Handle a failed simulation job by downloading logs and raising informative error.
 
@@ -216,30 +230,50 @@ def _handle_failed_job(job, output_dir: Path, verbose: bool) -> None:
     if detail_reason:
         error_parts.append(f"Details: {detail_reason}")
 
+    if exit_code in _SIGNAL_EXIT_CODES:
+        error_parts.append(f"Note: {_SIGNAL_EXIT_CODES[exit_code]}")
+
     # Try to download logs even though job failed
     try:
-        if exit_code is not None and job.download_urls:
+        if exit_code is not None and not job.download_urls:
+            error_parts.append(
+                "No output artifacts were uploaded, so no solver log is "
+                "available — the container most likely died before writing "
+                "any output."
+            )
+        elif exit_code is not None:
             if verbose:
                 print("Downloading logs from failed job...")  # noqa: T201
 
             raw_results = sim.download_results(job, output_dir=output_dir)
             all_files = _flatten_results(raw_results)
 
-            # Look for log files and display them
+            # Look for log files and display them. Fall back to any *.log so a
+            # solver that names its log differently is still surfaced.
             log_files = ["palace.log", "stdout.log", "stderr.log", "output.log"]
-            for log_name in log_files:
-                if log_name in all_files:
-                    content = all_files[log_name].read_text()
-                    error_parts.append(f"\n--- {log_name} (last 100 lines) ---")
-                    lines = content.strip().split("\n")
-                    error_parts.append("\n".join(lines[-100:]))
-                    break
+            log_name = next(
+                (name for name in log_files if name in all_files),
+                next(
+                    (name for name in sorted(all_files) if name.endswith(".log")),
+                    None,
+                ),
+            )
+            if log_name is not None:
+                content = all_files[log_name].read_text()
+                error_parts.append(f"\n--- {log_name} (last 100 lines) ---")
+                lines = content.strip().split("\n")
+                error_parts.append("\n".join(lines[-100:]))
+            else:
+                error_parts.append(
+                    f"No log file among the downloaded artifacts "
+                    f"({', '.join(sorted(all_files)) or 'none'})."
+                )
 
             if verbose and all_files:
                 print(f"Logs downloaded to {output_dir}")  # noqa: T201
 
     except Exception as e:
-        error_parts.append(f"(Failed to download logs: {e})")
+        error_parts.append(f"(Failed to download logs: {type(e).__name__}: {e})")
 
     raise RuntimeError("\n".join(error_parts))
 
@@ -272,12 +306,24 @@ def _sdk_accepts(func: Any, param: str) -> bool:
         return False
 
 
+@functools.cache
+def _warn_cache_unsupported() -> None:
+    """Warn once per process that the installed SDK cannot look up the cache."""
+    logger.warning(
+        "Installed gdsfactoryplus has no check_cache(); cache lookups are "
+        "disabled. Upgrade gdsfactoryplus to reuse completed jobs without "
+        "re-uploading their inputs."
+    )
+
+
 def check_cache(job_type: str, input_hash: str) -> str | None:
     """Look up a previously completed job with identical inputs.
 
     Never raises: a cache lookup is an optimization, so an unsupported SDK,
     a transient network error, or a server error all degrade to a miss and
-    the caller submits the job normally.
+    the caller submits the job normally. Those degraded paths are logged at
+    ``WARNING`` — silently returning a miss makes a permanently broken
+    lookup indistinguishable from a cold cache.
 
     Args:
         job_type: Solver name, e.g. ``"meep"`` or ``"palace"``.
@@ -288,9 +334,7 @@ def check_cache(job_type: str, input_hash: str) -> str | None:
     """
     sdk_check = getattr(sim, "check_cache", None)
     if sdk_check is None:
-        logger.debug(
-            "Installed gdsfactoryplus has no check_cache(); skipping cache lookup"
-        )
+        _warn_cache_unsupported()
         return None
 
     try:
@@ -299,10 +343,16 @@ def check_cache(job_type: str, input_hash: str) -> str | None:
             input_hash=input_hash,
         )
     except Exception as exc:
-        logger.debug("Cache lookup failed (%s); submitting normally", exc)
+        logger.warning(
+            "Cache lookup for %s failed (%s: %s); submitting normally",
+            job_type,
+            type(exc).__name__,
+            exc,
+        )
         return None
 
     if not getattr(result, "cached", False):
+        logger.debug("Cache miss for %s %s", job_type, input_hash)
         return None
     return getattr(result, "job_id", None)
 

--- a/tests/test_gcloud_cache.py
+++ b/tests/test_gcloud_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from unittest.mock import MagicMock, create_autospec, patch
 
@@ -64,11 +65,51 @@ class TestCheckCache:
         with patch.object(gcloud.sim, "check_cache", None, create=True):
             assert gcloud.check_cache("meep", "sha256:abc") is None
 
+    def test_unsupported_sdk_warns_once(self, caplog):
+        """An SDK without check_cache warns, but only once per process."""
+        gcloud._warn_cache_unsupported.cache_clear()
+        with (
+            caplog.at_level(logging.WARNING, logger=gcloud.logger.name),
+            patch.object(gcloud.sim, "check_cache", None, create=True),
+        ):
+            gcloud.check_cache("meep", "sha256:abc")
+            gcloud.check_cache("meep", "sha256:def")
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "no check_cache()" in warnings[0].getMessage()
+
     def test_server_error_returns_none(self):
         """A failing lookup degrades to a miss rather than raising."""
         fake = MagicMock(side_effect=RuntimeError("boom"))
         with patch.object(gcloud.sim, "check_cache", fake, create=True):
             assert gcloud.check_cache("meep", "sha256:abc") is None
+
+    def test_server_error_warns(self, caplog):
+        """A failing lookup is visible: a dead endpoint is not a cold cache."""
+        fake = MagicMock(side_effect=RuntimeError("boom"))
+        with (
+            caplog.at_level(logging.WARNING, logger=gcloud.logger.name),
+            patch.object(gcloud.sim, "check_cache", fake, create=True),
+        ):
+            gcloud.check_cache("palace", "sha256:abc")
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "RuntimeError" in message
+        assert "boom" in message
+
+    def test_miss_does_not_warn(self, caplog):
+        """A genuine cache miss is expected and stays quiet."""
+        fake = MagicMock(return_value=FakeCacheResponse(cached=False))
+        with (
+            caplog.at_level(logging.WARNING, logger=gcloud.logger.name),
+            patch.object(gcloud.sim, "check_cache", fake, create=True),
+        ):
+            assert gcloud.check_cache("meep", "sha256:abc") is None
+
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
 
     def test_unknown_job_type_returns_none(self):
         """An unknown solver name degrades to a miss, not a crash."""

--- a/tests/test_gcloud_start.py
+++ b/tests/test_gcloud_start.py
@@ -513,3 +513,51 @@ class TestModuleLevelExports:
 
         assert hasattr(gsim, "wait_for_results")
         assert callable(gsim.wait_for_results)
+
+
+# ---------------------------------------------------------------------------
+# _handle_failed_job
+# ---------------------------------------------------------------------------
+
+
+class TestHandleFailedJob:
+    """Tests for the error raised when a cloud job fails."""
+
+    def _fail(self, tmp_path, **kwargs):
+        """Run _handle_failed_job on a failed job and return the message."""
+        from gsim.gcloud import _handle_failed_job
+
+        job = FakeJob(status=SimStatus.FAILED, **kwargs)
+        with pytest.raises(RuntimeError) as exc:
+            _handle_failed_job(job, tmp_path, verbose=False)
+        return str(exc.value)
+
+    def test_reports_missing_artifacts(self, tmp_path):
+        """An empty download set is stated, not left as an unexplained blank."""
+        message = self._fail(tmp_path, exit_code=1, download_urls={})
+        assert "exit code 1" in message
+        assert "No output artifacts" in message
+
+    def test_explains_signal_exit_code(self, tmp_path):
+        """128+N exit codes get a signal explanation instead of a bare number."""
+        message = self._fail(tmp_path, exit_code=134, download_urls={})
+        assert "SIGABRT" in message
+
+    def test_explains_oom_kill(self, tmp_path):
+        """SIGKILL is called out as a memory limit."""
+        assert "memory limit" in self._fail(tmp_path, exit_code=137, download_urls={})
+
+    def test_no_note_for_plain_failure(self, tmp_path):
+        """An ordinary non-signal exit code gets no signal note."""
+        assert "SIGABRT" not in self._fail(tmp_path, exit_code=1, download_urls={})
+
+    def test_surfaces_unconventionally_named_log(self, tmp_path):
+        """Any *.log among the artifacts is shown when the known names are absent."""
+        log = tmp_path / "solver-run.log"
+        log.write_text("line one\nfatal: mesh is degenerate\n", encoding="utf-8")
+
+        with patch("gsim.gcloud.sim.download_results", return_value={"log": log}):
+            message = self._fail(tmp_path, exit_code=1, download_urls={"a": "url"})
+
+        assert "solver-run.log" in message
+        assert "fatal: mesh is degenerate" in message


### PR DESCRIPTION
Fixes #225. Requested by @joamatab.

**Reminder: AI-created PRs still require human review of the actual code changes before merge.**

### `check_cache()` visibility

The degrade-to-a-miss behaviour is right; logging it at `DEBUG` is not. A permanently broken lookup was indistinguishable from a cold cache — and results kept coming back correctly, because `upload()` sends `input_hash` and the server deduplicates on it, so the only casualty was the upload round-trip the client-side lookup exists to skip.

- Missing SDK `check_cache` → `WARNING`, once per process (`functools.cache`), since the condition is static.
- Lookup raises → `WARNING` with exception type and message.
- Genuine miss (`cached: false`) → `DEBUG`. That one is expected and must stay quiet.

### `_handle_failed_job()` diagnostics

Three gaps, all hit while diagnosing two crashed Palace jobs whose error output was three lines with no log and no explanation for the absence:

1. **No artifacts** — `if exit_code is not None and job.download_urls:` skipped the whole block silently, so you got `exit code 134` / `Status: failed` and nothing about why there was no solver log. Now stated: the container most likely died before writing output.
2. **Log discovery** — only four hardcoded names were matched. Falls back to any `*.log` among the artifacts, and lists what was actually downloaded when nothing matches.
3. **Signal exit codes** — 134 / 137 / 139 get a one-line note (SIGABRT / SIGKILL / SIGSEGV, with the likely cause and remedy). They read as solver errors but usually mean a resource limit.

### Testing

Added to `tests/test_gcloud_cache.py`: warn-once on unsupported SDK, warn on lookup error (asserting type and message reach the log), and — importantly — **no** warning on a genuine miss, so this doesn't become log noise.

Added `TestHandleFailedJob` to `tests/test_gcloud_start.py`: missing artifacts stated, signal note present for 134/137, absent for a plain exit 1, and an unconventionally-named `*.log` surfaced with its contents.

No existing tests were modified.

⚠️ I could not run pytest or the `ty` hook locally: `gdsfactoryplus>=1.8.20` is not on public PyPI, so the environment won't build here. `ruff check`, `ruff format`, `codespell`, `interrogate` and the rest of pre-commit pass. Please let CI be the judge on the test run.
