### PR TITLE
feat: add ergonomic FDTD cloud workflow

### DIFF
--- a/docs/api/fdtd.md
+++ b/docs/api/fdtd.md
@@ -1,75 +1,183 @@
 # GDSFactory FDTD API
 
-`gsim.fdtd` generates the coarse tetrahedral mesh and validated `config.json`
-consumed by GDSFactory FDTD. The backend voxelizes this mesh onto its own Yee
-grid, so the Gmsh mesh does not need to resolve the electromagnetic fields.
+`gsim.fdtd` separates simulation setup into geometry, materials, source,
+monitors, domain, and solver concerns. It generates the transfer mesh and
+validated `config.json`, submits one source to one cloud job, and returns typed
+results.
 
-## PDK-native workflow
-
-Pass the PDK module when it exposes project-level `MATERIAL_CARDS`; otherwise,
-pass a PDK object or use the active PDK. Material names are resolved exactly,
-using the project's cards first and gsim's built-in cards as fallbacks.
+## Configure and run
 
 ```python
-import gpdk
-
 from gsim import fdtd
 
-simulation = fdtd.Simulation(pdk=gpdk)
-simulation.geometry("mmi1x2")
-artifacts = simulation.write("fdtd_output")
+sim = fdtd.Simulation(pdk=gpdk)
+sim.materials(background="SiO2")
+sim.geometry(component=mmi, mesh_size_nm=400)
+sim.source(
+    port="o1",
+    wavelength_um=1.55,
+    wavelength_span_um=0.1,
+    num_wavelengths=101,
+)
+sim.domain(padding_um=0.75, pml_cells=16)
+sim.solver(
+    cell_size_nm=40,
+    energy_decay_fraction=1e-6,
+    max_wall_seconds=3600,
+)
 
-print(artifacts.mesh_path)  # fdtd_output/mesh.msh
-print(artifacts.config_path)  # fdtd_output/config.json
+result = sim.run(check_cache=True)
+result.plot()
+result.plot_plotly()
 ```
 
-The generated mesh is ASCII Gmsh MSH 2.2 with linear tetrahedra for material
-regions and linear triangles for `port_<name>` groups. Geometry and wavelength
-values in the artifacts are in nanometers. PML extrusion is left to GDSFactory
-FDTD.
+`mesh_size_nm` controls the coarse Gmsh transfer mesh. `cell_size_nm` requests
+the actual Yee grid used by the FDTD solver and defaults to 60 nm. Source sweeps
+default to 101 wavelengths. Guided-port monitors are implicit; one port source
+returns one S-matrix column.
 
-## Initial geometry limits
+Use `write(path)` to generate `mesh.msh` and `config.json` without submitting.
+The original flat constructor keywords remain accepted for compatibility.
 
-The backend supports disconnected polygons, polygon holes, axis-aligned guided
-ports, and vertical or constant-angle sidewalls. Tapered layers use a small
-number of midpoint-sampled prisms selected from the Yee-cell size, keeping the
-lateral approximation error below one quarter cell while leaving field
-resolution to the backend voxelizer.
+## Setup visualization
 
-Vertical `vertical_te` and `vertical_tm` ports are free-space apertures rather
-than material-owned eigenmode ports. By default a vertical port becomes a
-plane/fiber monitor while the first guided port is excited. Select the vertical
-port explicitly to generate a Gaussian-beam source:
+FDTD setup views use the ported ZapFDTD Three.js viewer and do not depend on
+PyVista. All physical groups are shown by default. Smaller material groups are
+listed first, followed by the largest volumetric group and then the ports.
 
 ```python
-simulation = fdtd.Simulation(pdk=gpdk, default_port="o2")
-simulation.geometry("grating_coupler_elliptical")
-simulation.write("fdtd_output/grating")
+sim.plot_3d()                                   # solid interactive geometry
+sim.plot_3d(show_mesh=True)                     # add Gmsh surface edges
+sim.plot_2d(axis="z", position_um=0.11)         # filled cross-section
+sim.plot_2d(axis="x", position_um=0, show_mesh=True)  # add cell edges
 ```
 
-The aperture defaults to a square using the port width, top-facing `+z`, with a
-beam waist equal to half the aperture width. Override these policies with
-`vertical_port_axis`, `vertical_port_aperture_width_um`, and
-`vertical_port_waist_radius_um`.
+Omit `position_um` to start at the geometry midpoint. The 2D viewer includes a
+slider that moves the plane through the mesh. Both methods return a standalone
+`MeshViewer`. Set `show_mesh=True` when element edges are useful, or use
+`viewer.save("mesh.html")` to share the visualization outside a notebook.
 
-The initial implementation rejects unsupported `bias`/`z_to_bias` profiles and
-lossy material snapshots because config schema version 1 accepts only real
-scalar refractive indices.
+## Sources
+
+`PortSource` requires an explicit `sim.source(port="...")` selection before
+artifacts can be written or a job can run. A guided PDK port maps to an
+eigenmode source. Selecting a `vertical_te` or `vertical_tm` PDK port instead
+derives a Gaussian beam and fiber monitor from the port metadata.
+
+Replace `sim.source` to use another physical source:
+
+```python
+sim.source = fdtd.DipoleSource(
+    position_um=(0, 0, 0.11),
+    current_axis="z",
+    wavelength_um=1.55,
+)
+
+sim.source = fdtd.LineCurrentSource(
+    position_um=(0, -0.5, 0.11),
+    line_axis="y",
+    current_axis="z",
+    length_um=1,
+)
+```
+
+`GaussianBeamSource` exposes the aperture center and size, propagation and
+polarization vectors, focal point, waist, and optional background index. Only
+`PortSource` on a guided port produces normalized S-parameters. Other source
+types return outgoing port amplitudes and powers.
+
+## Plane monitors
+
+Additional plane monitors can independently record flux, scalar heatmaps, and
+Gaussian fiber overlap:
+
+```python
+sim.monitors.add_plane(
+    name="top",
+    center_um=(0, 0, 1),
+    size_um=(10, 6, 0),
+    normal="+z",
+    flux=True,
+    heatmap=fdtd.Heatmap(
+        quantity="intensity",
+        wavelengths_um=[1.55],
+    ),
+)
+```
+
+Monitor names are unique. Use `add()`, `remove()`, and `clear()` to manage the
+collection. A plane's size must be zero along its normal.
+
+## Results
+
+```python
+result.s_parameters.plot()
+result.s_parameters.plot_plotly()
+s_parameter_table = result.s_parameters.to_dataframe()
+
+result.port_outputs.plot(quantity="modal_power")
+port_table = result.port_outputs.to_dataframe()
+
+top = result.monitors["top"]
+top.plot_flux()
+top.plot_heatmap(wavelength_um=1.55)
+```
+
+Heatmap arrays are loaded lazily from their `.npy` sidecars. S-parameter plots
+gap samples flagged below the source noise floor by default. Convergence, grid,
+timing, and resolved runtime settings remain available on the result object.
+
+Simulation setup views remain separate from these result plots: `sim.plot_*()`
+inspects the submitted geometry and mesh, while `result.plot*()` displays solver
+output.
 
 ## Reference
 
 ::: gsim.fdtd.Simulation
     options:
       show_source: false
+      inherited_members: false
+      members:
+        - write
+        - upload
+        - start
+        - get_status
+        - wait_for_results
+        - run
+        - plot_2d
+        - plot_3d
 
-::: gsim.fdtd.SimulationArtifacts
+::: gsim.fdtd.PortSource
     options:
       show_source: false
+      members: false
 
-::: gsim.fdtd.MeshManifest
+::: gsim.fdtd.DipoleSource
     options:
       show_source: false
+      members: false
 
-::: gsim.fdtd.FDTDConfig
+::: gsim.fdtd.LineCurrentSource
     options:
       show_source: false
