### PR TITLE
feat(fdtd): loft angled sidewalls

### DIFF
--- a/docs/api/fdtd.md
+++ b/docs/api/fdtd.md
@@ -39,6 +39,11 @@ the actual Yee grid used by the FDTD solver and defaults to 60 nm. Source sweeps
 default to 101 wavelengths. Guided-port monitors are implicit; one port source
 returns one S-matrix column.
 
+Linear PDK sidewall angles are represented as continuous ruled solids between
+their exact bottom and top contours. If polygon offsetting changes component,
+hole, or edge topology, meshing safely falls back to bounded-error vertical
+slices instead of constructing an invalid loft.
+
 Use `write(path)` to generate `mesh.msh` and `config.json` without submitting.
 The original flat constructor keywords remain accepted for compatibility.
 

--- a/nbs/fdtd_mmi_gpdk.ipynb
+++ b/nbs/fdtd_mmi_gpdk.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation = fdtd.Simulation(pdk=gf.gpdk.PDK)\n",
+    "simulation = fdtd.Simulation()\n",
     "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757})\n",
     "simulation.geometry(component)\n",
     "simulation.source(port=\"o1\", num_wavelengths=101)\n",

--- a/src/gsim/fdtd/mesh.py
+++ b/src/gsim/fdtd/mesh.py
@@ -9,11 +9,8 @@ from typing import Any
 import gmsh
 
 from gsim.common.pdk import ResolvedLayer, ResolvedPassivePcell, ResolvedPort
