### PR TITLE
feat: add geometry-aware FDTD mesh sizing

### DIFF
--- a/docs/api/fdtd.md
+++ b/docs/api/fdtd.md
@@ -31,7 +31,10 @@ result.plot()
 result.plot_plotly()
 ```
 
-`mesh_size_nm` controls the coarse Gmsh transfer mesh. `cell_size_nm` requests
+The transfer mesh uses geometry-aware refinement rather than uniform
+tetrahedra. Material polygon edges use the smaller of `mesh_size_nm` and the
+requested `cell_size_nm`; slowly varying bulk regions grow to at least eight
+times that feature size with a graded transition. `cell_size_nm` still requests
 the actual Yee grid used by the FDTD solver and defaults to 60 nm. Source sweeps
 default to 101 wavelengths. Guided-port monitors are implicit; one port source
 returns one S-matrix column.

--- a/nbs/fdtd_mmi_gpdk.ipynb
+++ b/nbs/fdtd_mmi_gpdk.ipynb
@@ -82,11 +82,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7",
-   "metadata": {
-    "tags": [
-     "skip-execution"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "result = simulation.run(check_cache=True)"
@@ -104,11 +100,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9",
-   "metadata": {
-    "tags": [
-     "skip-execution"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "result.plot_plotly()"

--- a/src/gsim/fdtd/mesh.py
+++ b/src/gsim/fdtd/mesh.py
@@ -14,6 +14,10 @@ from gsim.fdtd.mesh_geometry import (
     UM_TO_NM,
     add_layer_volumes,
 )
+from gsim.fdtd.mesh_sizing import (
+    geometry_aware_sizing,
+    install_geometry_aware_mesh_field,
+)
 from gsim.fdtd.mesh_validation import validate_mesh
 from gsim.fdtd.models import (
     FDTDGeometryError,
@@ -28,6 +32,7 @@ _GMSH_OPTIONS_CHANGED = (
     "Mesh.ElementOrder",
     "Mesh.MeshSizeExtendFromBoundary",
     "Mesh.MeshSizeFromCurvature",
+    "Mesh.MeshSizeFromPoints",
     "Mesh.MeshSizeMax",
     "Mesh.MeshSizeMin",
     "Mesh.MshFileVersion",
@@ -297,10 +302,8 @@ def generate_mesh(
         gmsh.option.setNumber("Mesh.Binary", 0)
         gmsh.option.setNumber("Mesh.ElementOrder", 1)
         gmsh.option.setNumber("Mesh.SaveAll", 0)
-        gmsh.option.setNumber("Mesh.MeshSizeMin", mesh_size_nm)
-        gmsh.option.setNumber("Mesh.MeshSizeMax", mesh_size_nm)
-        gmsh.option.setNumber("Mesh.MeshSizeFromCurvature", 0)
-        gmsh.option.setNumber("Mesh.MeshSizeExtendFromBoundary", 0)
+        sizing = geometry_aware_sizing(mesh_size_nm, nanometers_per_cell)
+        install_geometry_aware_mesh_field(resolved, sizing)
         gmsh.model.mesh.generate(3)
         gmsh.write(str(mesh_path))
     except FDTDGeometryError:

--- a/src/gsim/fdtd/mesh_sizing.py
+++ b/src/gsim/fdtd/mesh_sizing.py
@@ -1,0 +1,116 @@
+"""Geometry-aware Gmsh size fields for FDTD transfer meshes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import gmsh
+
+from gsim.common.pdk import ResolvedPassivePcell
+from gsim.fdtd.mesh_geometry import UM_TO_NM, iter_polygons
+
+_BULK_TO_FEATURE_RATIO = 8.0
+_FEATURE_HALF_WIDTH_RATIO = 2.0
+_TRANSITION_WIDTH_RATIO = 10.0
+
+FeatureRegion = tuple[float, float, float, float]
+
+
+@dataclass(frozen=True)
+class GeometryAwareSizing:
+    """Resolved feature, bulk, and transition sizes in nanometers."""
+
+    feature_size_nm: float
+    bulk_size_nm: float
+    feature_half_width_nm: float
+    transition_width_nm: float
+
+
+def geometry_aware_sizing(
+    mesh_size_nm: float,
+    nanometers_per_cell: float,
+) -> GeometryAwareSizing:
+    """Resolve the production sizing policy from mesh and Yee-grid targets."""
+    feature_size_nm = min(mesh_size_nm, nanometers_per_cell)
+    return GeometryAwareSizing(
+        feature_size_nm=feature_size_nm,
+        bulk_size_nm=max(mesh_size_nm, _BULK_TO_FEATURE_RATIO * feature_size_nm),
+        feature_half_width_nm=_FEATURE_HALF_WIDTH_RATIO * feature_size_nm,
+        transition_width_nm=_TRANSITION_WIDTH_RATIO * feature_size_nm,
+    )
+
+
+def geometry_feature_regions_nm(
+    resolved: ResolvedPassivePcell,
+) -> list[FeatureRegion]:
+    """Return unique vertical edge regions from all material polygon rings."""
+    regions: set[FeatureRegion] = set()
+    for layer in resolved.layers.values():
+        z_lower_nm = round(layer.z_bounds[0] * UM_TO_NM, 6)
+        z_upper_nm = round(layer.z_bounds[1] * UM_TO_NM, 6)
+        for polygon in iter_polygons(layer.geometry, layer_key=layer.key):
+            for ring in (polygon.exterior, *polygon.interiors):
+                for x_um, y_um, *_ in list(ring.coords)[:-1]:
+                    regions.add(
+                        (
+                            round(float(x_um) * UM_TO_NM, 6),
+                            round(float(y_um) * UM_TO_NM, 6),
+                            z_lower_nm,
+                            z_upper_nm,
+                        )
+                    )
+    return sorted(regions)
+
+
+def install_geometry_aware_mesh_field(
+    resolved: ResolvedPassivePcell,
+    sizing: GeometryAwareSizing,
+) -> None:
+    """Install fine boxes at material edges and coarse sizing elsewhere."""
+    gmsh.option.setNumber("Mesh.MeshSizeMin", sizing.feature_size_nm)
+    gmsh.option.setNumber("Mesh.MeshSizeMax", sizing.bulk_size_nm)
+    gmsh.option.setNumber("Mesh.MeshSizeFromPoints", 0)
+    gmsh.option.setNumber("Mesh.MeshSizeFromCurvature", 0)
+    gmsh.option.setNumber("Mesh.MeshSizeExtendFromBoundary", 0)
+
+    coarse_field = gmsh.model.mesh.field.add("MathEval")
+    gmsh.model.mesh.field.setString(coarse_field, "F", str(sizing.bulk_size_nm))
+    fields = [coarse_field]
+    for x_nm, y_nm, z_lower_nm, z_upper_nm in geometry_feature_regions_nm(resolved):
+        feature_field = gmsh.model.mesh.field.add("Box")
+        gmsh.model.mesh.field.setNumber(feature_field, "VIn", sizing.feature_size_nm)
+        gmsh.model.mesh.field.setNumber(feature_field, "VOut", sizing.bulk_size_nm)
+        gmsh.model.mesh.field.setNumber(
+            feature_field, "XMin", x_nm - sizing.feature_half_width_nm
+        )
+        gmsh.model.mesh.field.setNumber(
+            feature_field, "XMax", x_nm + sizing.feature_half_width_nm
+        )
+        gmsh.model.mesh.field.setNumber(
+            feature_field, "YMin", y_nm - sizing.feature_half_width_nm
+        )
+        gmsh.model.mesh.field.setNumber(
+            feature_field, "YMax", y_nm + sizing.feature_half_width_nm
+        )
+        gmsh.model.mesh.field.setNumber(
+            feature_field, "ZMin", z_lower_nm - sizing.feature_half_width_nm
+        )
+        gmsh.model.mesh.field.setNumber(
+            feature_field, "ZMax", z_upper_nm + sizing.feature_half_width_nm
+        )
+        gmsh.model.mesh.field.setNumber(
+            feature_field, "Thickness", sizing.transition_width_nm
+        )
+        fields.append(feature_field)
+
+    minimum_field = gmsh.model.mesh.field.add("Min")
+    gmsh.model.mesh.field.setNumbers(minimum_field, "FieldsList", fields)
+    gmsh.model.mesh.field.setAsBackgroundMesh(minimum_field)
+
+
+__all__ = [
+    "GeometryAwareSizing",
+    "geometry_aware_sizing",
+    "geometry_feature_regions_nm",
+    "install_geometry_aware_mesh_field",
+]

--- a/tests/fdtd/test_mesh_sizing.py
+++ b/tests/fdtd/test_mesh_sizing.py
@@ -1,0 +1,54 @@
+"""Tests for geometry-aware FDTD transfer-mesh sizing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from shapely.geometry import MultiPolygon, Polygon
+
+from gsim.fdtd.mesh_sizing import (
+    geometry_aware_sizing,
+    geometry_feature_regions_nm,
+)
+
+
+def test_approved_fifty_nanometer_policy() -> None:
+    """The selected prototype settings remain the production policy."""
+    sizing = geometry_aware_sizing(mesh_size_nm=50, nanometers_per_cell=60)
+
+    assert sizing.feature_size_nm == 50
+    assert sizing.bulk_size_nm == 400
+    assert sizing.feature_half_width_nm == 100
+    assert sizing.transition_width_nm == 500
+
+
+def test_default_policy_tracks_the_yee_grid_at_features() -> None:
+    """Slow bulk regions remain coarse while features follow solver resolution."""
+    sizing = geometry_aware_sizing(mesh_size_nm=500, nanometers_per_cell=60)
+
+    assert sizing.feature_size_nm == 60
+    assert sizing.bulk_size_nm == 500
+    assert sizing.feature_half_width_nm == 120
+    assert sizing.transition_width_nm == 600
+
+
+def test_feature_regions_include_exterior_hole_and_disconnected_edges() -> None:
+    """Every material ring contributes unique vertical refinement regions."""
+    ring = Polygon(
+        [(0, 0), (4, 0), (4, 4), (0, 4)],
+        holes=[[(1, 1), (3, 1), (3, 3), (1, 3)]],
+    )
+    bus = Polygon([(5, 0), (7, 0), (7, 1), (5, 1)])
+    layer = SimpleNamespace(
+        key="core",
+        geometry=MultiPolygon([ring, bus]),
+        z_bounds=(0.1, 0.3),
+    )
+    resolved = SimpleNamespace(layers={"core": layer})
+
+    regions = geometry_feature_regions_nm(resolved)
+
+    assert len(regions) == 12
+    assert (0.0, 0.0, 100.0, 300.0) in regions
+    assert (1000.0, 1000.0, 100.0, 300.0) in regions
+    assert (7000.0, 1000.0, 100.0, 300.0) in regions

--- a/tests/fdtd/test_simulation.py
+++ b/tests/fdtd/test_simulation.py
@@ -156,6 +156,7 @@ def test_write_restores_options_from_existing_gmsh_session(
         "Mesh.ElementOrder": 2.0,
         "Mesh.MeshSizeExtendFromBoundary": 1.0,
         "Mesh.MeshSizeFromCurvature": 1.0,
+        "Mesh.MeshSizeFromPoints": 1.0,
         "Mesh.MeshSizeMax": 34.5,
         "Mesh.MeshSizeMin": 12.5,
         "Mesh.MshFileVersion": 4.1,


### PR DESCRIPTION
Replaces uniform FDTD transfer-mesh sizing with geometry-aware local refinement at material polygon edges and coarse sizing in slowly varying bulk regions.

For GPDK mmi1x2 at a 50 nm feature target, production output is byte-identical to the accepted prototype: 2,582,745 bytes and 54,443 elements, versus 524,379,798 bytes and 9,406,509 elements for uniform 50 nm. ZapFDTD dry-run passes.

Also enables the GPDK MMI docs notebook cloud and result cells so the generated docs include the simulated S-parameters.

Validated with 62 FDTD/cloud tests, repository pre-commit hooks, and clean execution of the FDTD docs notebook.