+      members: false
+
+::: gsim.fdtd.GaussianBeamSource
+    options:
+      show_source: false
+      members: false
+
+::: gsim.fdtd.PlaneMonitor
+    options:
+      show_source: false
+      members: false
+
+::: gsim.fdtd.FDTDResult
+    options:
+      show_source: false
+      inherited_members: false
+      members:
+        - from_file
+        - from_run_result
+        - plot
+        - plot_plotly

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -3,6 +3,7 @@ docs_dir = "."
 nav = [
   { "Home" = "index.md" },
   { "FDTD for Photonics" = [
+    { "GDSFactory FDTD: GPDK MMI" = "nbs/fdtd_mmi_gpdk.md" },
     { "Y-Branch" = "nbs/meep_ybranch.md" },
     { "Ring Coupler" = "nbs/meep_ring_coupler.md" },
     { "Directional Coupler" = "nbs/meep_dc.md" },

--- a/nbs/fdtd_mmi_gpdk.ipynb
+++ b/nbs/fdtd_mmi_gpdk.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# GPDK MMI with GDSFactory FDTD\n",
+    "\n",
+    "The **GDSFactory FDTD engine** runs full-wave electromagnetic simulations from GDSFactory components. This notebook configures a 3D GPDK MMI, previews the simulation geometry, runs it in the cloud, and plots its S-parameters.\n",
+    "\n",
+    "**Requirements:**\n",
+    "\n",
+    "- [GDSFactory+](https://gdsfactory.com) account with cloud simulation access\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "from gsim import fdtd\n",
+    "\n",
+    "gf.gpdk.PDK.activate()\n",
+    "component = gf.get_component(\"mmi1x2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "### Configure the FDTD simulation\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simulation = fdtd.Simulation(pdk=gf.gpdk.PDK)\n",
+    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757})\n",
+    "simulation.geometry(component)\n",
+    "simulation.source(port=\"o1\", num_wavelengths=101)\n",
+    "simulation.domain(padding_um=1)\n",
+    "simulation.solver(energy_decay_fraction=1e-5, cell_size_nm=60)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "### Preview the simulation geometry\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simulation.plot_3d()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "### Run the simulation in the cloud\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "result = simulation.run(check_cache=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "### Plot the S-parameters\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {
+    "tags": [
+     "skip-execution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "result.plot_plotly()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gsim (3.12.10)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,6 +287,9 @@ select = ["ALL"]
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.setuptools.package-data]
+"gsim.fdtd" = ["assets/*.html"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/gsim/fdtd/__init__.py
+++ b/src/gsim/fdtd/__init__.py
@@ -1,5 +1,20 @@
-"""Passive artifact generation for GDSFactory FDTD."""
+"""Ergonomic setup, cloud execution, and results for GDSFactory FDTD."""
 
+from gsim.fdtd.api import (
+    DipoleSource,
+    Domain,
+    FiberMode,
+    GaussianBeamSource,
+    Geometry,
+    Heatmap,
+    LineCurrentSource,
+    Material,
+    Materials,
+    Monitors,
+    PlaneMonitor,
+    PortSource,
+    Solver,
+)
 from gsim.fdtd.config import FDTDConfig
 from gsim.fdtd.models import (
     FDTDArtifactError,
@@ -8,14 +23,54 @@ from gsim.fdtd.models import (
     MeshManifest,
     SimulationArtifacts,
 )
-from gsim.fdtd.simulation import Simulation
+from gsim.fdtd.results import (
+    ComplexTrace,
+    FDTDResult,
+    HeatmapResult,
+    MonitorResults,
+    PlaneMonitorResult,
+    PortOutputResults,
+    SParameterResults,
+)
+from gsim.fdtd.viz import MeshViewer
+from gsim.fdtd.workflow import Simulation
+from gsim.gcloud import RunResult, register_result_parser
+
+
+def _parse_fdtd_result(run_result: RunResult) -> FDTDResult:
+    """Parse downloaded ZapFDTD JSON and sidecar outputs."""
+    return FDTDResult.from_run_result(run_result)
+
+
+register_result_parser("fdtd", _parse_fdtd_result)
 
 __all__ = [
+    "ComplexTrace",
+    "DipoleSource",
+    "Domain",
     "FDTDArtifactError",
     "FDTDConfig",
     "FDTDConfigError",
     "FDTDGeometryError",
+    "FDTDResult",
+    "FiberMode",
+    "GaussianBeamSource",
+    "Geometry",
+    "Heatmap",
+    "HeatmapResult",
+    "LineCurrentSource",
+    "Material",
+    "Materials",
     "MeshManifest",
+    "MeshViewer",
+    "MonitorResults",
+    "Monitors",
+    "PlaneMonitor",
+    "PlaneMonitorResult",
+    "PortOutputResults",
+    "PortSource",
+    "SParameterResults",
     "Simulation",
     "SimulationArtifacts",
+    "Solver",
 ]

--- a/src/gsim/fdtd/api.py
+++ b/src/gsim/fdtd/api.py
@@ -1,0 +1,339 @@
+"""User-facing configuration objects for GDSFactory FDTD simulations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Any, Literal, Self
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
+
+Vector3 = tuple[float, float, float]
+Axis = Literal["x", "y", "z"]
+SignedAxis = Literal["+x", "-x", "+y", "-y", "+z", "-z"]
+Waveform = Literal["pulse", "continuous_wave"]
+HeatmapQuantity = Literal[
+    "abs_e", "intensity", "abs_h", "ex", "ey", "ez", "hx", "hy", "hz"
+]
+
+
+class _MutableModel(BaseModel):
+    """Validated model that supports concise batch updates."""
+
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
+
+    def __call__(self, **updates: Any) -> Self:
+        """Validate and apply several settings atomically."""
+        updated = type(self).model_validate({**self.model_dump(), **updates})
+        for field_name in type(self).model_fields:
+            object.__setattr__(self, field_name, getattr(updated, field_name))
+        return self
+
+
+class Geometry(BaseModel):
+    """Component and meshing settings, expressed in micrometers and nanometers."""
+
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
+
+    component: Any | None = None
+    settings: dict[str, Any] = Field(default_factory=dict)
+    mesh_size_nm: float = Field(default=500.0, gt=0)
+    _resolver: Any = PrivateAttr(default=None)
+
+    def bind(self, resolver: Any) -> None:
+        """Attach the simulation's canonical PDK geometry resolver."""
+        self._resolver = resolver
+
+    def __call__(
+        self,
+        component: Any | None = None,
+        *,
+        settings: Mapping[str, Any] | None = None,
+        mesh_size_nm: float | None = None,
+    ) -> Any:
+        """Configure geometry and return its canonical resolved representation."""
+        updates: dict[str, Any] = {}
+        if component is not None:
+            updates["component"] = component
+        if settings is not None:
+            updates["settings"] = dict(settings)
+        if mesh_size_nm is not None:
+            updates["mesh_size_nm"] = mesh_size_nm
+        updated = type(self).model_validate({**self.model_dump(), **updates})
+        for field_name in type(self).model_fields:
+            object.__setattr__(self, field_name, getattr(updated, field_name))
+        if self.component is None:
+            raise ValueError("component is required")
+        return self._resolver() if self._resolver is not None else self
+
+
+class Material(_MutableModel):
+    """Lossless scalar material override at the source wavelength."""
+
+    refractive_index: float = Field(gt=0)
+
+
+class Materials(_MutableModel):
+    """Background material and optional refractive-index overrides."""
+
+    background: str = Field(default="SiO2", min_length=1)
+    overrides: dict[str, Material] = Field(default_factory=dict)
+
+    @field_validator("overrides", mode="before")
+    @classmethod
+    def coerce_materials(cls, value: Any) -> Any:
+        """Allow ``{"si": 3.47}`` as a compact material override."""
+        if value is None:
+            return {}
+        return {
+            name: Material(refractive_index=item)
+            if isinstance(item, (int, float))
+            else item
+            for name, item in dict(value).items()
+        }
+
+    def __getitem__(self, name: str) -> Material:
+        """Return one explicit material override by name."""
+        return self.overrides[name]
+
+    def __setitem__(
+        self, name: str, value: float | Material | Mapping[str, Any]
+    ) -> None:
+        """Validate and store one explicit material override."""
+        updated = dict(self.overrides)
+        updated[name] = (
+            Material(refractive_index=value)
+            if isinstance(value, (int, float))
+            else Material.model_validate(value)
+        )
+        self(overrides=updated)
+
+
+class Source(_MutableModel):
+    """Settings shared by every FDTD source."""
+
+    waveform: Waveform = "pulse"
+    wavelength_um: float = Field(default=1.55, gt=0)
+    wavelength_span_um: float = Field(default=0.1, ge=0)
+    num_wavelengths: int = Field(default=101, ge=1)
+    amplitude: float = 1.0
+
+    @model_validator(mode="after")
+    def validate_spectrum(self) -> Self:
+        """Require a physical sweep and a nonzero source."""
+        if self.wavelength_span_um / 2 >= self.wavelength_um:
+            raise ValueError(
+                "wavelength_span_um must be smaller than twice wavelength_um"
+            )
+        if self.waveform == "continuous_wave" and self.num_wavelengths != 1:
+            raise ValueError("continuous_wave requires num_wavelengths=1")
+        if self.amplitude == 0:
+            raise ValueError("source amplitude cannot be zero")
+        return self
+
+    @property
+    def wavelength_halfspan_um(self) -> float:
+        """Return the half-span expected by the ZapFDTD runtime schema."""
+        return self.wavelength_span_um / 2
+
+
+class PortSource(Source):
+    """Excite an explicitly selected PDK port."""
+
+    type: Literal["port"] = "port"
+    port: str | None = Field(default=None, min_length=1)
+    vertical_axis: Literal["+z", "-z"] = "+z"
+    vertical_aperture_width_um: float | None = Field(default=None, gt=0)
+    vertical_waist_radius_um: float | None = Field(default=None, gt=0)
+
+
+class DipoleSource(Source):
+    """Single-cell electric-current source."""
+
+    type: Literal["dipole"] = "dipole"
+    position_um: Vector3
+    current_axis: Axis
+
+
+class LineCurrentSource(Source):
+    """Line of in-phase electric-current sources."""
+
+    type: Literal["line_current"] = "line_current"
+    position_um: Vector3
+    line_axis: Axis
+    current_axis: Axis
+    length_um: float = Field(gt=0)
+
+
+class GaussianBeamSource(Source):
+    """Focused Gaussian beam injected through an axis-aligned aperture."""
+
+    type: Literal["gaussian_beam"] = "gaussian_beam"
+    center_um: Vector3
+    size_um: Vector3
+    aperture_normal: SignedAxis
+    propagation_direction: Vector3
+    e_polarization: Vector3
+    focal_point_um: Vector3
+    waist_radius_um: float = Field(gt=0)
+    refractive_index: float | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def validate_aperture(self) -> Self:
+        """Require a plane whose zero-size axis matches the normal."""
+        if any(size < 0 for size in self.size_um):
+            raise ValueError("size_um components cannot be negative")
+        axis = {"x": 0, "y": 1, "z": 2}[self.aperture_normal[-1]]
+        if self.size_um[axis] != 0:
+            raise ValueError("size_um must be zero along aperture_normal")
+        return self
+
+
+SourceType = PortSource | DipoleSource | LineCurrentSource | GaussianBeamSource
+
+
+class Heatmap(_MutableModel):
+    """Steady-state scalar field images requested from a plane monitor."""
+
+    quantity: HeatmapQuantity = "intensity"
+    wavelengths_um: list[float] = Field(min_length=1)
+
+    @field_validator("wavelengths_um")
+    @classmethod
+    def validate_wavelengths(cls, values: list[float]) -> list[float]:
+        """Require physical heatmap wavelengths."""
+        if any(value <= 0 for value in values):
+            raise ValueError("heatmap wavelengths must be positive")
+        return values
+
+
+class FiberMode(_MutableModel):
+    """Analytic Gaussian fiber profile for overlap projection."""
+
+    propagation_direction: Vector3
+    e_polarization: Vector3
+    focal_point_um: Vector3
+    waist_radius_um: float = Field(gt=0)
+    refractive_index: float | None = Field(default=None, gt=0)
+
+
+class PlaneMonitor(_MutableModel):
+    """Flux, field, and optional fiber-overlap measurement on a plane."""
+
+    name: str = Field(min_length=1)
+    center_um: Vector3
+    size_um: Vector3
+    normal: SignedAxis
+    flux: bool = True
+    wavelengths_um: list[float] | None = None
+    heatmap: Heatmap | None = None
+    fiber_mode: FiberMode | None = None
+
+    @model_validator(mode="after")
+    def validate_plane(self) -> Self:
+        """Require planar geometry and at least one measurement."""
+        if any(size < 0 for size in self.size_um):
+            raise ValueError("size_um components cannot be negative")
+        axis = {"x": 0, "y": 1, "z": 2}[self.normal[-1]]
+        if self.size_um[axis] != 0:
+            raise ValueError("size_um must be zero along the monitor normal")
+        if self.wavelengths_um is not None and any(
+            wavelength <= 0 for wavelength in self.wavelengths_um
+        ):
+            raise ValueError("monitor wavelengths must be positive")
+        if not self.flux and self.heatmap is None and self.fiber_mode is None:
+            raise ValueError(
+                "a plane monitor must request flux, a heatmap, or fiber overlap"
+            )
+        return self
+
+
+class Monitors:
+    """Named collection of additional plane monitors; port monitors are implicit."""
+
+    def __init__(self, monitors: list[PlaneMonitor | Mapping[str, Any]] | None = None):
+        """Validate an optional initial list of named plane monitors."""
+        self._items: dict[str, PlaneMonitor] = {}
+        for monitor in monitors or []:
+            validated = PlaneMonitor.model_validate(monitor)
+            self.add(validated)
+
+    def add(self, monitor: PlaneMonitor) -> PlaneMonitor:
+        """Add an already configured monitor, requiring a unique name."""
+        if monitor.name in self._items:
+            raise ValueError(f"monitor {monitor.name!r} already exists")
+        self._items[monitor.name] = monitor
+        return monitor
+
+    def add_plane(self, name: str, **settings: Any) -> PlaneMonitor:
+        """Create and add a named plane monitor."""
+        return self.add(PlaneMonitor(name=name, **settings))
+
+    def remove(self, name: str) -> PlaneMonitor:
+        """Remove and return one named plane monitor."""
+        return self._items.pop(name)
+
+    def clear(self) -> None:
+        """Remove all explicitly configured plane monitors."""
+        self._items.clear()
+
+    def __getitem__(self, name: str) -> PlaneMonitor:
+        """Return one monitor by name."""
+        return self._items[name]
+
+    def __iter__(self) -> Iterator[PlaneMonitor]:
+        """Iterate over monitors in insertion order."""
+        return iter(self._items.values())
+
+    def __len__(self) -> int:
+        """Return the number of explicitly configured monitors."""
+        return len(self._items)
+
+    def model_dump(self) -> list[dict[str, Any]]:
+        """Return serializable monitor dictionaries."""
+        return [monitor.model_dump() for monitor in self]
+
+
+class Domain(_MutableModel):
+    """Simulation-domain padding and absorbing boundary settings."""
+
+    padding_um: float = Field(default=1.0, gt=0)
+    pml_cells: int = Field(default=32, ge=0)
+
+
+class Solver(_MutableModel):
+    """Yee-grid resolution and termination controls."""
+
+    cell_size_nm: float = Field(default=60.0, gt=0)
+    max_timesteps: int | None = Field(default=None, gt=0)
+    energy_decay_fraction: float = Field(default=1e-6, gt=0, lt=1)
+    max_wall_seconds: float = Field(default=3600.0, ge=0)
+
+
+__all__ = [
+    "Axis",
+    "DipoleSource",
+    "Domain",
+    "FiberMode",
+    "GaussianBeamSource",
+    "Geometry",
+    "Heatmap",
+    "HeatmapQuantity",
+    "LineCurrentSource",
+    "Material",
+    "Materials",
+    "Monitors",
+    "PlaneMonitor",
+    "PortSource",
+    "SignedAxis",
+    "Solver",
+    "Source",
+    "SourceType",
+    "Vector3",
+]

--- a/src/gsim/fdtd/assets/mesh-viewer.html
+++ b/src/gsim/fdtd/assets/mesh-viewer.html
@@ -1,0 +1,1092 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <link rel="icon" href="data:," />
+    <title>GDSFactory FDTD mesh viewer</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        overflow: hidden;
+        background: #101216;
+        color: #eef2f7;
+      }
+      #canvas {
+        width: 100vw;
+        height: 100vh;
+      }
+      #panel {
+        position: absolute;
+        z-index: 2;
+        top: 14px;
+        left: 14px;
+        width: 250px;
+        max-height: calc(100vh - 28px);
+        overflow: auto;
+        padding: 14px;
+        border: 1px solid #ffffff20;
+        border-radius: 10px;
+        background: #12151ddd;
+        box-shadow: 0 8px 30px #0008;
+      }
+      #panel.collapsed {
+        width: auto;
+        max-height: none;
+        overflow: hidden;
+        padding: 10px 12px;
+      }
+      #panel.collapsed #panel-body {
+        display: none;
+      }
+      #panel-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      h1 {
+        margin: 0;
+        font-size: 16px;
+      }
+      .muted {
+        color: #94a0b2;
+        font-size: 11px;
+        line-height: 1.4;
+      }
+      .section {
+        margin-top: 12px;
+        padding-top: 10px;
+        border-top: 1px solid #ffffff14;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+      }
+      #groups {
+        display: grid;
+        gap: 5px;
+        margin-top: 7px;
+      }
+      button {
+        width: 100%;
+        padding: 5px 8px;
+        border: 0;
+        border-radius: 5px;
+        background: #2868c7;
+        color: white;
+        text-align: left;
+        cursor: pointer;
+      }
+      button.group-button {
+        background: var(--group-color);
+        color: #101216;
+      }
+      button.group-button.off {
+        background: #343a46;
+        color: #9aa5b5;
+      }
+      #panel-toggle {
+        width: 32px;
+        height: 26px;
+        flex: 0 0 auto;
+        padding: 0;
+        border: 1px solid #ffffff14;
+        background: #ffffff08;
+        color: #94a0b2;
+        display: grid;
+        place-items: center;
+      }
+      #panel-toggle svg {
+        width: 14px;
+        height: 14px;
+        transform: rotate(180deg);
+        transition: transform 160ms ease;
+      }
+      #panel.collapsed #panel-toggle svg {
+        transform: rotate(0);
+      }
+      #panel-toggle:hover,
+      #panel-toggle:focus-visible {
+        background: #ffffff14;
+        color: #eef2f7;
+      }
+      input[type="range"] {
+        width: 100%;
+        accent-color: #4f91f7;
+      }
+      #error {
+        color: #ff8f8f;
+        white-space: pre-wrap;
+      }
+      #orientation-gizmo {
+        position: absolute;
+        z-index: 3;
+        right: 10px;
+        bottom: 10px;
+        width: 112px;
+        height: 112px;
+        user-select: none;
+      }
+      #orientation-gizmo svg {
+        width: 100%;
+        height: 100%;
+        overflow: visible;
+      }
+      .gizmo-axis {
+        stroke: #4f9cff;
+        stroke-width: 3;
+        stroke-linecap: round;
+      }
+      .gizmo-target {
+        cursor: pointer;
+        outline: none;
+      }
+      .gizmo-target circle {
+        stroke: #101216;
+        stroke-width: 2;
+      }
+      .gizmo-axis-target circle {
+        fill: #4f9cff;
+      }
+      .gizmo-target:hover circle,
+      .gizmo-target:focus circle {
+        stroke: white;
+        stroke-width: 3;
+      }
+      .gizmo-label {
+        fill: #101216;
+        font:
+          700 11px Inter,
+          ui-sans-serif,
+          system-ui,
+          sans-serif;
+        text-anchor: middle;
+        dominant-baseline: central;
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="panel">
+      <div id="panel-header">
+        <h1>GDSFactory FDTD</h1>
+        <button
+          id="panel-toggle"
+          type="button"
+          aria-expanded="true"
+          aria-controls="panel-body"
+          aria-label="Collapse controls"
+          title="Collapse controls"
+        >
+          <svg viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path
+              d="m5 7.5 5 5 5-5"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+      <div id="panel-body">
+        <div id="stats" class="section muted" hidden>Loading mesh...</div>
+        <div id="slice-section" class="section" hidden>
+          <div class="row">
+            <label for="slice">Slice</label
+            ><span id="slice-value" class="muted"></span>
+          </div>
+          <input id="slice" type="range" step="any" />
+        </div>
+        <div class="section">
+          <div class="muted">Physical groups</div>
+          <div id="groups"></div>
+        </div>
+        <div class="section muted">
+          Drag to rotate, scroll to zoom toward the cursor, right-drag to pan.
+          Slice views pan and zoom without rotation.
+        </div>
+        <div id="error" class="section muted"></div>
+      </div>
+    </div>
+    <div id="canvas"></div>
+    <div id="orientation-gizmo" aria-label="View orientation" hidden>
+      <svg viewBox="0 0 112 112" role="group" aria-label="View orientation">
+        <line
+          id="gizmo-x-line"
+          class="gizmo-axis"
+          x1="56"
+          y1="56"
+          x2="90"
+          y2="56"
+        />
+        <line
+          id="gizmo-y-line"
+          class="gizmo-axis"
+          x1="56"
+          y1="56"
+          x2="56"
+          y2="22"
+        />
+        <line
+          id="gizmo-z-line"
+          class="gizmo-axis"
+          x1="56"
+          y1="56"
+          x2="32"
+          y2="80"
+        />
+        <g
+          id="gizmo-x-target"
+          class="gizmo-target gizmo-axis-target"
+          role="button"
+          tabindex="0"
+          aria-label="View from positive X axis"
+        >
+          <circle r="10" />
+          <text class="gizmo-label" y="0.5">X</text>
+        </g>
+        <g
+          id="gizmo-y-target"
+          class="gizmo-target gizmo-axis-target"
+          role="button"
+          tabindex="0"
+          aria-label="View from positive Y axis"
+        >
+          <circle r="10" />
+          <text class="gizmo-label" y="0.5">Y</text>
+        </g>
+        <g
+          id="gizmo-z-target"
+          class="gizmo-target gizmo-axis-target"
+          role="button"
+          tabindex="0"
+          aria-label="View from positive Z axis"
+        >
+          <circle r="10" />
+          <text class="gizmo-label" y="0.5">Z</text>
+        </g>
+        <g
+          id="gizmo-center-target"
+          class="gizmo-target"
+          role="button"
+          tabindex="0"
+          aria-label="Reset isometric view"
+        >
+          <circle cx="56" cy="56" r="7" fill="#d7dde7" />
+        </g>
+      </svg>
+    </div>
+
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+          "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
+        }
+      }
+    </script>
+    <script type="module">
+      import * as THREE from "three";
+      import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+      import { toCreasedNormals } from "three/addons/utils/BufferGeometryUtils.js";
+
+      const meshText = __GSIM_MESH_DATA__;
+      const options = __GSIM_VIEW_OPTIONS__;
+      const NM_TO_UM = 1e-3;
+      const isSlice = options.mode === "slice" || options.mode === "mesh_slice";
+      const showEdges =
+        options.mode === "mesh" || options.mode === "mesh_slice";
+      const statsPanel = document.getElementById("stats");
+      statsPanel.hidden = !showEdges;
+      const axisIndex = { x: 0, y: 1, z: 2 }[options.axis];
+      const axisVectors = [
+        new THREE.Vector3(1, 0, 0),
+        new THREE.Vector3(0, 1, 0),
+        new THREE.Vector3(0, 0, 1),
+      ];
+      const orientationAxes = {
+        x: axisVectors[0],
+        y: axisVectors[1],
+        z: axisVectors[2],
+      };
+      const zUp = new THREE.Vector3(0, 0, 1);
+      const defaultViewDirection = new THREE.Vector3(
+        1.8,
+        -1.5,
+        1.8,
+      ).normalize();
+      const physicalGroupPalette = [
+        0xff9fba, 0xb8b2b0, 0x55dfff, 0x69f0bd, 0xd6a4ff, 0xffe082, 0x7dd3fc,
+        0x9fe6cf,
+      ];
+      const physicalGroupColors = new Map();
+      const panel = document.getElementById("panel");
+      const panelToggle = document.getElementById("panel-toggle");
+      const orientationGizmo = document.getElementById("orientation-gizmo");
+      orientationGizmo.hidden = isSlice;
+
+      panelToggle.addEventListener("click", () => {
+        const collapsed = panel.classList.toggle("collapsed");
+        const label = collapsed ? "Expand controls" : "Collapse controls";
+        panelToggle.setAttribute("aria-expanded", String(!collapsed));
+        panelToggle.setAttribute("aria-label", label);
+        panelToggle.title = label;
+      });
+
+      let camera;
+      let controls;
+      let cameraAnimation;
+      let currentModel;
+      let groupRoots = new Map();
+      let slicePosition = options.positionUm;
+      let orthographicHalfHeight = 1;
+      let rebuildFrame;
+
+      const scene = new THREE.Scene();
+      scene.background = new THREE.Color(0x101216);
+      scene.add(new THREE.HemisphereLight(0xdce9ff, 0x253044, 2.4));
+      const keyLight = new THREE.DirectionalLight(0xffffff, 2.1);
+      keyLight.position.set(3, -5, 4);
+      scene.add(keyLight);
+      const renderer = new THREE.WebGLRenderer({ antialias: true });
+      const clock = new THREE.Clock();
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      document.getElementById("canvas").appendChild(renderer.domElement);
+
+      function faceKey(a, b, c) {
+        if (a > b) [a, b] = [b, a];
+        if (b > c) [b, c] = [c, b];
+        if (a > b) [a, b] = [b, a];
+        return `${a},${b},${c}`;
+      }
+
+      function sectionStart(lines, tag) {
+        const index = lines.findIndex((line) => line.trim() === tag);
+        if (index < 0) throw new Error(`Missing ${tag} section`);
+        return index + 1;
+      }
+
+      function parseGmsh(text) {
+        const lines = text.split(/\r?\n/);
+        let index = sectionStart(lines, "$MeshFormat");
+        const major = Number.parseInt(lines[index].trim().split(/\s+/)[0], 10);
+        if (major !== 2 && major !== 4)
+          throw new Error(`Unsupported Gmsh version ${major}`);
+
+        const names = new Map();
+        if (text.includes("$PhysicalNames")) {
+          index = sectionStart(lines, "$PhysicalNames");
+          const count = Number(lines[index++]);
+          for (let i = 0; i < count; i++) {
+            const parts = lines[index++].trim().split(/\s+/);
+            const name = parts.slice(2).join(" ").replace(/^"|"$/g, "");
+            names.set(`${parts[0]}_${parts[1]}`, name);
+          }
+        }
+
+        const entityGroups = new Map();
+        if (major === 4 && text.includes("$Entities")) {
+          index = sectionStart(lines, "$Entities");
+          const counts = lines[index++].trim().split(/\s+/).map(Number);
+          for (let dim = 0; dim < 4; dim++) {
+            for (let i = 0; i < counts[dim]; i++) {
+              const parts = lines[index++].trim().split(/\s+/).map(Number);
+              const physicalCountIndex = dim === 0 ? 4 : 7;
+              if (parts[physicalCountIndex] > 0) {
+                entityGroups.set(
+                  `${dim}_${parts[0]}`,
+                  parts[physicalCountIndex + 1],
+                );
+              }
+            }
+          }
+        }
+
+        const nodes = new Map();
+        index = sectionStart(lines, "$Nodes");
+        if (major === 2) {
+          const count = Number(lines[index++]);
+          for (let i = 0; i < count; i++) {
+            const parts = lines[index++].trim().split(/\s+/).map(Number);
+            nodes.set(
+              parts[0],
+              parts.slice(1, 4).map((value) => value * NM_TO_UM),
+            );
+          }
+        } else {
+          const blockCount = Number(lines[index++].trim().split(/\s+/)[0]);
+          for (let block = 0; block < blockCount; block++) {
+            const header = lines[index++].trim().split(/\s+/).map(Number);
+            const count = header[3];
+            const tags = [];
+            for (let i = 0; i < count; i++)
+              tags.push(Number(lines[index++].trim()));
+            for (let i = 0; i < count; i++) {
+              const point = lines[index++]
+                .trim()
+                .split(/\s+/)
+                .slice(0, 3)
+                .map(Number);
+              nodes.set(
+                tags[i],
+                point.map((value) => value * NM_TO_UM),
+              );
+            }
+          }
+        }
+
+        const triangles = [];
+        const tetrahedra = [];
+        index = sectionStart(lines, "$Elements");
+        if (major === 2) {
+          const count = Number(lines[index++]);
+          for (let i = 0; i < count; i++) {
+            const parts = lines[index++].trim().split(/\s+/).map(Number);
+            const type = parts[1];
+            const tagCount = parts[2];
+            const nodeStart = 3 + tagCount;
+            const physicalTag = tagCount ? parts[3] : 0;
+            if (type === 2)
+              triangles.push({
+                group: `2_${physicalTag}`,
+                nodes: parts.slice(nodeStart, nodeStart + 3),
+              });
+            if (type === 4)
+              tetrahedra.push({
+                group: `3_${physicalTag}`,
+                nodes: parts.slice(nodeStart, nodeStart + 4),
+              });
+          }
+        } else {
+          const blockCount = Number(lines[index++].trim().split(/\s+/)[0]);
+          for (let block = 0; block < blockCount; block++) {
+            const header = lines[index++].trim().split(/\s+/).map(Number);
+            const [dimension, entityTag, type, count] = header;
+            const physicalTag =
+              entityGroups.get(`${dimension}_${entityTag}`) ?? 0;
+            for (let i = 0; i < count; i++) {
+              const parts = lines[index++].trim().split(/\s+/).map(Number);
+              if (type === 2)
+                triangles.push({
+                  group: `2_${physicalTag}`,
+                  nodes: parts.slice(1, 4),
+                });
+              if (type === 4)
+                tetrahedra.push({
+                  group: `3_${physicalTag}`,
+                  nodes: parts.slice(1, 5),
+                });
+            }
+          }
+        }
+        if (!nodes.size || (!triangles.length && !tetrahedra.length))
+          throw new Error("Mesh has no renderable elements");
+        return { names, nodes, tetrahedra, triangles };
+      }
+
+      function addFace(groups, group, nodes) {
+        if (!groups.has(group)) groups.set(group, []);
+        groups.get(group).push(...nodes);
+      }
+
+      function orientedTetFace(tet, indices, nodeMap) {
+        const [aIndex, bIndex, cIndex, oppositeIndex] = indices;
+        const a = nodeMap.get(tet.nodes[aIndex]);
+        const b = nodeMap.get(tet.nodes[bIndex]);
+        const c = nodeMap.get(tet.nodes[cIndex]);
+        const opposite = nodeMap.get(tet.nodes[oppositeIndex]);
+        const ab = b.map((value, index) => value - a[index]);
+        const ac = c.map((value, index) => value - a[index]);
+        const normal = [
+          ab[1] * ac[2] - ab[2] * ac[1],
+          ab[2] * ac[0] - ab[0] * ac[2],
+          ab[0] * ac[1] - ab[1] * ac[0],
+        ];
+        const towardInterior = normal.reduce(
+          (sum, value, index) => sum + value * (opposite[index] - a[index]),
+          0,
+        );
+        const tags = [tet.nodes[aIndex], tet.nodes[bIndex], tet.nodes[cIndex]];
+        return towardInterior > 0 ? [tags[0], tags[2], tags[1]] : tags;
+      }
+
+      function surfaceGroups(mesh) {
+        const explicitKeys = new Set(
+          mesh.triangles.map((item) => faceKey(...item.nodes)),
+        );
+        const faces = new Map();
+        const tetFaces = [
+          [0, 1, 2, 3],
+          [0, 1, 3, 2],
+          [0, 2, 3, 1],
+          [1, 2, 3, 0],
+        ];
+        for (const tet of mesh.tetrahedra) {
+          for (const indices of tetFaces) {
+            const nodes = orientedTetFace(tet, indices, mesh.nodes);
+            const key = faceKey(...nodes);
+            if (!faces.has(key)) faces.set(key, []);
+            faces.get(key).push({ group: tet.group, nodes });
+          }
+        }
+        const groups = new Map();
+        for (const [key, owners] of faces) {
+          const distinct = new Set(owners.map((owner) => owner.group));
+          if (explicitKeys.has(key)) continue;
+          if (owners.length === 1 || distinct.size > 1) {
+            for (const group of distinct) {
+              const owner = owners.find(
+                (candidate) => candidate.group === group,
+              );
+              addFace(groups, group, owner.nodes);
+            }
+          }
+        }
+        for (const triangle of mesh.triangles)
+          addFace(groups, triangle.group, triangle.nodes);
+        return groups;
+      }
+
+      const edgePairs = [
+        [0, 1],
+        [0, 2],
+        [0, 3],
+        [1, 2],
+        [1, 3],
+        [2, 3],
+      ];
+      function slicePolygon(tet, nodes, axis, position) {
+        const points = [];
+        const epsilon = 1e-9;
+        function addUnique(point) {
+          if (
+            !points.some((existing) =>
+              existing.every(
+                (value, i) => Math.abs(value - point[i]) < epsilon,
+              ),
+            )
+          )
+            points.push(point);
+        }
+        for (const [aIndex, bIndex] of edgePairs) {
+          const a = nodes.get(tet.nodes[aIndex]);
+          const b = nodes.get(tet.nodes[bIndex]);
+          const da = a[axis] - position;
+          const db = b[axis] - position;
+          if (Math.abs(da) < epsilon) addUnique(a.slice());
+          if (Math.abs(db) < epsilon) addUnique(b.slice());
+          if (da * db < -epsilon * epsilon) {
+            const fraction = da / (da - db);
+            addUnique(a.map((value, i) => value + fraction * (b[i] - value)));
+          }
+        }
+        if (points.length < 3) return [];
+        const planeAxes = axis === 0 ? [1, 2] : axis === 1 ? [0, 2] : [0, 1];
+        const center = [0, 0, 0];
+        points.forEach((point) =>
+          point.forEach((value, i) => (center[i] += value / points.length)),
+        );
+        points.sort(
+          (a, b) =>
+            Math.atan2(
+              a[planeAxes[1]] - center[planeAxes[1]],
+              a[planeAxes[0]] - center[planeAxes[0]],
+            ) -
+            Math.atan2(
+              b[planeAxes[1]] - center[planeAxes[1]],
+              b[planeAxes[0]] - center[planeAxes[0]],
+            ),
+        );
+        return points;
+      }
+
+      function slicedGroups(mesh, position) {
+        const groups = new Map();
+        for (const tet of mesh.tetrahedra) {
+          const polygon = slicePolygon(tet, mesh.nodes, axisIndex, position);
+          if (!polygon.length) continue;
+          if (!groups.has(tet.group))
+            groups.set(tet.group, { faces: [], edges: [] });
+          const output = groups.get(tet.group);
+          for (let i = 1; i < polygon.length - 1; i++)
+            output.faces.push(...polygon[0], ...polygon[i], ...polygon[i + 1]);
+          for (let i = 0; i < polygon.length; i++)
+            output.edges.push(
+              ...polygon[i],
+              ...polygon[(i + 1) % polygon.length],
+            );
+        }
+        return groups;
+      }
+
+      function positionsForNodeTags(tags, nodes) {
+        const positions = new Float32Array(tags.length * 3);
+        tags.forEach((tag, index) => positions.set(nodes.get(tag), index * 3));
+        return positions;
+      }
+
+      function isPortGroup(mesh, group) {
+        return groupName(mesh, group).toLowerCase().startsWith("port_");
+      }
+
+      function colorFor(mesh, group) {
+        if (isPortGroup(mesh, group)) return new THREE.Color(0xf4f7fb);
+        if (!physicalGroupColors.has(group)) {
+          physicalGroupColors.set(
+            group,
+            physicalGroupPalette[
+              physicalGroupColors.size % physicalGroupPalette.length
+            ],
+          );
+        }
+        return new THREE.Color(physicalGroupColors.get(group));
+      }
+
+      function groupName(mesh, group) {
+        return mesh.names.get(group) ?? `Group ${group}`;
+      }
+
+      function shouldShow(mesh, group) {
+        const name = groupName(mesh, group);
+        if (
+          options.showGroups &&
+          !options.showGroups.includes(name) &&
+          !options.showGroups.includes(group)
+        )
+          return false;
+        return (
+          !options.hideGroups.includes(name) &&
+          !options.hideGroups.includes(group)
+        );
+      }
+
+      function tetrahedronVolume(tetrahedron, nodes) {
+        const [a, b, c, d] = tetrahedron.nodes.map((tag) => nodes.get(tag));
+        const ab = b.map((value, index) => value - a[index]);
+        const ac = c.map((value, index) => value - a[index]);
+        const ad = d.map((value, index) => value - a[index]);
+        const determinant =
+          ab[0] * (ac[1] * ad[2] - ac[2] * ad[1]) -
+          ab[1] * (ac[0] * ad[2] - ac[2] * ad[0]) +
+          ab[2] * (ac[0] * ad[1] - ac[1] * ad[0]);
+        return Math.abs(determinant) / 6;
+      }
+
+      function largestMaterialGroup(mesh, groups) {
+        const materialEntries = [...groups.entries()].filter(
+          ([group]) => !isPortGroup(mesh, group),
+        );
+        if (!materialEntries.length) return null;
+        const volumes = new Map();
+        for (const tetrahedron of mesh.tetrahedra) {
+          volumes.set(
+            tetrahedron.group,
+            (volumes.get(tetrahedron.group) ?? 0) +
+              tetrahedronVolume(tetrahedron, mesh.nodes),
+          );
+        }
+        const volumetricEntries = materialEntries.filter(([group]) =>
+          volumes.has(group),
+        );
+        const candidates = volumetricEntries.length
+          ? volumetricEntries
+          : materialEntries;
+        return candidates.reduce((largest, entry) => {
+          const entrySize =
+            volumes.get(entry[0]) ?? entry[1].faces?.length ?? entry[1].length;
+          const largestSize =
+            volumes.get(largest[0]) ??
+            largest[1].faces?.length ??
+            largest[1].length;
+          return entrySize > largestSize ? entry : largest;
+        })[0];
+      }
+
+      function orderedGroupEntries(mesh, groups) {
+        const entries = [...groups.entries()];
+        const materialEntries = entries.filter(
+          ([group]) => !isPortGroup(mesh, group),
+        );
+        const portEntries = entries.filter(([group]) =>
+          isPortGroup(mesh, group),
+        );
+        const largestGroup = largestMaterialGroup(mesh, groups);
+        if (largestGroup === null) return portEntries;
+        const largestEntry = materialEntries.find(
+          ([group]) => group === largestGroup,
+        );
+        return [
+          ...materialEntries.filter(([group]) => group !== largestGroup),
+          largestEntry,
+          ...portEntries,
+        ];
+      }
+
+      function disposeModel() {
+        if (!currentModel) return;
+        scene.remove(currentModel);
+        currentModel.traverse((item) => {
+          item.geometry?.dispose();
+          if (Array.isArray(item.material))
+            item.material.forEach((material) => material.dispose());
+          else item.material?.dispose();
+        });
+      }
+
+      function addRenderable(
+        root,
+        mesh,
+        group,
+        facePositions,
+        explicitEdges = null,
+        isLargestMaterial = false,
+      ) {
+        const rawGeometry = new THREE.BufferGeometry();
+        rawGeometry.setAttribute(
+          "position",
+          new THREE.BufferAttribute(facePositions, 3),
+        );
+        let geometry = rawGeometry;
+        if (isSlice) {
+          geometry.computeVertexNormals();
+        } else {
+          geometry = toCreasedNormals(rawGeometry, Math.PI / 3);
+          rawGeometry.dispose();
+        }
+        const color = colorFor(mesh, group);
+        const opacity = isLargestMaterial
+          ? isSlice
+            ? 0.55
+            : 0.35
+          : isSlice
+            ? 0.96
+            : 0.7;
+        const material = new THREE.MeshStandardMaterial({
+          color,
+          roughness: 0.72,
+          metalness: 0.04,
+          side:
+            isSlice || group.startsWith("2_")
+              ? THREE.DoubleSide
+              : THREE.FrontSide,
+          transparent: true,
+          opacity,
+          depthWrite: isSlice && !isLargestMaterial,
+          polygonOffset: true,
+          polygonOffsetFactor: 1,
+          polygonOffsetUnits: 1,
+        });
+        const face = new THREE.Mesh(geometry, material);
+        const groupRoot = new THREE.Group();
+        groupRoot.add(face);
+        if (showEdges) {
+          const lineGeometry = explicitEdges
+            ? new THREE.BufferGeometry()
+            : new THREE.WireframeGeometry(geometry);
+          if (explicitEdges)
+            lineGeometry.setAttribute(
+              "position",
+              new THREE.BufferAttribute(explicitEdges, 3),
+            );
+          const lines = new THREE.LineSegments(
+            lineGeometry,
+            new THREE.LineBasicMaterial({
+              color: 0xe8eef7,
+              transparent: true,
+              opacity: 0.32,
+            }),
+          );
+          groupRoot.add(lines);
+        }
+        groupRoot.visible = shouldShow(mesh, group);
+        root.add(groupRoot);
+        groupRoots.set(group, groupRoot);
+      }
+
+      function buildModel(mesh) {
+        disposeModel();
+        groupRoots = new Map();
+        const root = new THREE.Group();
+        if (isSlice) {
+          const groups = slicedGroups(mesh, slicePosition);
+          const largestGroup = largestMaterialGroup(mesh, groups);
+          for (const [group, data] of orderedGroupEntries(mesh, groups)) {
+            addRenderable(
+              root,
+              mesh,
+              group,
+              new Float32Array(data.faces),
+              new Float32Array(data.edges),
+              group === largestGroup,
+            );
+          }
+        } else {
+          const groups = surfaceGroups(mesh);
+          const largestGroup = largestMaterialGroup(mesh, groups);
+          for (const [group, tags] of orderedGroupEntries(mesh, groups)) {
+            addRenderable(
+              root,
+              mesh,
+              group,
+              positionsForNodeTags(tags, mesh.nodes),
+              null,
+              group === largestGroup,
+            );
+          }
+        }
+        scene.add(root);
+        currentModel = root;
+        buildGroupControls(mesh);
+        frameCamera(root);
+        const triangles = [...root.children].reduce(
+          (total, child) =>
+            total + child.children[0].geometry.attributes.position.count / 3,
+          0,
+        );
+        statsPanel.textContent = `${mesh.nodes.size.toLocaleString()} nodes \u00b7 ${Math.round(triangles).toLocaleString()} visible triangles`;
+      }
+
+      function buildGroupControls(mesh) {
+        const container = document.getElementById("groups");
+        container.innerHTML = "";
+        for (const [group, root] of groupRoots) {
+          const button = document.createElement("button");
+          button.className = "group-button";
+          button.textContent = groupName(mesh, group);
+          button.style.setProperty(
+            "--group-color",
+            `#${colorFor(mesh, group).getHexString()}`,
+          );
+          button.classList.toggle("off", !root.visible);
+          button.addEventListener("click", () => {
+            root.visible = !root.visible;
+            button.classList.toggle("off", !root.visible);
+          });
+          container.appendChild(button);
+        }
+      }
+
+      function makeControls() {
+        controls?.dispose();
+        controls = new OrbitControls(camera, renderer.domElement);
+        controls.enableDamping = true;
+        controls.dampingFactor = 0.06;
+        controls.screenSpacePanning = true;
+        controls.zoomToCursor = true;
+        controls.enableRotate = !isSlice;
+      }
+
+      function frameCamera(root) {
+        const box = new THREE.Box3().setFromObject(root);
+        if (box.isEmpty()) return;
+        const center = box.getCenter(new THREE.Vector3());
+        const size = box.getSize(new THREE.Vector3());
+        const radius = Math.max(size.length() / 2, 0.01);
+        if (isSlice) {
+          const planeSizes =
+            axisIndex === 0
+              ? [size.y, size.z]
+              : axisIndex === 1
+                ? [size.x, size.z]
+                : [size.x, size.y];
+          const aspect = window.innerWidth / window.innerHeight;
+          orthographicHalfHeight =
+            Math.max(planeSizes[1] / 2, planeSizes[0] / (2 * aspect), 0.01) *
+            1.12;
+          camera = new THREE.OrthographicCamera(
+            -orthographicHalfHeight * aspect,
+            orthographicHalfHeight * aspect,
+            orthographicHalfHeight,
+            -orthographicHalfHeight,
+            0.001,
+            radius * 20 + 1,
+          );
+          camera.position
+            .copy(center)
+            .addScaledVector(axisVectors[axisIndex], radius * 3 + 1);
+          camera.up.set(0, axisIndex === 2 ? 1 : 0, axisIndex === 2 ? 0 : 1);
+        } else {
+          camera = new THREE.PerspectiveCamera(
+            48,
+            window.innerWidth / window.innerHeight,
+            Math.max(radius / 100, 0.001),
+            radius * 100 + 1,
+          );
+          camera.up.copy(zUp);
+          camera.position
+            .copy(center)
+            .add(new THREE.Vector3(radius * 1.8, radius * -1.5, radius * 1.8));
+        }
+        camera.lookAt(center);
+        makeControls();
+        controls.target.copy(center);
+        controls.update();
+      }
+
+      function snapCamera(direction) {
+        if (!camera || !controls || isSlice) return;
+        const normalizedDirection = direction.clone().normalize();
+        const center = controls.target.clone();
+        const distance = Math.max(camera.position.distanceTo(center), 0.001);
+        const targetUp =
+          Math.abs(normalizedDirection.dot(zUp)) > 0.999
+            ? new THREE.Vector3(0, 1, 0)
+            : zUp.clone();
+        cameraAnimation = {
+          center,
+          duration: 0.35,
+          elapsed: 0,
+          startPosition: camera.position.clone(),
+          startUp: camera.up.clone(),
+          targetPosition: center
+            .clone()
+            .addScaledVector(normalizedDirection, distance),
+          targetUp,
+        };
+        controls.enabled = false;
+      }
+
+      function updateCameraAnimation(delta) {
+        if (!cameraAnimation) return;
+        cameraAnimation.elapsed += delta;
+        const progress = Math.min(
+          cameraAnimation.elapsed / cameraAnimation.duration,
+          1,
+        );
+        const eased = 1 - (1 - progress) ** 3;
+        camera.position.lerpVectors(
+          cameraAnimation.startPosition,
+          cameraAnimation.targetPosition,
+          eased,
+        );
+        camera.up
+          .lerpVectors(cameraAnimation.startUp, cameraAnimation.targetUp, eased)
+          .normalize();
+        camera.lookAt(cameraAnimation.center);
+        if (progress === 1) {
+          cameraAnimation = undefined;
+          controls.enabled = true;
+        }
+      }
+
+      function updateOrientationGizmo() {
+        if (!camera || isSlice) return;
+        const inverseCameraRotation = camera.quaternion.clone().invert();
+        for (const [axis, direction] of Object.entries(orientationAxes)) {
+          const projected = direction
+            .clone()
+            .applyQuaternion(inverseCameraRotation);
+          const x = 56 + projected.x * 34;
+          const y = 56 - projected.y * 34;
+          const line = document.getElementById(`gizmo-${axis}-line`);
+          const target = document.getElementById(`gizmo-${axis}-target`);
+          line.setAttribute("x2", x);
+          line.setAttribute("y2", y);
+          target.setAttribute("transform", `translate(${x} ${y})`);
+          const opacity = 0.55 + 0.45 * ((projected.z + 1) / 2);
+          line.style.opacity = opacity;
+          target.style.opacity = opacity;
+        }
+      }
+
+      function activateOnKeyboard(element, callback) {
+        element.addEventListener("click", callback);
+        element.addEventListener("keydown", (event) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          callback();
+        });
+      }
+
+      for (const [axis, direction] of Object.entries(orientationAxes)) {
+        activateOnKeyboard(
+          document.getElementById(`gizmo-${axis}-target`),
+          () => snapCamera(direction),
+        );
+      }
+      activateOnKeyboard(document.getElementById("gizmo-center-target"), () =>
+        snapCamera(defaultViewDirection),
+      );
+
+      function configureSlice(mesh) {
+        if (!isSlice) return;
+        let minimum = Infinity;
+        let maximum = -Infinity;
+        for (const point of mesh.nodes.values()) {
+          minimum = Math.min(minimum, point[axisIndex]);
+          maximum = Math.max(maximum, point[axisIndex]);
+        }
+        if (slicePosition === null || slicePosition === undefined)
+          slicePosition = (minimum + maximum) / 2;
+        if (slicePosition < minimum || slicePosition > maximum)
+          throw new Error(
+            `Slice ${options.axis}=${slicePosition} \u00b5m is outside [${minimum}, ${maximum}] \u00b5m`,
+          );
+        const slider = document.getElementById("slice");
+        document.getElementById("slice-section").hidden = false;
+        slider.min = minimum;
+        slider.max = maximum;
+        slider.step = "any";
+        slider.value = slicePosition;
+        const label = document.getElementById("slice-value");
+        const updateLabel = () =>
+          (label.textContent = `${options.axis} = ${slicePosition.toFixed(4)} \u00b5m`);
+        updateLabel();
+        slider.addEventListener("input", () => {
+          slicePosition = Number(slider.value);
+          updateLabel();
+          cancelAnimationFrame(rebuildFrame);
+          rebuildFrame = requestAnimationFrame(() => buildModel(mesh));
+        });
+      }
+
+      function resize() {
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        if (!camera) return;
+        const aspect = window.innerWidth / window.innerHeight;
+        if (camera.isPerspectiveCamera) camera.aspect = aspect;
+        else {
+          camera.left = -orthographicHalfHeight * aspect;
+          camera.right = orthographicHalfHeight * aspect;
+        }
+        camera.updateProjectionMatrix();
+      }
+
+      function animate() {
+        requestAnimationFrame(animate);
+        const delta = clock.getDelta();
+        updateCameraAnimation(delta);
+        controls?.update();
+        updateOrientationGizmo();
+        if (camera) {
+          renderer.render(scene, camera);
+        }
+      }
+
+      try {
+        const mesh = parseGmsh(meshText);
+        configureSlice(mesh);
+        buildModel(mesh);
+      } catch (error) {
+        console.error(error);
+        document.getElementById("error").textContent = error.message;
+        statsPanel.hidden = false;
+        statsPanel.textContent = "Viewer failed to load";
+      }
+      window.addEventListener("resize", resize);
+      animate();
+    </script>
+  </body>
+</html>

