### PR TITLE
chore: remove generated simulation output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Simulation outputs
+/output/
 sim-data-*/
 palace-sim-*/
 meep-sim-*/

--- a/output/palace/palace.json
+++ b/output/palace/palace.json
@@ -1,7 +1,0 @@
-{
-  "GitTag": "v0.16.1-51-g4f2e2d97",
-  "Problem": {
-    "MPISize": 4,
-    "OpenMPThreads": 1
-  }
-}


### PR DESCRIPTION
Removes the tracked Palace runtime output from `output/palace`.

Ignores the root-level `output/` directory so generated simulation artifacts are not committed again.