### PR TITLE
test: migrate cloud fixtures to z bounds

### DIFF
--- a/tests/_cloud_fixtures.py
+++ b/tests/_cloud_fixtures.py
@@ -38,7 +38,7 @@ def make_sbend_sim():
     sim.domain.pml = 1.0
     sim.domain.margin_x = 0.5
     sim.domain.margin_y = 0.5
-    sim.domain.margin_z = 0.5
+    sim.domain.z_bounds = (-0.5, 0.72)
     sim.solver.resolution = 10
     sim.solver.stop_when_energy_decayed(dt=15.0, decay_by=0.05)
     return sim
@@ -82,7 +82,7 @@ def make_2d_xz_gc_sim():
     sim.domain.pml = 1.0
     sim.domain.margin_x = 0.5
     sim.domain.margin_y = 0.5
-    sim.domain.margin_z = 0.5
+    sim.domain.z_bounds = (-0.5, 4.6)
     sim.num_freqs = 11
     return sim
 

--- a/tests/meep/test_cloud_cross_section_mode.py
+++ b/tests/meep/test_cloud_cross_section_mode.py
@@ -68,7 +68,7 @@ def test_cross_section_mode_cloud(tmp_path, cross_section_component) -> None:
     sim.num_freqs = 1
     sim.monitors = []
     sim.domain.pml = 1.0
-    sim.domain.margin_z = 0.5
+    sim.domain.z_bounds = (-2.5, 2.5)
     sim.solver.resolution = 10
     sim.solver.stop_when_energy_decayed(dt=15.0, decay_by=0.05)
 

--- a/tests/meep/test_cloud_slab_mode.py
+++ b/tests/meep/test_cloud_slab_mode.py
@@ -26,7 +26,7 @@ def test_slab_mode_cloud(tmp_path) -> None:
     sim.num_freqs = 1
     sim.monitors = []
     sim.domain.pml = 1.0
-    sim.domain.margin_z = 0.5
+    sim.domain.z_bounds = (-3.5, 6.1)
     sim.solver.resolution = 10
     sim.solver.stop_when_energy_decayed(dt=15.0, decay_by=0.05)
 


### PR DESCRIPTION
Follow-up to #219.\n\nMigrates the remaining MEEP cloud fixtures from deprecated `domain.margin_z` to explicit `domain.z_bounds`, preserving their resolved Z intervals.