--- a/src/gsim/fdtd/cloud.py
+++ b/src/gsim/fdtd/cloud.py
@@ -1,0 +1,130 @@
+"""Cloud lifecycle mixin for an FDTD simulation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from gsim.fdtd.models import SimulationArtifacts
+
+
+class CloudWorkflowMixin:
+    """Upload, start, monitor, and retrieve a simulation through gcloud."""
+
+    _job_id: str | None
+    _input_hash: str | None
+    _config_dir: Path | None
+
+    if TYPE_CHECKING:
+
+        def write(self, output_dir: str | Path) -> SimulationArtifacts:
+            """Write the simulation artifacts consumed by the cloud workflow."""
+            ...
+
+    def _prepare_upload_dir(self) -> Path:
+        """Generate upload artifacts in a fresh temporary directory."""
+        import tempfile
+
+        directory = Path(tempfile.mkdtemp(prefix="fdtd_"))
+        self.write(directory)
+        self._config_dir = directory
+        return directory
+
+    def upload(self, *, verbose: bool = True) -> str:
+        """Generate and upload artifacts without starting the cloud job."""
+        from gsim import gcloud
+        from gsim.hashing import compute_input_hash
+
+        directory = self._prepare_upload_dir()
+        self._input_hash = compute_input_hash(directory, "fdtd")
+        self._job_id = gcloud.upload(
+            directory,
+            "fdtd",
+            verbose=verbose,
+            input_hash=self._input_hash,
+        )
+        return self._job_id
+
+    def start(self, *, verbose: bool = True) -> None:
+        """Start the previously uploaded cloud job."""
+        from gsim import gcloud
+
+        if self._job_id is None:
+            raise ValueError("Call upload() first")
+        gcloud.start(self._job_id, verbose=verbose)
+
+    def get_status(self) -> str:
+        """Return the current cloud job status."""
+        from gsim import gcloud
+
+        if self._job_id is None:
+            raise ValueError("No job submitted yet")
+        return gcloud.get_status(self._job_id)
+
+    def wait_for_results(
+        self,
+        *,
+        verbose: Literal["quiet", "status", "full"] = "status",
+        parent_dir: str | Path | None = None,
+        poll_interval: float = 5.0,
+    ) -> Any:
+        """Wait for, download, and parse the current cloud job."""
+        from gsim import gcloud
+
+        if self._job_id is None:
+            raise ValueError("No job submitted yet")
+        return gcloud.wait_for_results(
+            self._job_id,
+            verbose=verbose,
+            parent_dir=parent_dir,
+            poll_interval=poll_interval,
+        )
+
+    def run(
+        self,
+        parent_dir: str | Path | None = None,
+        *,
+        verbose: Literal["quiet", "status", "full"] = "status",
+        wait: bool = True,
+        check_cache: bool = False,
+        poll_interval: float = 5.0,
+    ) -> Any:
+        """Submit to cloud FDTD and optionally wait for typed results."""
+        from gsim import gcloud
+
+        if check_cache:
+            directory = self._prepare_upload_dir()
+            self._input_hash, cached_job_id = gcloud.check_cache_for_dir(
+                directory, "fdtd"
+            )
+            if cached_job_id is not None:
+                self._job_id = cached_job_id
+                if verbose != "quiet":
+                    print(f"Cache hit: reusing job {cached_job_id}")  # noqa: T201
+                if not wait:
+                    return self._job_id
+                return self.wait_for_results(
+                    verbose=verbose,
+                    parent_dir=parent_dir,
+                    poll_interval=poll_interval,
+                )
+            self._job_id = gcloud.upload(
+                directory,
+                "fdtd",
+                verbose=False,
+                input_hash=self._input_hash,
+            )
+        else:
+            self.upload(verbose=False)
+        self.start(verbose=verbose != "quiet")
+        if not wait:
+            return self._job_id
+        return self.wait_for_results(
+            verbose=verbose,
+            parent_dir=parent_dir,
+            poll_interval=poll_interval,
+        )
+
+
+__all__ = ["CloudWorkflowMixin"]

--- a/src/gsim/fdtd/config.py
+++ b/src/gsim/fdtd/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from gsim.common.materials import MaterialSnapshot
 from gsim.fdtd.models import FDTDConfigError, MeshManifest
@@ -57,6 +57,7 @@ class GeometryConfig(_StrictModel):
 
 
 Vector3 = tuple[float, float, float]
+Axis = Literal["x", "y", "z"]
 SignedAxis = Literal["+x", "-x", "+y", "-y", "+z", "-z"]
 
 
@@ -73,6 +74,22 @@ class GaussianBeamConfig(_StrictModel):
     refractive_index: float = Field(gt=0)
 
 
+class DipoleConfig(_StrictModel):
+    """Single-cell electric-current source."""
+
+    position: Vector3
+    current_axis: Axis
+
+
+class LineCurrentConfig(_StrictModel):
+    """Line of in-phase electric-current sources."""
+
+    position: Vector3
+    line_axis: Axis
+    current_axis: Axis
+    length: float = Field(gt=0)
+
+
 class FiberModeConfig(_StrictModel):
     """Analytic Gaussian fiber profile used by a plane monitor."""
 
@@ -81,6 +98,23 @@ class FiberModeConfig(_StrictModel):
     focal_point: Vector3
     waist_radius: float = Field(gt=0)
     refractive_index: float = Field(gt=0)
+
+
+class HeatmapConfig(_StrictModel):
+    """Scalar field images requested from a plane monitor."""
+
+    quantity: Literal[
+        "abs_e", "intensity", "abs_h", "ex", "ey", "ez", "hx", "hy", "hz"
+    ] = "intensity"
+    wavelengths: list[float] = Field(min_length=1)
+
+    @field_validator("wavelengths")
+    @classmethod
+    def validate_wavelengths(cls, values: list[float]) -> list[float]:
+        """Require physical heatmap wavelengths."""
+        if any(value <= 0 for value in values):
+            raise ValueError("heatmap wavelengths must be positive")
+        return values
 
 
 class PlaneMonitorConfig(_StrictModel):
@@ -92,6 +126,7 @@ class PlaneMonitorConfig(_StrictModel):
     normal: SignedAxis
     flux: bool = True
     wavelengths: list[float] | None = None
+    heatmap: HeatmapConfig | None = None
     fiber_mode: FiberModeConfig | None = None
 
     @model_validator(mode="after")
@@ -115,13 +150,15 @@ class PlaneMonitorConfig(_StrictModel):
 class ExcitationConfig(_StrictModel):
     """Initial eigenmode pulse configuration."""
 
-    type: Literal["eigenmode", "gaussian_beam"] = "eigenmode"
+    type: Literal["eigenmode", "dipole", "line_current", "gaussian_beam"] = "eigenmode"
     waveform: Literal["pulse", "continuous_wave"] = "pulse"
     center_wavelength: float = Field(gt=0)
     wavelength_halfspan: float = Field(ge=0)
     num_wavelengths: int = Field(ge=1)
     amplitude: float = 1.0
     default_port: str | None = Field(default=None, min_length=1)
+    dipole: DipoleConfig | None = None
+    line_current: LineCurrentConfig | None = None
     gaussian_beam: GaussianBeamConfig | None = None
 
     @model_validator(mode="after")
@@ -133,16 +170,24 @@ class ExcitationConfig(_StrictModel):
             raise ValueError("continuous_wave requires num_wavelengths=1")
         if self.amplitude == 0:
             raise ValueError("excitation amplitude cannot be zero")
+        source_blocks = {
+            "dipole": self.dipole,
+            "line_current": self.line_current,
+            "gaussian_beam": self.gaussian_beam,
+        }
         if self.type == "eigenmode":
             if self.default_port is None:
                 raise ValueError("eigenmode excitation requires default_port")
-            if self.gaussian_beam is not None:
-                raise ValueError("eigenmode excitation cannot include gaussian_beam")
-        else:
-            if self.gaussian_beam is None:
-                raise ValueError("gaussian_beam excitation requires its settings")
-            if self.default_port is not None:
-                raise ValueError("gaussian_beam excitation cannot use default_port")
+            if any(block is not None for block in source_blocks.values()):
+                raise ValueError("eigenmode excitation cannot include a source block")
+            return self
+        if self.default_port is not None:
+            raise ValueError(f"{self.type} excitation cannot use default_port")
+        for source_type, block in source_blocks.items():
+            if (source_type == self.type) != (block is not None):
+                raise ValueError(
+                    f"{self.type} excitation requires only its matching source block"
+                )
         return self
 
 
@@ -233,6 +278,7 @@ def build_fdtd_config(
     max_timesteps: int | None,
     energy_decay_fraction: float,
     max_wall_seconds: float,
+    excitation: ExcitationConfig | None = None,
     gaussian_beam: GaussianBeamConfig | None = None,
     monitors: list[PlaneMonitorConfig] | None = None,
 ) -> FDTDConfig:
@@ -274,7 +320,8 @@ def build_fdtd_config(
                 for name, group in manifest.ports.items()
             },
         ),
-        excitation=ExcitationConfig(
+        excitation=excitation
+        or ExcitationConfig(
             type="gaussian_beam" if gaussian_beam is not None else "eigenmode",
             center_wavelength=center_wavelength_nm,
             wavelength_halfspan=wavelength_halfspan_nm,
@@ -296,12 +343,15 @@ def build_fdtd_config(
 
 
 __all__ = [
+    "DipoleConfig",
     "ExcitationConfig",
     "FDTDConfig",
     "FiberModeConfig",
     "GaussianBeamConfig",
     "GeometryConfig",
     "GridConfig",
+    "HeatmapConfig",
+    "LineCurrentConfig",
     "MaterialConfig",
     "PlaneMonitorConfig",
     "PortConfig",

--- a/src/gsim/fdtd/results.py
+++ b/src/gsim/fdtd/results.py
@@ -1,0 +1,517 @@
+"""Typed loading, tabulation, and plotting of ZapFDTD output."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+_S_PARAMETER_PATTERN = re.compile(r"S\(([^,]+),([^\)]+)\)")
+
+
+@dataclass(frozen=True)
+class ComplexTrace:
+    """A complex spectral trace plus optional backend-derived quantities."""
+
+    values: np.ndarray
+    valid: np.ndarray
+    modal_power: np.ndarray | None = None
+    power_fraction: np.ndarray | None = None
+
+    @classmethod
+    def from_samples(
+        cls, samples: list[Mapping[str, Any]], valid: np.ndarray
+    ) -> ComplexTrace:
+        """Build a trace from ZapFDTD's list-of-records representation."""
+        values = np.asarray(
+            [complex(sample.get("re", 0), sample.get("im", 0)) for sample in samples]
+        )
+        if len(values) != len(valid):
+            raise ValueError("spectral trace length does not match frequencies")
+        modal_power = _optional_array(samples, "modal_power")
+        power_fraction = _optional_array(samples, "power_fraction")
+        return cls(values, valid.copy(), modal_power, power_fraction)
+
+    @property
+    def magnitude(self) -> np.ndarray:
+        """Return linear complex magnitude."""
+        return np.abs(self.values)
+
+    @property
+    def magnitude_db(self) -> np.ndarray:
+        """Return amplitude magnitude in decibels."""
+        with np.errstate(divide="ignore"):
+            return 20 * np.log10(self.magnitude)
+
+    @property
+    def phase_deg(self) -> np.ndarray:
+        """Return complex phase in degrees."""
+        return np.angle(self.values, deg=True)
+
+
+def _optional_array(
+    samples: list[Mapping[str, Any]], field_name: str
+) -> np.ndarray | None:
+    """Load an optional scalar field shared by every spectral sample."""
+    if not samples or any(field_name not in sample for sample in samples):
+        return None
+    return np.asarray([sample[field_name] for sample in samples], dtype=float)
+
+
+class _TraceCollection:
+    """Shared dataframe and plotting behavior for spectral trace mappings."""
+
+    def __init__(
+        self,
+        traces: Mapping[Any, ComplexTrace],
+        wavelength_um: np.ndarray,
+        frequency_hz: np.ndarray,
+    ) -> None:
+        """Store spectral traces and their shared wavelength coordinates."""
+        self._traces = dict(traces)
+        self.wavelength_um = wavelength_um
+        self.frequency_hz = frequency_hz
+
+    def __len__(self) -> int:
+        """Return the number of spectral traces."""
+        return len(self._traces)
+
+    def __iter__(self) -> Iterator[Any]:
+        """Iterate over spectral trace keys."""
+        return iter(self._traces)
+
+    def items(self):
+        """Return trace key-value pairs."""
+        return self._traces.items()
+
+    def plot(
+        self,
+        *,
+        quantity: str = "magnitude_db",
+        mask_invalid: bool = True,
+        ax: Any = None,
+    ) -> tuple[Any, Any]:
+        """Plot all traces against wavelength, gapping invalid samples."""
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            _, ax = plt.subplots()
+        for key, trace in self.items():
+            values = np.asarray(getattr(trace, quantity), dtype=float).copy()
+            if mask_invalid:
+                values[~trace.valid] = np.nan
+            ax.plot(self.wavelength_um, values, label=self._label(key))
+        ax.set_xlabel("Wavelength (µm)")
+        ax.set_ylabel(_quantity_label(quantity))
+        if self._traces:
+            ax.legend()
+        return ax.figure, ax
+
+    def plot_plotly(
+        self, *, quantity: str = "magnitude_db", mask_invalid: bool = True
+    ) -> Any:
+        """Return an interactive Plotly plot fitted to finite result samples."""
+        import plotly.graph_objects as go
+
+        figure = go.Figure()
+        plotted_wavelengths = []
+        for key, trace in self.items():
+            values = np.asarray(getattr(trace, quantity), dtype=float).copy()
+            if mask_invalid:
+                values[~trace.valid] = np.nan
+            finite = np.isfinite(values) & np.isfinite(self.wavelength_um)
+            plotted_wavelengths.extend(self.wavelength_um[finite])
+            figure.add_scatter(
+                x=self.wavelength_um,
+                y=values,
+                mode="lines",
+                name=self._label(key),
+            )
+        figure.update_layout(
+            xaxis_title="Wavelength (µm)", yaxis_title=_quantity_label(quantity)
+        )
+        if plotted_wavelengths:
+            x_min = float(np.min(plotted_wavelengths))
+            x_max = float(np.max(plotted_wavelengths))
+            if x_min < x_max:
+                figure.update_xaxes(range=[x_min, x_max])
+        return figure
+
+    @staticmethod
+    def _label(key: Any) -> str:
+        """Format a generic trace key for plot legends."""
+        return str(key)
+
+
+def _quantity_label(quantity: str) -> str:
+    """Return a human-readable axis label for a plotted quantity."""
+    labels = {
+        "magnitude": "Magnitude",
+        "magnitude_db": "Magnitude (dB)",
+        "phase_deg": "Phase (degrees)",
+        "modal_power": "Modal power",
+        "power_fraction": "Power fraction",
+    }
+    if quantity not in labels:
+        raise ValueError(f"Unknown plot quantity {quantity!r}")
+    return labels[quantity]
+
+
+class SParameterResults(_TraceCollection):
+    """One S-matrix column from an eigenmode-source simulation."""
+
+    def __getitem__(self, key: str | tuple[str, str]) -> ComplexTrace:
+        """Return one trace by tuple key or ``S(receive,source)`` string."""
+        if isinstance(key, str):
+            match = _S_PARAMETER_PATTERN.fullmatch(key)
+            if match is None:
+                raise KeyError(key)
+            key = (match.group(1), match.group(2))
+        return self._traces[key]
+
+    @staticmethod
+    def _label(key: tuple[str, str]) -> str:
+        """Format an S-parameter tuple for plot legends."""
+        return f"S({key[0]},{key[1]})"
+
+    def to_dataframe(self) -> Any:
+        """Return one tidy row per S-parameter and wavelength."""
+        import pandas as pd
+
+        records = []
+        for (receive_port, source_port), trace in self.items():
+            for index, wavelength_um in enumerate(self.wavelength_um):
+                records.append(
+                    {
+                        "wavelength_um": wavelength_um,
+                        "frequency_hz": self.frequency_hz[index],
+                        "receive_port": receive_port,
+                        "source_port": source_port,
+                        "real": trace.values[index].real,  # noqa: PD011
+                        "imaginary": trace.values[index].imag,  # noqa: PD011
+                        "magnitude": trace.magnitude[index],
+                        "magnitude_db": trace.magnitude_db[index],
+                        "phase_deg": trace.phase_deg[index],
+                        "valid": bool(trace.valid[index]),
+                    }
+                )
+        return pd.DataFrame.from_records(records)
+
+
+class PortOutputResults(_TraceCollection):
+    """Outgoing port amplitudes from a non-eigenmode source."""
+
+    def __getitem__(self, port: str) -> ComplexTrace:
+        """Return the outgoing trace for one port."""
+        return self._traces[port]
+
+    def to_dataframe(self) -> Any:
+        """Return one tidy row per port and wavelength."""
+        import pandas as pd
+
+        records = []
+        for port, trace in self.items():
+            for index, wavelength_um in enumerate(self.wavelength_um):
+                records.append(
+                    {
+                        "wavelength_um": wavelength_um,
+                        "frequency_hz": self.frequency_hz[index],
+                        "port": port,
+                        "real": trace.values[index].real,  # noqa: PD011
+                        "imaginary": trace.values[index].imag,  # noqa: PD011
+                        "modal_power": _array_value(trace.modal_power, index),
+                        "power_fraction": _array_value(trace.power_fraction, index),
+                        "valid": bool(trace.valid[index]),
+                    }
+                )
+        return pd.DataFrame.from_records(records)
+
+
+def _array_value(values: np.ndarray | None, index: int) -> float | None:
+    """Return one optional array sample as a scalar."""
+    return None if values is None else float(values[index])
+
+
+@dataclass(frozen=True)
+class HeatmapResult:
+    """Metadata and lazy file loading for one monitor heatmap."""
+
+    file: Path
+    quantity: str
+    wavelength_um: float
+    shape: tuple[int, int]
+
+    def load(self) -> np.ndarray:
+        """Load and validate the referenced NumPy field image."""
+        values = np.load(self.file)
+        if values.shape != self.shape:
+            raise ValueError(
+                f"heatmap {self.file.name!r} has shape {values.shape}, "
+                f"expected {self.shape}"
+            )
+        return values
+
+
+@dataclass
+class PlaneMonitorResult:
+    """Flux, heatmaps, and optional fiber response from one plane monitor."""
+
+    name: str
+    normal_axis: str
+    normal_sign: int
+    u_axis: str
+    v_axis: str
+    plane_position_um: float
+    u_extent_um: tuple[float, float]
+    v_extent_um: tuple[float, float]
+    shape: tuple[int, int]
+    wavelength_um: np.ndarray
+    flux: np.ndarray | None = None
+    heatmaps: list[HeatmapResult] = field(default_factory=list)
+    coupling_efficiency: ComplexTrace | None = None
+    fiber_amplitude: ComplexTrace | None = None
+
+    def plot_flux(self, *, ax: Any = None) -> tuple[Any, Any]:
+        """Plot signed outward flux against wavelength."""
+        import matplotlib.pyplot as plt
+
+        if self.flux is None:
+            raise ValueError(f"monitor {self.name!r} has no flux data")
+        if ax is None:
+            _, ax = plt.subplots()
+        ax.plot(self.wavelength_um, self.flux)
+        ax.set_xlabel("Wavelength (µm)")
+        ax.set_ylabel("Outward flux")
+        ax.set_title(self.name)
+        return ax.figure, ax
+
+    def heatmap(
+        self, *, wavelength_um: float, quantity: str | None = None
+    ) -> HeatmapResult:
+        """Select the closest available heatmap at a requested wavelength."""
+        candidates = [
+            result
+            for result in self.heatmaps
+            if quantity is None or result.quantity == quantity
+        ]
+        if not candidates:
+            raise KeyError(f"monitor {self.name!r} has no matching heatmaps")
+        return min(candidates, key=lambda item: abs(item.wavelength_um - wavelength_um))
+
+    def plot_heatmap(
+        self,
+        *,
+        wavelength_um: float,
+        quantity: str | None = None,
+        ax: Any = None,
+        **imshow_kwargs: Any,
+    ) -> tuple[Any, Any]:
+        """Plot one lazy-loaded heatmap with its physical plane coordinates."""
+        import matplotlib.pyplot as plt
+
+        selected = self.heatmap(wavelength_um=wavelength_um, quantity=quantity)
+        if ax is None:
+            _, ax = plt.subplots()
+        image = ax.imshow(
+            selected.load(),
+            origin="lower",
+            aspect="auto",
+            extent=(*self.u_extent_um, *self.v_extent_um),
+            **imshow_kwargs,
+        )
+        ax.set_xlabel(f"{self.u_axis} (µm)")
+        ax.set_ylabel(f"{self.v_axis} (µm)")
+        ax.set_title(
+            f"{self.name}: {selected.quantity} at {selected.wavelength_um:g} µm"
+        )
+        ax.figure.colorbar(image, ax=ax)
+        return ax.figure, ax
+
+
+class MonitorResults(dict[str, PlaneMonitorResult]):
+    """Plane-monitor results keyed by the names configured on the simulation."""
+
+
+@dataclass
+class FDTDResult:
+    """Complete typed result from one ZapFDTD cloud run."""
+
+    excitation_type: str
+    excited_port: str | None
+    ports: list[str]
+    wavelength_um: np.ndarray
+    frequency_hz: np.ndarray
+    valid: np.ndarray
+    s_parameters: SParameterResults
+    port_outputs: PortOutputResults
+    monitors: MonitorResults
+    convergence: dict[str, Any]
+    grid: dict[str, Any]
+    timing: dict[str, Any]
+    config_resolved: dict[str, Any]
+    output_path: Path
+    sim_dir: Path | None = None
+    job_name: str = ""
+    files: dict[str, Path] = field(default_factory=dict)
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        *,
+        files: Mapping[str, Path] | None = None,
+        sim_dir: str | Path | None = None,
+        job_name: str = "",
+    ) -> FDTDResult:
+        """Load a result JSON and lazy references to any heatmap sidecars."""
+        output_path = Path(path)
+        document = json.loads(output_path.read_text(encoding="utf8"))
+        wavelength_um = (
+            np.asarray(document["frequencies"]["wavelength_nm"], dtype=float) / 1000
+        )
+        frequency_hz = np.asarray(document["frequencies"]["hz"], dtype=float)
+        below_noise = document["frequencies"].get(
+            "below_noise_floor", [False] * len(wavelength_um)
+        )
+        valid = ~np.asarray(below_noise, dtype=bool)
+        s_traces = {}
+        for name, samples in document.get("s_parameters", {}).items():
+            match = _S_PARAMETER_PATTERN.fullmatch(name)
+            if match is None:
+                raise ValueError(f"Invalid S-parameter name {name!r}")
+            s_traces[(match.group(1), match.group(2))] = ComplexTrace.from_samples(
+                samples, valid
+            )
+        port_traces = {
+            name: ComplexTrace.from_samples(samples, valid)
+            for name, samples in document.get("port_outputs", {}).items()
+        }
+        file_map = {name: Path(value) for name, value in (files or {}).items()}
+        monitors = MonitorResults(
+            {
+                name: _parse_monitor(name, data, output_path.parent, file_map, valid)
+                for name, data in document.get("plane_monitors", {}).items()
+            }
+        )
+        return cls(
+            excitation_type=document["excitation_type"],
+            excited_port=document.get("excited_port"),
+            ports=list(document.get("ports", [])),
+            wavelength_um=wavelength_um,
+            frequency_hz=frequency_hz,
+            valid=valid,
+            s_parameters=SParameterResults(s_traces, wavelength_um, frequency_hz),
+            port_outputs=PortOutputResults(port_traces, wavelength_um, frequency_hz),
+            monitors=monitors,
+            convergence=dict(document.get("convergence", {})),
+            grid=dict(document.get("grid", {})),
+            timing=dict(document.get("timing", {})),
+            config_resolved=dict(document.get("config_resolved", {})),
+            output_path=output_path,
+            sim_dir=Path(sim_dir) if sim_dir is not None else None,
+            job_name=job_name,
+            files=file_map,
+        )
+
+    @classmethod
+    def from_run_result(cls, run_result: Any) -> FDTDResult:
+        """Locate and parse ZapFDTD output downloaded by :mod:`gsim.gcloud`."""
+        candidates = [
+            Path(path)
+            for name, path in run_result.files.items()
+            if name.endswith(".json") and Path(name).stem.startswith("sparams")
+        ]
+        if not candidates:
+            candidates = list(Path(run_result.sim_dir).rglob("sparams*.json"))
+        if not candidates:
+            raise FileNotFoundError("No sparams*.json file found in FDTD results")
+        return cls.from_file(
+            candidates[0],
+            files=run_result.files,
+            sim_dir=run_result.sim_dir,
+            job_name=run_result.job_name,
+        )
+
+    def plot(self, **kwargs: Any) -> tuple[Any, Any]:
+        """Plot S-parameters, or port power for a non-eigenmode source."""
+        if self.s_parameters:
+            return self.s_parameters.plot(**kwargs)
+        kwargs.setdefault("quantity", "modal_power")
+        return self.port_outputs.plot(**kwargs)
+
+    def plot_plotly(self, **kwargs: Any) -> Any:
+        """Interactively plot S-parameters, or non-eigenmode port power."""
+        if self.s_parameters:
+            return self.s_parameters.plot_plotly(**kwargs)
+        kwargs.setdefault("quantity", "modal_power")
+        return self.port_outputs.plot_plotly(**kwargs)
+
+
+def _parse_monitor(
+    name: str,
+    data: Mapping[str, Any],
+    output_dir: Path,
+    files: Mapping[str, Path],
+    valid: np.ndarray,
+) -> PlaneMonitorResult:
+    """Parse one plane-monitor record and resolve lazy heatmap paths."""
+    wavelengths = np.asarray(data.get("wavelength_nm", []), dtype=float) / 1000
+    monitor_valid = (
+        valid
+        if len(valid) == len(wavelengths)
+        else np.ones(len(wavelengths), dtype=bool)
+    )
+    heatmaps = []
+    for metadata in data.get("heatmaps", []):
+        filename = metadata["file"]
+        heatmaps.append(
+            HeatmapResult(
+                file=files.get(filename, output_dir / filename),
+                quantity=metadata["quantity"],
+                wavelength_um=float(metadata["wavelength_nm"]) / 1000,
+                shape=tuple(metadata["shape"]),
+            )
+        )
+    return PlaneMonitorResult(
+        name=name,
+        normal_axis=data["normal_axis"],
+        normal_sign=int(data["normal_sign"]),
+        u_axis=data["u_axis"],
+        v_axis=data["v_axis"],
+        plane_position_um=float(data["plane_position_nm"]) / 1000,
+        u_extent_um=tuple(value / 1000 for value in data["u_extent_nm"]),
+        v_extent_um=tuple(value / 1000 for value in data["v_extent_nm"]),
+        shape=tuple(data["shape"]),
+        wavelength_um=wavelengths,
+        flux=np.asarray(data["flux"], dtype=float) if "flux" in data else None,
+        heatmaps=heatmaps,
+        coupling_efficiency=_optional_complex_trace(
+            data.get("coupling_efficiency"), monitor_valid
+        ),
+        fiber_amplitude=_optional_complex_trace(
+            data.get("fiber_amplitude"), monitor_valid
+        ),
+    )
+
+
+def _optional_complex_trace(
+    samples: list[Mapping[str, Any]] | None, valid: np.ndarray
+) -> ComplexTrace | None:
+    """Parse an optional complex spectral trace."""
+    return None if samples is None else ComplexTrace.from_samples(samples, valid)
+
+
+__all__ = [
+    "ComplexTrace",
+    "FDTDResult",
+    "HeatmapResult",
+    "MonitorResults",
+    "PlaneMonitorResult",
+    "PortOutputResults",
+    "SParameterResults",
+]