-from gsim.fdtd.mesh_geometry import (
-    GEOMETRY_TOLERANCE_NM,
-    UM_TO_NM,
-    add_layer_volumes,
-)
+from gsim.fdtd.mesh_geometry import GEOMETRY_TOLERANCE_NM, UM_TO_NM
+from gsim.fdtd.mesh_loft import add_layer_volumes
 from gsim.fdtd.mesh_sizing import (
     geometry_aware_sizing,
     install_geometry_aware_mesh_field,

--- a/src/gsim/fdtd/mesh_geometry.py
+++ b/src/gsim/fdtd/mesh_geometry.py
@@ -229,15 +229,14 @@ def _add_polygon_prism(
     return volume_tag
 
 
-def add_layer_volumes(
+def _add_stepped_layer_volumes(
     kernel: Any,
     layer: ResolvedLayer,
     ports: list[ResolvedPort],
     *,
     nanometers_per_cell: float,
 ) -> list[int]:
-    """Create all unfused midpoint-slice prisms for one logical layer."""
-    _validate_layer(layer)
+    """Create midpoint-slice prisms when exact loft correspondence is unsafe."""
     slice_count = sidewall_slice_count(layer, nanometers_per_cell)
     z_lower_um, z_upper_um = layer.z_bounds
     volume_tags = []
@@ -268,7 +267,6 @@ def add_layer_volumes(
 __all__ = [
     "GEOMETRY_TOLERANCE_NM",
     "UM_TO_NM",
-    "add_layer_volumes",
     "iter_polygons",
     "sidewall_slice_count",
 ]

--- a/src/gsim/fdtd/mesh_loft.py
+++ b/src/gsim/fdtd/mesh_loft.py
@@ -1,0 +1,257 @@
+"""Continuous ruled sidewalls for GDSFactory FDTD transfer meshes."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from math import hypot
+from typing import Any
+
+from shapely.geometry import Polygon
+from shapely.geometry.polygon import orient
+
+from gsim.common.pdk import ResolvedLayer, ResolvedPort
+from gsim.fdtd.mesh_geometry import (
+    GEOMETRY_TOLERANCE_NM,
+    UM_TO_NM,
+    _add_stepped_layer_volumes,
+    _sidewall_offset_um,
+    _validate_layer,
+    iter_polygons,
+)
+from gsim.fdtd.models import FDTDGeometryError
+
+_EDGE_DIRECTION_TOLERANCE = 1e-7
+
+
+class LoftIncompatibleError(ValueError):
+    """Raised when exact bottom and top contours cannot be paired safely."""
+
+
+def _ring_coordinates(polygon: Polygon) -> list[tuple[float, float]]:
+    """Return an open counterclockwise exterior ring in micrometers."""
+    oriented_polygon = orient(polygon, sign=1.0)
+    return [
+        (float(point[0]), float(point[1]))
+        for point in list(oriented_polygon.exterior.coords)[:-1]
+    ]
+
+
+def _validate_edge_correspondence(
+    base_coordinates: list[tuple[float, float]],
+    offset_coordinates: list[tuple[float, float]],
+) -> None:
+    """Reject ring pairings whose corresponding edges are not parallel."""
+    point_count = len(base_coordinates)
+    for index in range(point_count):
+        base_start = base_coordinates[index]
+        base_end = base_coordinates[(index + 1) % point_count]
+        offset_start = offset_coordinates[index]
+        offset_end = offset_coordinates[(index + 1) % point_count]
+        base_vector = (
+            base_end[0] - base_start[0],
+            base_end[1] - base_start[1],
+        )
+        offset_vector = (
+            offset_end[0] - offset_start[0],
+            offset_end[1] - offset_start[1],
+        )
+        base_length = hypot(*base_vector)
+        offset_length = hypot(*offset_vector)
+        if base_length == 0 or offset_length == 0:
+            raise LoftIncompatibleError("A sidewall contour has a zero-length edge.")
+        cross_product = (
+            base_vector[0] * offset_vector[1] - base_vector[1] * offset_vector[0]
+        )
+        dot_product = (
+            base_vector[0] * offset_vector[0] + base_vector[1] * offset_vector[1]
+        )
+        if (
+            abs(cross_product) > _EDGE_DIRECTION_TOLERANCE * base_length * offset_length
+            or dot_product <= 0
+        ):
+            raise LoftIncompatibleError(
+                "Offsetting changed polygon edge correspondence."
+            )
+
+
+def _align_offset_ring(
+    base_coordinates: list[tuple[float, float]],
+    offset_coordinates: list[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    """Cyclically align a stable offset ring with its source vertices."""
+    if len(base_coordinates) != len(offset_coordinates):
+        raise LoftIncompatibleError("Offsetting changed the polygon vertex count.")
+    if len(base_coordinates) < 3:
+        raise LoftIncompatibleError("A sidewall contour has fewer than 3 vertices.")
+
+    base_x, base_y = base_coordinates[0]
+    best_shift = min(
+        range(len(offset_coordinates)),
+        key=lambda index: (base_x - offset_coordinates[index][0]) ** 2
+        + (base_y - offset_coordinates[index][1]) ** 2,
+    )
+    aligned_coordinates = [
+        offset_coordinates[(index + best_shift) % len(offset_coordinates)]
+        for index in range(len(offset_coordinates))
+    ]
+    _validate_edge_correspondence(base_coordinates, aligned_coordinates)
+    return aligned_coordinates
+
+
+def _align_ring_to_ports(
+    base_coordinates: list[tuple[float, float]],
+    offset_coordinates: list[tuple[float, float]],
+    ports: list[ResolvedPort],
+    offset_um: float,
+) -> list[tuple[float, float]]:
+    """Keep each tapered port end on its fixed simulation-domain plane."""
+    aligned_coordinates = [list(point) for point in offset_coordinates]
+    tolerance_um = GEOMETRY_TOLERANCE_NM / UM_TO_NM
+    matched_indices: dict[str, list[int]] = defaultdict(list)
+    for index, base_point in enumerate(base_coordinates):
+        for port in ports:
+            normal_axis = next(
+                axis for axis, component in enumerate(port.normal) if component
+            )
+            if normal_axis not in {0, 1}:
+                raise FDTDGeometryError(
+                    f"Guided port {port.name!r} is not in the component plane."
+                )
+            transverse_axis = 1 - normal_axis
+            transverse_delta = (
+                base_point[transverse_axis] - port.center[transverse_axis]
+            )
+            if (
+                abs(base_point[normal_axis] - port.center[normal_axis]) > tolerance_um
+                or abs(abs(transverse_delta) - port.width / 2) > tolerance_um
+            ):
+                continue
+            half_width = port.width / 2 + offset_um
+            if half_width <= 0:
+                raise FDTDGeometryError(
+                    f"Layer {port.layer_key!r} sidewall closes port {port.name!r}."
+                )
+            transverse_sign = 1.0 if transverse_delta > 0 else -1.0
+            aligned_coordinates[index][normal_axis] = port.center[normal_axis]
+            aligned_coordinates[index][transverse_axis] = (
+                port.center[transverse_axis] + transverse_sign * half_width
+            )
+            matched_indices[port.name].append(index)
+            break
+
+    point_count = len(base_coordinates)
+    for port in ports:
+        indices = matched_indices[port.name]
+        if len(indices) != 2 or (indices[0] - indices[1]) % point_count not in {
+            1,
+            point_count - 1,
+        }:
+            raise LoftIncompatibleError(
+                f"Port {port.name!r} does not map to one polygon edge."
+            )
+    return [(point[0], point[1]) for point in aligned_coordinates]
+
+
+def loft_section_polygons(
+    layer: ResolvedLayer,
+    ports: list[ResolvedPort],
+) -> tuple[Polygon, Polygon]:
+    """Prepare exact bottom and top contours with verified correspondence."""
+    base_polygons = iter_polygons(layer.geometry, layer_key=layer.key)
+    if len(base_polygons) != 1 or base_polygons[0].interiors:
+        raise LoftIncompatibleError(
+            "Lofting currently requires one connected polygon without holes."
+        )
+    base_coordinates = _ring_coordinates(base_polygons[0])
+    section_polygons = []
+    for normalized_z in (0.0, 1.0):
+        offset_um = _sidewall_offset_um(layer, normalized_z)
+        offset_geometry = layer.geometry.buffer(offset_um, join_style=2)
+        try:
+            offset_polygons = iter_polygons(offset_geometry, layer_key=layer.key)
+        except FDTDGeometryError as error:
+            raise LoftIncompatibleError(str(error)) from error
+        if len(offset_polygons) != 1 or offset_polygons[0].interiors:
+            raise LoftIncompatibleError(
+                "Offsetting changed the polygon component or hole topology."
+            )
+        offset_coordinates = _ring_coordinates(offset_polygons[0])
+        aligned_coordinates = _align_offset_ring(
+            base_coordinates,
+            offset_coordinates,
+        )
+        aligned_coordinates = _align_ring_to_ports(
+            base_coordinates,
+            aligned_coordinates,
+            ports,
+            offset_um,
+        )
+        section_polygon = Polygon(aligned_coordinates)
+        if (
+            section_polygon.is_empty
+            or not section_polygon.is_valid
+            or section_polygon.area <= 0
+        ):
+            raise LoftIncompatibleError("A port-aligned sidewall contour is invalid.")
+        section_polygons.append(section_polygon)
+    return section_polygons[0], section_polygons[1]
+
+
+def _add_polygon_wire(kernel: Any, polygon: Polygon, z_nm: float) -> int:
+    """Create one closed OCC wire from a preflighted polygon exterior."""
+    point_tags = [
+        kernel.addPoint(x_um * UM_TO_NM, y_um * UM_TO_NM, z_nm)
+        for x_um, y_um in _ring_coordinates(polygon)
+    ]
+    line_tags = [
+        kernel.addLine(point_tag, point_tags[(index + 1) % len(point_tags)])
+        for index, point_tag in enumerate(point_tags)
+    ]
+    return kernel.addWire(line_tags, checkClosed=True)
+
+
+def _add_lofted_layer_volumes(
+    kernel: Any,
+    layer: ResolvedLayer,
+    section_polygons: tuple[Polygon, Polygon],
+) -> list[int]:
+    """Create continuous ruled solids from verified bottom and top contours."""
+    bottom_polygon, top_polygon = section_polygons
+    z_lower_um, z_upper_um = layer.z_bounds
+    bottom_wire = _add_polygon_wire(kernel, bottom_polygon, z_lower_um * UM_TO_NM)
+    top_wire = _add_polygon_wire(kernel, top_polygon, z_upper_um * UM_TO_NM)
+    loft_entities = kernel.addThruSections(
+        [bottom_wire, top_wire],
+        makeSolid=True,
+        makeRuled=True,
+    )
+    volume_tags = [
+        entity_tag for dimension, entity_tag in loft_entities if dimension == 3
+    ]
+    if not volume_tags:
+        raise FDTDGeometryError(f"Layer {layer.key!r} produced no lofted volume.")
+    return volume_tags
+
+
+def add_layer_volumes(
+    kernel: Any,
+    layer: ResolvedLayer,
+    ports: list[ResolvedPort],
+    *,
+    nanometers_per_cell: float,
+) -> list[int]:
+    """Create a continuous sidewall loft, with stepped topology fallback."""
+    _validate_layer(layer)
+    try:
+        section_polygons = loft_section_polygons(layer, ports)
+    except LoftIncompatibleError:
+        return _add_stepped_layer_volumes(
+            kernel,
+            layer,
+            ports,
+            nanometers_per_cell=nanometers_per_cell,
+        )
+    return _add_lofted_layer_volumes(kernel, layer, section_polygons)
+
+
+__all__ = ["add_layer_volumes", "loft_section_polygons"]

--- a/tests/fdtd/test_mesh.py
+++ b/tests/fdtd/test_mesh.py
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 import pytest
 from shapely.geometry import MultiPolygon, Polygon
 
-from gsim.common.pdk import ResolvedLayer
+import gsim.fdtd.mesh_loft as mesh_loft
+from gsim.common.pdk import ResolvedLayer, ResolvedPort
 from gsim.fdtd.mesh import _priority_by_mesh_order
 from gsim.fdtd.mesh_geometry import iter_polygons, sidewall_slice_count
+from gsim.fdtd.mesh_loft import LoftIncompatibleError, loft_section_polygons
 
 
 def test_lower_pdk_mesh_order_becomes_higher_fdtd_priority() -> None:
@@ -49,6 +51,19 @@ def _resolved_layer(geometry: Polygon | MultiPolygon) -> ResolvedLayer:
     )
 
 
+def _resolved_port(name: str, x_um: float, normal_x: int) -> ResolvedPort:
+    return ResolvedPort(
+        name=name,
+        center=(x_um, 0, 0.11),
+        width=0.5,
+        orientation=180.0 if normal_x < 0 else 0.0,
+        normal=(normal_x, 0, 0),
+        port_type="optical",
+        layer_key="core",
+        material="Si",
+    )
+
+
 def test_sidewall_slices_bound_error_to_quarter_cell() -> None:
     layer = _resolved_layer(Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]))
 
@@ -71,3 +86,58 @@ def test_disconnected_polygons_retain_holes() -> None:
     assert len(polygons) == 2
     assert sum(len(polygon.interiors) for polygon in polygons) == 1
     assert sum(polygon.area for polygon in polygons) == pytest.approx(14)
+
+
+def test_loft_sections_follow_exact_sidewall_and_port_planes() -> None:
+    layer = _resolved_layer(Polygon([(0, -0.25), (1, -0.25), (1, 0.25), (0, 0.25)]))
+    ports = [_resolved_port("o1", 0, -1), _resolved_port("o2", 1, 1)]
+
+    bottom, top = loft_section_polygons(layer, ports)
+
+    sidewall_offset_um = 0.01939596787793115
+    assert bottom.bounds == pytest.approx(
+        (0, -0.25 - sidewall_offset_um, 1, 0.25 + sidewall_offset_um)
+    )
+    assert top.bounds == pytest.approx(
+        (0, -0.25 + sidewall_offset_um, 1, 0.25 - sidewall_offset_um)
+    )
+
+
+def test_loft_preflight_rejects_topology_without_ring_correspondence() -> None:
+    ring = Polygon(
+        [(0, 0), (4, 0), (4, 4), (0, 4)],
+        holes=[[(1, 1), (3, 1), (3, 3), (1, 3)]],
+    )
+
+    with pytest.raises(LoftIncompatibleError, match="without holes"):
+        loft_section_polygons(_resolved_layer(ring), [])
+
+
+def test_incompatible_loft_uses_stepped_fallback(monkeypatch) -> None:
+    ring = Polygon(
+        [(0, 0), (4, 0), (4, 4), (0, 4)],
+        holes=[[(1, 1), (3, 1), (3, 3), (1, 3)]],
+    )
+    fallback_calls = []
+
+    def fake_stepped_builder(kernel, layer, ports, *, nanometers_per_cell) -> list[int]:
+        fallback_calls.append((kernel, layer, ports, nanometers_per_cell))
+        return [42]
+
+    monkeypatch.setattr(
+        mesh_loft,
+        "_add_stepped_layer_volumes",
+        fake_stepped_builder,
+    )
+    kernel = object()
+    layer = _resolved_layer(ring)
+
+    volume_tags = mesh_loft.add_layer_volumes(
+        kernel,
+        layer,
+        [],
+        nanometers_per_cell=60,
+    )
+
+    assert volume_tags == [42]
+    assert fallback_calls == [(kernel, layer, [], 60)]

--- a/tests/fdtd/test_simulation.py
+++ b/tests/fdtd/test_simulation.py
@@ -21,6 +21,37 @@ def _physical_group_points(mesh: meshio.Mesh, name: str, cell_type: str) -> np.n
     return mesh.points[point_indices]
 
 
+def _internal_horizontal_boundary_faces(mesh: meshio.Mesh, name: str) -> np.ndarray:
+    """Return horizontal material-boundary faces away from its z extrema."""
+    physical_tag = mesh.field_data[name][0]
+    tetrahedra = mesh.cells_dict["tetra"]
+    tags = mesh.cell_data_dict["gmsh:physical"]["tetra"]
+    tetrahedra = tetrahedra[tags == physical_tag]
+    faces = np.concatenate(
+        [
+            tetrahedra[:, [0, 1, 2]],
+            tetrahedra[:, [0, 1, 3]],
+            tetrahedra[:, [0, 2, 3]],
+            tetrahedra[:, [1, 2, 3]],
+        ]
+    )
+    sorted_faces = np.sort(faces, axis=1)
+    _, unique_indices, counts = np.unique(
+        sorted_faces,
+        axis=0,
+        return_index=True,
+        return_counts=True,
+    )
+    boundary_faces = faces[unique_indices[counts == 1]]
+    face_z = mesh.points[boundary_faces, 2]
+    material_z = mesh.points[np.unique(tetrahedra), 2]
+    is_horizontal = np.ptp(face_z, axis=1) < 1e-6
+    is_internal = (face_z[:, 0] > material_z.min() + 1e-6) & (
+        face_z[:, 0] < material_z.max() - 1e-6
+    )
+    return boundary_faces[is_horizontal & is_internal]
+
+
 def test_write_uses_project_material_then_fallback_and_valid_mesh(
     tmp_path,
     fdtd_pdk_module,
@@ -67,10 +98,11 @@ def test_write_uses_project_material_then_fallback_and_valid_mesh(
 
     port_points = _physical_group_points(mesh, "port_o1", "triangle")
     assert port_points[:, 0] == pytest.approx(0)
-    assert port_points[:, 1].min() == pytest.approx(-259.697984, abs=1e-3)
-    assert port_points[:, 1].max() == pytest.approx(259.697984, abs=1e-3)
+    assert port_points[:, 1].min() == pytest.approx(-269.395968, abs=1e-3)
+    assert port_points[:, 1].max() == pytest.approx(269.395968, abs=1e-3)
     assert port_points[:, 2].min() == pytest.approx(0)
     assert port_points[:, 2].max() == pytest.approx(220)
+    assert len(_internal_horizontal_boundary_faces(mesh, "core")) == 0
 
     mesh_header = artifacts.mesh_path.read_text(encoding="utf8").splitlines()
     assert mesh_header[mesh_header.index("$MeshFormat") + 1] == "2.2 0 8"


### PR DESCRIPTION
Represent topology-stable PDK sidewall angles as continuous ruled OCC solids while preserving fixed guided-port planes. Geometry with incompatible component, hole, or edge correspondence safely retains the bounded-error stepped path.

The ruled loft was selected after benchmarking explicit faceting and 4/8-slice controls. For the GPDK mmi1x2 at 50 nm local sizing, production generates a 2.323 MB / 50,464-element mesh with an exact 10-degree boundary; ZapFDTD dry-run and the FDTD notebook pass.

Validated with 30 FDTD tests, targeted type checking, pre-commit hooks, notebook execution, and ZapFDTD dry-run.