--- a/src/gsim/fdtd/runtime.py
+++ b/src/gsim/fdtd/runtime.py
@@ -1,0 +1,344 @@
+"""Translation from public FDTD concerns to the ZapFDTD runtime schema."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import cos, radians, sin
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
+
+from gsim.common.materials import MaterialSnapshot
+from gsim.fdtd.api import (
+    DipoleSource,
+    FiberMode,
+    GaussianBeamSource,
+    LineCurrentSource,
+    PlaneMonitor,
+    PortSource,
+    Vector3,
+)
+from gsim.fdtd.config import (
+    DipoleConfig,
+    ExcitationConfig,
+    FDTDConfig,
+    FiberModeConfig,
+    GaussianBeamConfig,
+    HeatmapConfig,
+    LineCurrentConfig,
+    PlaneMonitorConfig,
+    build_fdtd_config,
+)
+from gsim.fdtd.mesh import background_bounds_nm
+from gsim.fdtd.models import FDTDConfigError, MeshManifest
+
+if TYPE_CHECKING:
+    from gsim.common.pdk import ResolvedPassivePcell
+    from gsim.fdtd.api import Domain, Materials, Monitors, Solver, SourceType
+
+
+def _scale_vector(vector: Vector3, factor: float) -> Vector3:
+    """Scale a fixed-length three-vector without losing its tuple type."""
+    return (
+        vector[0] * factor,
+        vector[1] * factor,
+        vector[2] * factor,
+    )
+
+
+class RuntimeConfigMixin:
+    """Serialize sources, monitors, and solver controls for ZapFDTD."""
+
+    source: SourceType
+    resolved: ResolvedPassivePcell
+    materials: Materials
+    monitors: Monitors
+    domain: Domain
+    solver: Solver
+
+    def _selected_port_name(self) -> str:
+        """Validate and return the explicitly selected source port."""
+        if not isinstance(self.source, PortSource):
+            raise TypeError("Port selection requires a PortSource")
+        if self.source.port is None:
+            raise FDTDConfigError(
+                "PortSource requires an explicit port. "
+                "Call simulation.source(port='...') before write() or run()."
+            )
+        if not self.resolved.ports:
+            raise FDTDConfigError("A PortSource requires at least one PDK port.")
+        if self.source.port not in self.resolved.ports:
+            raise FDTDConfigError(
+                f"source port {self.source.port!r} is not present on the component."
+            )
+        return self.source.port
+
+    @staticmethod
+    def _vertical_polarization(port: Any) -> tuple[float, float, float]:
+        """Map a vertical TE/TM marker into its in-plane E direction."""
+        angle = radians(port.orientation)
+        if port.port_type == "vertical_te":
+            vector = (-sin(angle), cos(angle), 0.0)
+        elif port.port_type == "vertical_tm":
+            vector = (cos(angle), sin(angle), 0.0)
+        else:
+            raise FDTDConfigError(f"Unsupported vertical port type {port.port_type!r}.")
+        return tuple(round(component, 12) for component in vector)
+
+    def _vertical_port_configs(
+        self, material_snapshots: Mapping[str, MaterialSnapshot]
+    ) -> dict[str, tuple[GaussianBeamConfig, PlaneMonitorConfig]]:
+        """Translate vertical PDK ports into beam and fiber-plane settings."""
+        if not isinstance(self.source, PortSource):
+            return {}
+        vertical_ports = {
+            name: port for name, port in self.resolved.ports.items() if port.is_vertical
+        }
+        if not vertical_ports:
+            return {}
+        bounds = background_bounds_nm(
+            self.resolved,
+            self.materials.background,
+            self.domain.padding_um,
+        )
+        background_index = material_snapshots[
+            self.materials.background
+        ].refractive_index
+        outward_sign = 1 if self.source.vertical_axis == "+z" else -1
+        aperture_z_nm = bounds[5] if outward_sign > 0 else bounds[2]
+        device_z_nm = self.resolved.bounds[1 if outward_sign > 0 else 0][2] * 1000
+        configs: dict[str, tuple[GaussianBeamConfig, PlaneMonitorConfig]] = {}
+        for name, port in vertical_ports.items():
+            aperture_width_um = self.source.vertical_aperture_width_um or port.width
+            waist_radius_um = (
+                self.source.vertical_waist_radius_um or aperture_width_um / 2
+            )
+            half_width_nm = aperture_width_um * 500
+            center_x_nm = port.center[0] * 1000
+            center_y_nm = port.center[1] * 1000
+            region_min = (
+                center_x_nm - half_width_nm,
+                center_y_nm - half_width_nm,
+                aperture_z_nm,
+            )
+            region_max = (
+                center_x_nm + half_width_nm,
+                center_y_nm + half_width_nm,
+                aperture_z_nm,
+            )
+            if (
+                region_min[0] < bounds[0]
+                or region_min[1] < bounds[1]
+                or region_max[0] > bounds[3]
+                or region_max[1] > bounds[4]
+            ):
+                raise FDTDConfigError(
+                    f"Vertical port {name!r} aperture exceeds the background domain; "
+                    "increase domain.padding_um or reduce its aperture width."
+                )
+            polarization = self._vertical_polarization(port)
+            focal_point = (center_x_nm, center_y_nm, device_z_nm)
+            configs[name] = (
+                GaussianBeamConfig(
+                    region_min=region_min,
+                    region_max=region_max,
+                    aperture_normal="-z" if outward_sign > 0 else "+z",
+                    propagation_direction=(0, 0, -outward_sign),
+                    e_polarization=polarization,
+                    focal_point=focal_point,
+                    waist_radius=waist_radius_um * 1000,
+                    refractive_index=background_index,
+                ),
+                PlaneMonitorConfig(
+                    name=name,
+                    region_min=region_min,
+                    region_max=region_max,
+                    normal=self.source.vertical_axis,
+                    fiber_mode=FiberModeConfig(
+                        propagation_direction=(0, 0, outward_sign),
+                        e_polarization=polarization,
+                        focal_point=focal_point,
+                        waist_radius=waist_radius_um * 1000,
+                        refractive_index=background_index,
+                    ),
+                ),
+            )
+        return configs
+
+    def _runtime_excitation(
+        self,
+        material_snapshots: Mapping[str, MaterialSnapshot],
+    ) -> tuple[ExcitationConfig, list[PlaneMonitorConfig]]:
+        """Translate the public source intent and additional monitors."""
+        source = self.source
+        common: dict[str, Any] = {
+            "waveform": source.waveform,
+            "center_wavelength": source.wavelength_um * 1000,
+            "wavelength_halfspan": source.wavelength_halfspan_um * 1000,
+            "num_wavelengths": source.num_wavelengths,
+            "amplitude": source.amplitude,
+        }
+        vertical_configs = self._vertical_port_configs(material_snapshots)
+        derived_monitors = [monitor for _, monitor in vertical_configs.values()]
+        if isinstance(source, PortSource):
+            selected_port = self._selected_port_name()
+            if self.resolved.ports[selected_port].is_vertical:
+                excitation = ExcitationConfig(
+                    type="gaussian_beam",
+                    gaussian_beam=vertical_configs[selected_port][0],
+                    **common,
+                )
+            else:
+                excitation = ExcitationConfig(
+                    type="eigenmode", default_port=selected_port, **common
+                )
+        elif isinstance(source, DipoleSource):
+            excitation = ExcitationConfig(
+                type="dipole",
+                dipole=DipoleConfig(
+                    position=_scale_vector(source.position_um, 1000),
+                    current_axis=source.current_axis,
+                ),
+                **common,
+            )
+        elif isinstance(source, LineCurrentSource):
+            excitation = ExcitationConfig(
+                type="line_current",
+                line_current=LineCurrentConfig(
+                    position=_scale_vector(source.position_um, 1000),
+                    line_axis=source.line_axis,
+                    current_axis=source.current_axis,
+                    length=source.length_um * 1000,
+                ),
+                **common,
+            )
+        else:
+            excitation = ExcitationConfig(
+                type="gaussian_beam",
+                gaussian_beam=self._explicit_gaussian_beam(source, material_snapshots),
+                **common,
+            )
+        public_monitors = [
+            self._plane_monitor_config(monitor, material_snapshots)
+            for monitor in self.monitors
+        ]
+        names = [monitor.name for monitor in [*derived_monitors, *public_monitors]]
+        if len(names) != len(set(names)):
+            raise FDTDConfigError(
+                "Explicit monitor names cannot shadow vertical ports."
+            )
+        return excitation, [*derived_monitors, *public_monitors]
+
+    def _explicit_gaussian_beam(
+        self,
+        source: GaussianBeamSource,
+        material_snapshots: Mapping[str, MaterialSnapshot],
+    ) -> GaussianBeamConfig:
+        """Translate an explicitly positioned public Gaussian beam."""
+        half_size_nm = tuple(value * 500 for value in source.size_um)
+        center_nm = tuple(value * 1000 for value in source.center_um)
+        return GaussianBeamConfig(
+            region_min=tuple(
+                center - half
+                for center, half in zip(center_nm, half_size_nm, strict=True)
+            ),
+            region_max=tuple(
+                center + half
+                for center, half in zip(center_nm, half_size_nm, strict=True)
+            ),
+            aperture_normal=source.aperture_normal,
+            propagation_direction=source.propagation_direction,
+            e_polarization=source.e_polarization,
+            focal_point=_scale_vector(source.focal_point_um, 1000),
+            waist_radius=source.waist_radius_um * 1000,
+            refractive_index=source.refractive_index
+            or material_snapshots[self.materials.background].refractive_index,
+        )
+
+    def _plane_monitor_config(
+        self,
+        monitor: PlaneMonitor,
+        material_snapshots: Mapping[str, MaterialSnapshot],
+    ) -> PlaneMonitorConfig:
+        """Translate one public plane-monitor definition."""
+        center_nm = tuple(value * 1000 for value in monitor.center_um)
+        half_size_nm = tuple(value * 500 for value in monitor.size_um)
+        fiber_mode = self._fiber_mode_config(monitor.fiber_mode, material_snapshots)
+        return PlaneMonitorConfig(
+            name=monitor.name,
+            region_min=tuple(
+                center - half
+                for center, half in zip(center_nm, half_size_nm, strict=True)
+            ),
+            region_max=tuple(
+                center + half
+                for center, half in zip(center_nm, half_size_nm, strict=True)
+            ),
+            normal=monitor.normal,
+            flux=monitor.flux,
+            wavelengths=(
+                [value * 1000 for value in monitor.wavelengths_um]
+                if monitor.wavelengths_um is not None
+                else None
+            ),
+            heatmap=(
+                HeatmapConfig(
+                    quantity=monitor.heatmap.quantity,
+                    wavelengths=[
+                        value * 1000 for value in monitor.heatmap.wavelengths_um
+                    ],
+                )
+                if monitor.heatmap is not None
+                else None
+            ),
+            fiber_mode=fiber_mode,
+        )
+
+    def _fiber_mode_config(
+        self,
+        fiber_mode: FiberMode | None,
+        material_snapshots: Mapping[str, MaterialSnapshot],
+    ) -> FiberModeConfig | None:
+        """Translate an optional analytic fiber mode."""
+        if fiber_mode is None:
+            return None
+        return FiberModeConfig(
+            propagation_direction=fiber_mode.propagation_direction,
+            e_polarization=fiber_mode.e_polarization,
+            focal_point=_scale_vector(fiber_mode.focal_point_um, 1000),
+            waist_radius=fiber_mode.waist_radius_um * 1000,
+            refractive_index=fiber_mode.refractive_index
+            or material_snapshots[self.materials.background].refractive_index,
+        )
+
+    def _config(
+        self,
+        manifest: MeshManifest,
+        material_snapshots: Mapping[str, MaterialSnapshot],
+    ) -> FDTDConfig:
+        """Build and cross-validate the runtime configuration."""
+        excitation, monitors = self._runtime_excitation(material_snapshots)
+        try:
+            return build_fdtd_config(
+                manifest,
+                material_snapshots,
+                background_material=self.materials.background,
+                center_wavelength_nm=self.source.wavelength_um * 1000,
+                wavelength_halfspan_nm=self.source.wavelength_halfspan_um * 1000,
+                num_wavelengths=self.source.num_wavelengths,
+                default_port=None,
+                nanometers_per_cell=self.solver.cell_size_nm,
+                pml_cells=self.domain.pml_cells,
+                max_timesteps=self.solver.max_timesteps,
+                energy_decay_fraction=self.solver.energy_decay_fraction,
+                max_wall_seconds=self.solver.max_wall_seconds,
+                excitation=excitation,
+                monitors=monitors,
+            )
+        except ValidationError as error:
+            raise FDTDConfigError(
+                f"Invalid GDSFactory FDTD configuration: {error}"
+            ) from error
+
+
+__all__ = ["RuntimeConfigMixin"]

--- a/src/gsim/fdtd/runtime.py
+++ b/src/gsim/fdtd/runtime.py
@@ -83,7 +83,11 @@ class RuntimeConfigMixin:
             vector = (cos(angle), sin(angle), 0.0)
         else:
             raise FDTDConfigError(f"Unsupported vertical port type {port.port_type!r}.")
-        return tuple(round(component, 12) for component in vector)
+        return (
+            round(vector[0], 12),
+            round(vector[1], 12),
+            round(vector[2], 12),
+        )
 
     def _vertical_port_configs(
         self, material_snapshots: Mapping[str, MaterialSnapshot]

--- a/src/gsim/fdtd/simulation.py
+++ b/src/gsim/fdtd/simulation.py
@@ -40,10 +40,10 @@ class Simulation:
     pdk: Any | None = None
     wavelength_um: float = 1.55
     background_material: str = "SiO2"
-    nanometers_per_cell: float = 31.25
+    nanometers_per_cell: float = 60.0
     pml_cells: int = 32
     wavelength_halfspan_um: float = 0.05
-    num_wavelengths: int = 11
+    num_wavelengths: int = 101
     default_port: str | None = None
     background_padding_um: float = 1.0
     mesh_size_nm: float = 500.0
@@ -182,18 +182,17 @@ class Simulation:
             ) from error
 
     def _selected_port_name(self) -> str:
-        """Choose an explicit port or prefer the first guided port by default."""
-        if self.default_port is not None:
-            if self.default_port not in self.resolved.ports:
-                raise FDTDConfigError(
-                    f"default_port {self.default_port!r} is not present on the "
-                    "resolved component."
-                )
-            return self.default_port
-        for name, port in self.resolved.ports.items():
-            if not port.is_vertical:
-                return name
-        return next(iter(self.resolved.ports))
+        """Validate and return the explicitly selected source port."""
+        if self.default_port is None:
+            raise FDTDConfigError(
+                "default_port is required before writing or running FDTD."
+            )
+        if self.default_port not in self.resolved.ports:
+            raise FDTDConfigError(
+                f"default_port {self.default_port!r} is not present on the "
+                "resolved component."
+            )
+        return self.default_port
 
     @staticmethod
     def _vertical_polarization(port: Any) -> tuple[float, float, float]:
@@ -325,4 +324,10 @@ class Simulation:
         )
 
 
-__all__ = ["Simulation"]
+# Keep the historical internal import path aligned with the public workflow.
+# The original artifact-only implementation above remains available while the
+# compatibility window is open, but new imports receive the concern-based API.
+ArtifactSimulation = Simulation
+from gsim.fdtd.workflow import Simulation as Simulation  # noqa: E402
+
+__all__ = ["ArtifactSimulation", "Simulation"]

--- a/src/gsim/fdtd/viz.py
+++ b/src/gsim/fdtd/viz.py
@@ -1,0 +1,93 @@
+"""Interactive Three.js views of ZapFDTD Gmsh simulation meshes."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from html import escape
+from importlib.resources import files
+from math import isfinite
+from pathlib import Path
+from typing import Literal
+
+ViewerMode = Literal["surface", "mesh", "slice", "mesh_slice"]
+Axis = Literal["x", "y", "z"]
+
+
+@dataclass(frozen=True)
+class MeshViewer:
+    """A self-contained interactive mesh document displayable in notebooks."""
+
+    html: str
+    height: int = 600
+
+    def _repr_html_(self) -> str:
+        """Embed the viewer in an isolated notebook iframe."""
+        source = escape(self.html, quote=True)
+        return (
+            f'<iframe srcdoc="{source}" width="100%" height="{self.height}" '
+            'style="border:0;border-radius:8px" '
+            'sandbox="allow-scripts"></iframe>'
+        )
+
+    def save(self, path: str | Path) -> Path:
+        """Save the standalone viewer document and return its path."""
+        output_path = Path(path)
+        output_path.write_text(self.html, encoding="utf8")
+        return output_path
+
+
+def plot_mesh(
+    mesh_path: str | Path,
+    *,
+    mode: ViewerMode = "surface",
+    axis: Axis = "z",
+    position_um: float | None = None,
+    show_groups: Sequence[str] | None = None,
+    hide_groups: Sequence[str] = (),
+    height: int = 600,
+) -> MeshViewer:
+    """Build an interactive ZapFDTD-style viewer for a Gmsh mesh.
+
+    The mesh is embedded in the returned HTML, so the source ``.msh`` file is
+    no longer needed once this function returns. Three.js is loaded from the
+    same public CDN used by the original ZapFDTD viewer.
+    """
+    path = Path(mesh_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Gmsh mesh not found: {path}")
+    if path.suffix.casefold() != ".msh":
+        raise ValueError(f"Expected a .msh file, got {path.name!r}")
+    if axis not in {"x", "y", "z"}:
+        raise ValueError(f"axis must be 'x', 'y', or 'z', got {axis!r}")
+    if position_um is not None and not isfinite(position_um):
+        raise ValueError("position_um must be finite when provided")
+    if height <= 0:
+        raise ValueError("height must be positive")
+
+    template = files("gsim.fdtd").joinpath("assets/mesh-viewer.html").read_text("utf8")
+    options = {
+        "axis": axis,
+        "hideGroups": list(hide_groups),
+        "mode": mode,
+        "positionUm": position_um,
+        "showGroups": None if show_groups is None else list(show_groups),
+    }
+    html = template.replace(
+        "__GSIM_MESH_DATA__", _script_json(path.read_text(encoding="utf8"))
+    ).replace("__GSIM_VIEW_OPTIONS__", _script_json(options))
+    return MeshViewer(html=html, height=height)
+
+
+def _script_json(value: object) -> str:
+    """Encode data for a script block without permitting tag termination."""
+    return (
+        json.dumps(value, ensure_ascii=True, separators=(",", ":"))
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
+__all__ = ["MeshViewer", "plot_mesh"]

--- a/src/gsim/fdtd/workflow.py
+++ b/src/gsim/fdtd/workflow.py
@@ -1,0 +1,399 @@
+"""Ergonomic simulation workflow for cloud-hosted GDSFactory FDTD."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import gdsfactory as gf
+from pdk_schema import Index, ScalarValue
+
+from gsim.common.materials import (
+    MaterialResolutionError,
+    MaterialSnapshot,
+    get_project_material_cards,
+    resolve_material_snapshot,
+)
+from gsim.common.materials._helpers import material_card
+from gsim.common.pdk import ResolvedPassivePcell, resolve_passive_pcell
+from gsim.fdtd.api import (
+    DipoleSource,
+    Domain,
+    GaussianBeamSource,
+    Geometry,
+    LineCurrentSource,
+    Materials,
+    Monitors,
+    PlaneMonitor,
+    PortSource,
+    Solver,
+    SourceType,
+)
+from gsim.fdtd.cloud import CloudWorkflowMixin
+from gsim.fdtd.mesh import generate_mesh
+from gsim.fdtd.models import (
+    FDTDConfigError,
+    FDTDGeometryError,
+    SimulationArtifacts,
+)
+from gsim.fdtd.runtime import RuntimeConfigMixin
+from gsim.fdtd.viz import Axis, ViewerMode
+
+
+def _source_from_value(value: SourceType | Mapping[str, Any] | None) -> SourceType:
+    """Validate a source mapping using its explicit public type."""
+    if value is None:
+        return PortSource()
+    if isinstance(
+        value, (PortSource, DipoleSource, LineCurrentSource, GaussianBeamSource)
+    ):
+        return value
+    source_data = dict(value)
+    source_type = source_data.get("type", "port")
+    source_classes = {
+        "port": PortSource,
+        "dipole": DipoleSource,
+        "line_current": LineCurrentSource,
+        "gaussian_beam": GaussianBeamSource,
+    }
+    try:
+        source_class = source_classes[source_type]
+    except KeyError as error:
+        raise ValueError(f"Unknown FDTD source type {source_type!r}") from error
+    return source_class.model_validate(source_data)
+
+
+class _PdkWithMaterialOverrides:
+    """Delegate to a PDK while exposing merged project material cards."""
+
+    def __init__(self, pdk: Any, material_cards: Mapping[str, Any]) -> None:
+        """Wrap a PDK and expose the merged material-card mapping."""
+        self._pdk = pdk
+        self.material_cards = material_cards
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate unknown attributes to the wrapped PDK."""
+        return getattr(self._pdk, name)
+
+
+def _constant_material_card(name: str, refractive_index: float) -> Any:
+    """Represent one public scalar override at the canonical PDK boundary."""
+    return material_card(
+        name=name,
+        temperature_ref=None,
+        permittivity=Index(
+            validity=None,
+            variation=None,
+            conductivity=None,
+            n=ScalarValue(unit="", value=refractive_index),
+            k=None,
+        ),
+    )
+
+
+class Simulation(CloudWorkflowMixin, RuntimeConfigMixin):
+    """Configure, serialize, and run a GDSFactory FDTD simulation."""
+
+    def __init__(
+        self,
+        pdk: Any | None = None,
+        *,
+        geometry: Geometry | Mapping[str, Any] | None = None,
+        materials: Materials | Mapping[str, Any] | None = None,
+        source: SourceType | Mapping[str, Any] | None = None,
+        monitors: Monitors | list[PlaneMonitor | Mapping[str, Any]] | None = None,
+        domain: Domain | Mapping[str, Any] | None = None,
+        solver: Solver | Mapping[str, Any] | None = None,
+        **legacy: Any,
+    ) -> None:
+        """Create a simulation, translating the original flat keyword API."""
+        geometry_data = self._model_data(geometry)
+        materials_data = self._model_data(materials)
+        source_data = self._model_data(source)
+        domain_data = self._model_data(domain)
+        solver_data = self._model_data(solver)
+        self._translate_legacy(
+            legacy,
+            geometry_data,
+            materials_data,
+            source_data,
+            domain_data,
+            solver_data,
+        )
+        self.pdk = pdk
+        self.geometry = Geometry.model_validate(geometry_data)
+        self.materials = Materials.model_validate(materials_data)
+        self.source = _source_from_value(source_data)
+        self.monitors = (
+            monitors if isinstance(monitors, Monitors) else Monitors(monitors)
+        )
+        self.domain = Domain.model_validate(domain_data)
+        self.solver = Solver.model_validate(solver_data)
+        self.geometry.bind(self._resolve_geometry)
+        self._resolved: ResolvedPassivePcell | None = None
+        self._job_id: str | None = None
+        self._input_hash: str | None = None
+        self._config_dir: Path | None = None
+        self._last_artifacts: SimulationArtifacts | None = None
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Validate source replacements while keeping concern mutation concise."""
+        if name == "source" and hasattr(self, "source"):
+            value = _source_from_value(value)
+        object.__setattr__(self, name, value)
+
+    @staticmethod
+    def _model_data(value: Any) -> dict[str, Any]:
+        """Normalize an optional model or mapping to mutable input data."""
+        if value is None:
+            return {}
+        if hasattr(value, "model_dump"):
+            return value.model_dump()
+        return dict(value)
+
+    @staticmethod
+    def _translate_legacy(
+        legacy: dict[str, Any],
+        geometry: dict[str, Any],
+        materials: dict[str, Any],
+        source: dict[str, Any],
+        domain: dict[str, Any],
+        solver: dict[str, Any],
+    ) -> None:
+        """Map the original flat constructor fields into concern objects."""
+        mappings = {
+            "mesh_size_nm": (geometry, "mesh_size_nm"),
+            "background_material": (materials, "background"),
+            "wavelength_um": (source, "wavelength_um"),
+            "num_wavelengths": (source, "num_wavelengths"),
+            "default_port": (source, "port"),
+            "vertical_port_axis": (source, "vertical_axis"),
+            "vertical_port_aperture_width_um": (
+                source,
+                "vertical_aperture_width_um",
+            ),
+            "vertical_port_waist_radius_um": (source, "vertical_waist_radius_um"),
+            "background_padding_um": (domain, "padding_um"),
+            "pml_cells": (domain, "pml_cells"),
+            "nanometers_per_cell": (solver, "cell_size_nm"),
+            "max_timesteps": (solver, "max_timesteps"),
+            "energy_decay_fraction": (solver, "energy_decay_fraction"),
+            "max_wall_seconds": (solver, "max_wall_seconds"),
+        }
+        for old_name, (target, new_name) in mappings.items():
+            if old_name in legacy:
+                target.setdefault(new_name, legacy.pop(old_name))
+        if "wavelength_halfspan_um" in legacy:
+            source.setdefault(
+                "wavelength_span_um", 2 * legacy.pop("wavelength_halfspan_um")
+            )
+        if legacy:
+            names = ", ".join(sorted(legacy))
+            raise TypeError(f"Unexpected Simulation arguments: {names}")
+
+    @property
+    def resolved(self) -> ResolvedPassivePcell:
+        """Return the most recently resolved canonical geometry."""
+        if self._resolved is None:
+            raise FDTDGeometryError(
+                "No geometry is configured. Call Simulation.geometry(...) first."
+            )
+        return self._resolved
+
+    @property
+    def job_id(self) -> str | None:
+        """Cloud job identifier after upload or run."""
+        return self._job_id
+
+    def _resolve_geometry(self) -> ResolvedPassivePcell:
+        """Resolve current geometry at the current source wavelength."""
+        if self.geometry.component is None:
+            raise FDTDGeometryError(
+                "No geometry is configured. Call Simulation.geometry(...) first."
+            )
+        pdk = self._pdk_for_resolution()
+        self._resolved = resolve_passive_pcell(
+            self.geometry.component,
+            pdk=pdk,
+            settings=self.geometry.settings,
+            wavelength_um=self.source.wavelength_um,
+        )
+        return self._resolved
+
+    def _pdk_for_resolution(self) -> Any:
+        """Return a delegating PDK with public material overrides attached."""
+        if not self.materials.overrides:
+            return self.pdk
+        pdk_object = (
+            gf.get_active_pdk()
+            if self.pdk is None
+            else getattr(self.pdk, "PDK", self.pdk)
+        )
+        cards = dict(get_project_material_cards(self.pdk))
+        cards.update(
+            {
+                name: _constant_material_card(name, material.refractive_index)
+                for name, material in self.materials.overrides.items()
+            }
+        )
+        return _PdkWithMaterialOverrides(pdk_object, cards)
+
+    def _material_snapshots(self) -> dict[str, MaterialSnapshot]:
+        """Resolve project-first materials, then apply explicit index overrides."""
+        snapshots = dict(self.resolved.materials)
+        background = self.materials.background
+        if background not in snapshots:
+            try:
+                project_cards = dict(get_project_material_cards(self.pdk))
+                if background in self.materials.overrides:
+                    project_cards[background] = _constant_material_card(
+                        background,
+                        self.materials.overrides[background].refractive_index,
+                    )
+                snapshots[background] = resolve_material_snapshot(
+                    background,
+                    self.source.wavelength_um,
+                    project_cards,
+                )
+            except MaterialResolutionError as error:
+                raise FDTDConfigError(
+                    f"Could not resolve background material {background!r}: {error}"
+                ) from error
+        for name, material in self.materials.overrides.items():
+            if name not in snapshots:
+                raise FDTDConfigError(
+                    f"Material override {name!r} is not used by the geometry "
+                    "or background."
+                )
+            snapshots[name] = replace(
+                snapshots[name],
+                refractive_index=material.refractive_index,
+                extinction_coefficient=0.0,
+            )
+        return snapshots
+
+    def write(self, output_dir: str | Path) -> SimulationArtifacts:
+        """Write ``mesh.msh`` and ``config.json`` for cloud execution."""
+        resolved = self._resolve_geometry()
+        if isinstance(self.source, PortSource):
+            self._selected_port_name()
+        directory = Path(output_dir)
+        directory.mkdir(parents=True, exist_ok=True)
+        mesh_path = directory / "mesh.msh"
+        config_path = directory / "config.json"
+        material_snapshots = self._material_snapshots()
+        manifest = generate_mesh(
+            resolved,
+            mesh_path,
+            background_material=self.materials.background,
+            background_padding_um=self.domain.padding_um,
+            mesh_size_nm=self.geometry.mesh_size_nm,
+            nanometers_per_cell=self.solver.cell_size_nm,
+        )
+        config = self._config(manifest, material_snapshots)
+        config_path.write_text(
+            config.model_dump_json(indent=2, exclude_none=True) + "\n",
+            encoding="utf8",
+        )
+        self._last_artifacts = SimulationArtifacts(
+            mesh_path=mesh_path,
+            config_path=config_path,
+            manifest=manifest,
+        )
+        return self._last_artifacts
+
+    def _plot_viewer(
+        self,
+        *,
+        mode: ViewerMode,
+        axis: Axis = "z",
+        position_um: float | None = None,
+        show_groups: Sequence[str] | None = None,
+        hide_groups: Sequence[str] = (),
+        height: int = 600,
+    ) -> Any:
+        """Render the current or a temporary mesh with the FDTD viewer."""
+        from gsim.fdtd.viz import plot_mesh
+
+        if (
+            self._last_artifacts is not None
+            and self._last_artifacts.mesh_path.is_file()
+        ):
+            return plot_mesh(
+                self._last_artifacts.mesh_path,
+                mode=mode,
+                axis=axis,
+                position_um=position_um,
+                show_groups=show_groups,
+                hide_groups=hide_groups,
+                height=height,
+            )
+
+        previous_artifacts = self._last_artifacts
+        with TemporaryDirectory(prefix="gsim-fdtd-view-") as directory:
+            try:
+                artifacts = self.write(directory)
+                return plot_mesh(
+                    artifacts.mesh_path,
+                    mode=mode,
+                    axis=axis,
+                    position_um=position_um,
+                    show_groups=show_groups,
+                    hide_groups=hide_groups,
+                    height=height,
+                )
+            finally:
+                self._last_artifacts = previous_artifacts
+
+    def plot_3d(
+        self,
+        *,
+        show_mesh: bool = False,
+        show_groups: Sequence[str] | None = None,
+        hide_groups: Sequence[str] = (),
+        height: int = 600,
+    ) -> Any:
+        """Show the 3D geometry, optionally with Gmsh surface edges."""
+        return self._plot_viewer(
+            mode="mesh" if show_mesh else "surface",
+            show_groups=show_groups,
+            hide_groups=hide_groups,
+            height=height,
+        )
+
+    def plot_2d(
+        self,
+        *,
+        axis: Axis = "z",
+        position_um: float | None = None,
+        show_mesh: bool = False,
+        show_groups: Sequence[str] | None = None,
+        hide_groups: Sequence[str] = (),
+        height: int = 600,
+    ) -> Any:
+        """Show a filled cross-section, optionally with intersected cell edges."""
+        position_um = self._default_slice_position(axis, position_um)
+        return self._plot_viewer(
+            mode="mesh_slice" if show_mesh else "slice",
+            axis=axis,
+            position_um=position_um,
+            show_groups=show_groups,
+            hide_groups=hide_groups,
+            height=height,
+        )
+
+    def _default_slice_position(
+        self, axis: Axis, position_um: float | None
+    ) -> float | None:
+        """Prefer the configured geometry midpoint over the padded domain center."""
+        if position_um is not None or self._resolved is None:
+            return position_um
+        axis_index = {"x": 0, "y": 1, "z": 2}[axis]
+        lower, upper = self.resolved.bounds
+        return (lower[axis_index] + upper[axis_index]) / 2
+
+
+__all__ = ["Simulation"]

--- a/src/gsim/gcloud.py
+++ b/src/gsim/gcloud.py
@@ -154,7 +154,7 @@ def _extract_solver_from_job(job) -> str | None:
     """
     name = getattr(job, "job_def_name", "") or ""
     # Try known solver names in the definition string
-    for solver in ("meep", "palace", "femwell"):
+    for solver in ("meep", "palace", "femwell", "fdtd"):
         if solver in name.lower():
             return solver
     return None
@@ -279,10 +279,16 @@ def _handle_failed_job(job, output_dir: Path, verbose: bool) -> None:
 
 
 def _get_job_definition(job_type: str):
-    """Get JobDefinition enum value by name."""
-    job_type_upper = job_type.upper()
+    """Get the SDK job definition, with support for newer gsim solvers."""
+    normalized_job_type = job_type.casefold()
+    job_type_upper = normalized_job_type.upper()
     if not hasattr(sim.JobDefinition, job_type_upper):
-        valid = [e.name for e in sim.JobDefinition]
+        # gdsfactoryplus 1.8.x accepts strings but its enum predates FDTD.
+        # Keep that SDK usable until users are ready to upgrade it.
+        if normalized_job_type == "fdtd":
+            return normalized_job_type
+        valid = [e.name.casefold() for e in sim.JobDefinition]
+        valid.append("fdtd")
         raise ValueError(f"Unknown job type '{job_type}'. Valid types: {valid}")
     return getattr(sim.JobDefinition, job_type_upper)
 
@@ -811,7 +817,7 @@ def upload_simulation_dir(
 
 def run_simulation(
     config_dir: str | Path,
-    job_type: Literal["palace", "meep"] = "palace",
+    job_type: Literal["palace", "meep", "fdtd"] = "palace",
     verbose: bool = True,
     on_started: Callable | None = None,
     parent_dir: str | Path | None = None,

--- a/tests/fdtd/test_api.py
+++ b/tests/fdtd/test_api.py
@@ -1,0 +1,149 @@
+"""Tests for the concern-based public FDTD API and cloud lifecycle."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import gdsfactory as gf
+import pytest
+from pydantic import ValidationError
+
+from gsim import fdtd, gcloud
+
+
+def test_material_override_participates_in_gpdk_resolution() -> None:
+    gf.gpdk.PDK.activate()
+    simulation = fdtd.Simulation(pdk=gf.gpdk.PDK)
+    simulation.materials(overrides={"si": 3.47})
+
+    resolved = simulation.geometry(gf.gpdk.PDK.get_component("mmi1x2"))
+
+    assert resolved.materials["si"].refractive_index == 3.47
+
+
+def test_concerns_batch_validate_without_partial_updates() -> None:
+    simulation = fdtd.Simulation()
+
+    assert simulation.source.num_wavelengths == 101
+    assert simulation.solver.cell_size_nm == 60
+
+    simulation.source(port="o2", wavelength_um=1.31, wavelength_span_um=0.04)
+    simulation.domain(padding_um=0.75, pml_cells=16)
+    simulation.solver(cell_size_nm=40, energy_decay_fraction=1e-5)
+
+    assert isinstance(simulation.source, fdtd.PortSource)
+    assert simulation.source.port == "o2"
+    assert simulation.domain.padding_um == 0.75
+    assert simulation.solver.cell_size_nm == 40
+
+    with pytest.raises(ValidationError):
+        simulation.solver(cell_size_nm=-1, max_wall_seconds=20)
+    assert simulation.solver.cell_size_nm == 40
+    assert simulation.solver.max_wall_seconds == 3600
+
+
+def test_dipole_material_override_and_plane_monitor_serialize(
+    tmp_path: Path,
+    fdtd_pdk_module,
+) -> None:
+    simulation = fdtd.Simulation(pdk=fdtd_pdk_module)
+    simulation.geometry("straight", settings={"length": 2}, mesh_size_nm=750)
+    simulation.materials(overrides={"Si": 3.4})
+    simulation.source = fdtd.DipoleSource(
+        position_um=(1, 0, 0.11),
+        current_axis="z",
+        wavelength_um=1.55,
+        wavelength_span_um=0.02,
+        num_wavelengths=3,
+    )
+    simulation.monitors.add_plane(
+        "top",
+        center_um=(1, 0, 0.5),
+        size_um=(2, 1, 0),
+        normal="+z",
+        heatmap=fdtd.Heatmap(quantity="intensity", wavelengths_um=[1.55]),
+    )
+
+    artifacts = simulation.write(tmp_path)
+    document = json.loads(artifacts.config_path.read_text(encoding="utf8"))
+
+    assert document["materials"]["Si"]["refractive_index"] == 3.4
+    assert document["excitation"]["type"] == "dipole"
+    assert document["excitation"]["dipole"] == {
+        "position": [1000.0, 0.0, 110.0],
+        "current_axis": "z",
+    }
+    assert document["monitors"][0]["region_min"] == [0.0, -500.0, 500.0]
+    assert document["monitors"][0]["heatmap"] == {
+        "quantity": "intensity",
+        "wavelengths": [1550.0],
+    }
+
+
+def test_line_current_and_gaussian_aperture_validation() -> None:
+    source = fdtd.LineCurrentSource(
+        position_um=(0, 0, 0),
+        line_axis="y",
+        current_axis="z",
+        length_um=0.5,
+    )
+    assert source.type == "line_current"
+
+    with pytest.raises(ValidationError, match="aperture_normal"):
+        fdtd.GaussianBeamSource(
+            center_um=(0, 0, 1),
+            size_um=(2, 2, 1),
+            aperture_normal="-z",
+            propagation_direction=(0, 0, -1),
+            e_polarization=(1, 0, 0),
+            focal_point_um=(0, 0, 0),
+            waist_radius_um=0.5,
+        )
+
+
+def test_monitor_collection_rejects_duplicates_and_supports_removal() -> None:
+    monitors = fdtd.Monitors()
+    monitor = monitors.add_plane(
+        "top", center_um=(0, 0, 1), size_um=(2, 2, 0), normal="+z"
+    )
+    with pytest.raises(ValueError, match="already exists"):
+        monitors.add(monitor)
+
+    assert monitors.remove("top") is monitor
+    monitors.add(monitor)
+    monitors.clear()
+    assert len(monitors) == 0
+
+
+def test_run_without_wait_uses_fine_grained_cloud_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    simulation = fdtd.Simulation()
+    calls: list[tuple] = []
+
+    def write_files(directory: Path) -> None:
+        directory.joinpath("config.json").write_text("{}", encoding="utf8")
+
+    monkeypatch.setattr(simulation, "write", write_files)
+    monkeypatch.setattr(
+        gcloud,
+        "upload",
+        lambda _directory, job_type, **kwargs: calls.append(
+            ("upload", job_type, kwargs["input_hash"])
+        )
+        or "job-123",
+    )
+    monkeypatch.setattr(
+        gcloud,
+        "start",
+        lambda job_id, **_kwargs: calls.append(("start", job_id)),
+    )
+
+    job_id = simulation.run(wait=False, verbose="quiet")
+
+    assert job_id == "job-123"
+    assert simulation.job_id == "job-123"
+    assert calls[0][0:2] == ("upload", "fdtd")
+    assert calls[0][2].startswith("sha256:")
+    assert calls[1] == ("start", "job-123")

--- a/tests/fdtd/test_results.py
+++ b/tests/fdtd/test_results.py
@@ -1,0 +1,125 @@
+"""Tests for typed ZapFDTD results, tables, and monitor plots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from gsim.fdtd import FDTDResult
+from gsim.gcloud import RunResult
+
+
+def _result_document(source_type: str = "eigenmode") -> dict[str, Any]:
+    common: dict[str, Any] = {
+        "schema_version": 1,
+        "excitation_type": source_type,
+        "excited_port": "o1" if source_type == "eigenmode" else None,
+        "ports": ["o1", "o2"],
+        "frequencies": {
+            "wavelength_nm": [1500, 1550, 1600],
+            "hz": [2.0e14, 1.93e14, 1.87e14],
+            "below_noise_floor": [True, False, False],
+        },
+        "plane_monitors": {
+            "top": {
+                "normal_axis": "z",
+                "normal_sign": 1,
+                "u_axis": "x",
+                "v_axis": "y",
+                "plane_position_nm": 500,
+                "u_extent_nm": [-1000, 1000],
+                "v_extent_nm": [-500, 500],
+                "shape": [2, 3],
+                "wavelength_nm": [1500, 1550, 1600],
+                "flux": [0.1, 0.2, 0.3],
+                "heatmaps": [
+                    {
+                        "file": "top_intensity_1550nm.npy",
+                        "quantity": "intensity",
+                        "wavelength_nm": 1550,
+                        "shape": [2, 3],
+                    }
+                ],
+            }
+        },
+        "convergence": {"converged": True},
+        "grid": {"total_cells": 100},
+        "timing": {"run_seconds": 2},
+        "config_resolved": {"source_type": source_type},
+    }
+    samples = [
+        {"re": 0, "im": 0},
+        {"re": 0.5, "im": 0},
+        {"re": 0, "im": 0.25},
+    ]
+    if source_type == "eigenmode":
+        common["s_parameters"] = {"S(o2,o1)": samples}
+    else:
+        common["port_outputs"] = {
+            "o2": [
+                {**sample, "modal_power": power, "power_fraction": 1.0}
+                for sample, power in zip(samples, [0, 0.25, 0.0625], strict=True)
+            ]
+        }
+    return common
+
+
+def _write_result(tmp_path: Path, source_type: str = "eigenmode") -> Path:
+    result_path = tmp_path / "sparams_o1.json"
+    result_path.write_text(json.dumps(_result_document(source_type)), encoding="utf8")
+    np.save(tmp_path / "top_intensity_1550nm.npy", np.arange(6).reshape(2, 3))
+    return result_path
+
+
+def test_eigenmode_result_masks_noise_and_builds_dataframe(tmp_path: Path) -> None:
+    result = FDTDResult.from_file(_write_result(tmp_path))
+
+    trace = result.s_parameters[("o2", "o1")]
+    frame = result.s_parameters.to_dataframe()
+
+    assert result.wavelength_um.tolist() == [1.5, 1.55, 1.6]
+    assert trace.valid.tolist() == [False, True, True]
+    assert frame["magnitude"].tolist() == [0, 0.5, 0.25]
+    figure, axes = result.plot()
+    assert np.isnan(axes.lines[0].get_ydata()[0])
+    plt.close(figure)
+    plotly_figure = result.plot_plotly()
+    assert plotly_figure.data[0].name == "S(o2,o1)"
+    assert tuple(plotly_figure.layout.xaxis.range) == (1.55, 1.6)
+
+
+def test_monitor_heatmap_is_lazy_and_uses_physical_axes(tmp_path: Path) -> None:
+    result_path = _write_result(tmp_path)
+    result = FDTDResult.from_file(result_path)
+    monitor = result.monitors["top"]
+
+    selected = monitor.heatmap(wavelength_um=1.551)
+    assert selected.load().shape == (2, 3)
+    figure, axes = monitor.plot_heatmap(wavelength_um=1.55)
+    assert axes.get_xlabel() == "x (µm)"
+    assert axes.get_ylabel() == "y (µm)"
+    plt.close(figure)
+
+
+def test_non_eigenmode_result_and_run_result_parser(tmp_path: Path) -> None:
+    result_path = _write_result(tmp_path, "dipole")
+    raw_result = RunResult(
+        sim_dir=tmp_path,
+        files={result_path.name: result_path},
+        job_name="fdtd-test",
+    )
+
+    result = FDTDResult.from_run_result(raw_result)
+    frame = result.port_outputs.to_dataframe()
+
+    assert result.job_name == "fdtd-test"
+    assert frame["modal_power"].tolist() == [0, 0.25, 0.0625]
+    figure, axes = result.plot()
+    assert axes.get_ylabel() == "Modal power"
+    plt.close(figure)
+    plotly_figure = result.plot_plotly()
+    assert plotly_figure.layout.yaxis.title.text == "Modal power"

--- a/tests/fdtd/test_simulation.py
+++ b/tests/fdtd/test_simulation.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from gsim import fdtd
-from gsim.fdtd.models import FDTDGeometryError
+from gsim.fdtd.models import FDTDConfigError, FDTDGeometryError
 
 
 def _physical_group_points(mesh: meshio.Mesh, name: str, cell_type: str) -> np.ndarray:
@@ -31,6 +31,7 @@ def test_write_uses_project_material_then_fallback_and_valid_mesh(
         background_padding_um=0.25,
         pml_cells=16,
         num_wavelengths=3,
+        default_port="o1",
     )
     resolved = simulation.geometry("straight", settings={"length": 2.0})
 
@@ -66,8 +67,8 @@ def test_write_uses_project_material_then_fallback_and_valid_mesh(
 
     port_points = _physical_group_points(mesh, "port_o1", "triangle")
     assert port_points[:, 0] == pytest.approx(0)
-    assert port_points[:, 1].min() == pytest.approx(-262.930645, abs=1e-3)
-    assert port_points[:, 1].max() == pytest.approx(262.930645, abs=1e-3)
+    assert port_points[:, 1].min() == pytest.approx(-259.697984, abs=1e-3)
+    assert port_points[:, 1].max() == pytest.approx(259.697984, abs=1e-3)
     assert port_points[:, 2].min() == pytest.approx(0)
     assert port_points[:, 2].max() == pytest.approx(220)
 
@@ -80,12 +81,23 @@ def test_write_requires_geometry(tmp_path) -> None:
         fdtd.Simulation().write(tmp_path)
 
 
+def test_write_requires_explicit_source_port(tmp_path, fdtd_pdk_module) -> None:
+    simulation = fdtd.Simulation(pdk=fdtd_pdk_module, mesh_size_nm=750)
+    simulation.geometry("straight", settings={"length": 2.0})
+
+    with pytest.raises(FDTDConfigError, match="requires an explicit port"):
+        simulation.write(tmp_path)
+
+    assert not (tmp_path / "mesh.msh").exists()
+
+
 def test_vertical_port_becomes_fiber_monitor_not_material_port(
     tmp_path,
     fdtd_pdk_module,
 ) -> None:
     simulation = fdtd.Simulation(
         pdk=fdtd_pdk_module,
+        default_port="o1",
         mesh_size_nm=750,
         background_padding_um=0.25,
     )
@@ -156,6 +168,7 @@ def test_write_restores_options_from_existing_gmsh_session(
 
         simulation = fdtd.Simulation(
             pdk=fdtd_pdk_module,
+            default_port="o1",
             mesh_size_nm=750,
             background_padding_um=0.25,
         )

--- a/tests/fdtd/test_viz.py
+++ b/tests/fdtd/test_viz.py
@@ -1,0 +1,121 @@
+"""Tests for the ZapFDTD-derived interactive Gmsh viewer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+from gsim import fdtd
+from gsim.fdtd.viz import MeshViewer, plot_mesh
+
+_TETRAHEDRON_MESH = """$MeshFormat
+2.2 0 8
+$EndMeshFormat
+$PhysicalNames
+1
+3 2 "core"
+$EndPhysicalNames
+$Nodes
+4
+1 0 0 0
+2 1000 0 0
+3 0 1000 0
+4 0 0 1000
+$EndNodes
+$Elements
+1
+1 4 2 2 1 1 2 3 4
+$EndElements
+"""
+
+
+def _write_mesh(path: Path) -> Path:
+    path.write_text(_TETRAHEDRON_MESH, encoding="utf8")
+    return path
+
+
+def test_viewer_embeds_mesh_and_slice_options(tmp_path: Path) -> None:
+    viewer = plot_mesh(
+        _write_mesh(tmp_path / "mesh.msh"),
+        mode="mesh_slice",
+        axis="x",
+        position_um=0.25,
+        show_groups=["core"],
+        height=420,
+    )
+    compact_html = "".join(viewer.html.split())
+
+    assert isinstance(viewer, MeshViewer)
+    assert '"mode":"mesh_slice"' in viewer.html
+    assert '"positionUm":0.25' in viewer.html
+    assert "$MeshFormat\\n2.2" in viewer.html
+    assert "__GSIM_" not in viewer.html
+    assert 'id="mode"' not in viewer.html
+    assert 'id="stats" class="section muted" hidden' in viewer.html
+    assert 'id="gizmo-center-target"' in viewer.html
+    assert 'id="gizmo-x-target"' in viewer.html
+    assert 'id="gizmo-y-target"' in viewer.html
+    assert 'id="gizmo-z-target"' in viewer.html
+    assert 'id="panel-toggle"' in viewer.html
+    assert 'aria-controls="panel-body"' in viewer.html
+    assert 'd="m5 7.5 5 5 5-5"' in viewer.html
+    assert 'panel.classList.toggle("collapsed")' in viewer.html
+    assert ".gizmo-axis{stroke:#4f9cff;" in compact_html
+    assert ".gizmo-axis-targetcircle{fill:#4f9cff;" in compact_html
+    assert "camera.up.copy(zUp)" in viewer.html
+    assert (
+        "constdefaultViewDirection=newTHREE.Vector3(1.8,-1.5,1.8,).normalize();"
+        in compact_html
+    )
+    assert "keyLight.position.set(3, -5, 4)" in viewer.html
+    assert "controls.zoomToCursor = true" in viewer.html
+    assert 'button.className = "group-button"' in viewer.html
+    assert 'startsWith("port_")' in viewer.html
+    assert "new THREE.Color(0xf4f7fb)" in viewer.html
+    assert "constphysicalGroupPalette=[0xff9fba,0xb8b2b0,0x55dfff" in compact_html
+    assert "setHSL" not in viewer.html
+    assert "function tetrahedronVolume" in viewer.html
+    assert "function largestMaterialGroup" in viewer.html
+    assert "function orderedGroupEntries" in viewer.html
+    assert "constopacity=isLargestMaterial?isSlice?0.55:0.35:" in compact_html
+    assert 'height="420"' in viewer._repr_html_()
+    assert viewer.save(tmp_path / "viewer.html").is_file()
+
+
+def test_simulation_view_methods_reuse_last_mesh(tmp_path: Path) -> None:
+    simulation = fdtd.Simulation()
+    mesh_path = _write_mesh(tmp_path / "mesh.msh")
+    simulation_state = cast(Any, simulation)
+    simulation_state._last_artifacts = SimpleNamespace(mesh_path=mesh_path)
+    simulation_state._resolved = SimpleNamespace(bounds=((0, -1, 0.1), (2, 1, 0.3)))
+
+    assert '"mode":"surface"' in simulation.plot_3d().html
+    assert '"hideGroups":[]' in simulation.plot_3d().html
+    assert '"mode":"mesh"' in simulation.plot_3d(show_mesh=True).html
+    slice_html = simulation.plot_2d().html
+    assert '"mode":"slice"' in slice_html
+    assert '"positionUm":0.2' in slice_html
+    assert '"mode":"mesh_slice"' in simulation.plot_2d(show_mesh=True).html
+    assert not hasattr(simulation, "plot_mesh")
+    assert not hasattr(simulation, "plot_mesh_slice")
+
+
+def test_simulation_view_can_generate_an_ephemeral_mesh(monkeypatch) -> None:
+    simulation = fdtd.Simulation()
+    generated_directories = []
+
+    def write(directory: str | Path):
+        generated_directories.append(Path(directory))
+        mesh_path = _write_mesh(Path(directory) / "mesh.msh")
+        artifacts = SimpleNamespace(mesh_path=mesh_path)
+        cast(Any, simulation)._last_artifacts = artifacts
+        return artifacts
+
+    monkeypatch.setattr(simulation, "write", write)
+
+    viewer = simulation.plot_3d()
+
+    assert generated_directories
+    assert '"mode":"surface"' in viewer.html
+    assert simulation._last_artifacts is None

--- a/tests/test_gcloud_start.py
+++ b/tests/test_gcloud_start.py
@@ -63,6 +63,13 @@ class TestExtractSolverFromJob:
         job = MagicMock(job_def_name="dev-femwell-simulation")
         assert _extract_solver_from_job(job) == "femwell"
 
+    def test_fdtd(self):
+        """Extracts 'fdtd' from dev job definition name."""
+        from gsim.gcloud import _extract_solver_from_job
+
+        job = MagicMock(job_def_name="dev-fdtd-simulation")
+        assert _extract_solver_from_job(job) == "fdtd"
+
     def test_plain_name(self):
         """Extracts solver from plain name without prefix."""
         from gsim.gcloud import _extract_solver_from_job
@@ -90,6 +97,45 @@ class TestExtractSolverFromJob:
 
         job = MagicMock(job_def_name=None)
         assert _extract_solver_from_job(job) is None
+
+
+# ---------------------------------------------------------------------------
+# Job definition compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestJobDefinitionCompatibility:
+    """Tests for solver names introduced after older SDK releases."""
+
+    @patch("gsim.gcloud.sim")
+    def test_fdtd_uses_string_when_sdk_enum_is_missing(self, mock_sim):
+        """FDTD works with SDK 1.8.x without modifying its enum."""
+        from enum import Enum
+
+        from gsim.gcloud import _get_job_definition
+
+        class LegacyJobDefinition(Enum):
+            MEEP = "meep"
+            PALACE = "palace"
+
+        mock_sim.JobDefinition = LegacyJobDefinition
+
+        assert _get_job_definition("fdtd") == "fdtd"
+
+    @patch("gsim.gcloud.sim")
+    def test_existing_sdk_enum_is_preserved(self, mock_sim):
+        """Existing solver definitions still use the SDK enum."""
+        from enum import Enum
+
+        from gsim.gcloud import _get_job_definition
+
+        class LegacyJobDefinition(Enum):
+            MEEP = "meep"
+            PALACE = "palace"
+
+        mock_sim.JobDefinition = LegacyJobDefinition
+
+        assert _get_job_definition("meep") is LegacyJobDefinition.MEEP
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_list_docs_notebooks.py
+++ b/tests/test_list_docs_notebooks.py
@@ -14,6 +14,7 @@ from scripts.list_docs_notebooks import (
 )
 
 EXPECTED_NOTEBOOKS = [
+    "nbs/fdtd_mmi_gpdk.ipynb",
     "nbs/meep_ybranch.ipynb",
     "nbs/meep_ring_coupler.ipynb",
     "nbs/meep_dc.ipynb",


### PR DESCRIPTION
Adds the GDSFactory FDTD workflow needed for dev cloud jobs:

- introduces concern-based geometry, materials, source, monitors, domain, solver, and cloud lifecycle APIs
- adds typed results, Matplotlib/Plotly plots, and the ported interactive Gmsh viewer
- keeps FDTD usable with the older gdsfactoryplus enum and validates explicit source ports
- documents the API and publishes a minimal GPDK MMI notebook; cloud-only cells are skipped during docs execution while the viewer is rendered

Validated with 59 FDTD/cloud tests, the repository pre-commit suite, and a clean notebook-to-Markdown docs execution.