### PR TITLE
feat: improve FDTD geometry viewer

### DIFF
--- a/docs/api/fdtd.md
+++ b/docs/api/fdtd.md
@@ -74,6 +74,7 @@ listed first, followed by the largest volumetric group and then the ports.
 ```python
 sim.plot_3d()                                   # solid interactive geometry
 sim.plot_3d(show_mesh=True)                     # add Gmsh surface edges
+sim.plot_3d(zoom_to_cursor=False)               # zoom toward the view center
 sim.plot_2d(axis="z", position_um=0.11)         # filled cross-section
 sim.plot_2d(axis="x", position_um=0, show_mesh=True)  # add cell edges
 ```
@@ -82,6 +83,13 @@ Omit `position_um` to start at the geometry midpoint. The 2D viewer includes a
 slider that moves the plane through the mesh. Both methods return a standalone
 `MeshViewer`. Set `show_mesh=True` when element edges are useful, or use
 `viewer.save("mesh.html")` to share the visualization outside a notebook.
+Zooming moves toward the pointer by default; set `zoom_to_cursor=False` to zoom
+toward the view center instead. The same choice is available in the viewer's
+**Zoom toward** controls.
+
+The viewer also summarizes the physical domain, estimated Yee-grid dimensions
+and total cell count (including PML). These values are estimates; the solver
+backend is authoritative when it constructs the final grid.
 
 ## Sources
 

--- a/src/gsim/fdtd/assets/mesh-viewer.html
+++ b/src/gsim/fdtd/assets/mesh-viewer.html
@@ -47,14 +47,7 @@
         display: none;
       }
       #panel-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-      }
-      h1 {
-        margin: 0;
-        font-size: 16px;
+        width: 100%;
       }
       .muted {
         color: #94a0b2;
@@ -65,6 +58,24 @@
         margin-top: 12px;
         padding-top: 10px;
         border-top: 1px solid #ffffff14;
+      }
+      .stats-title {
+        margin-bottom: 7px;
+      }
+      .stats-grid {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 4px 10px;
+        margin: 0;
+        font-size: 11px;
+      }
+      .stats-grid dt {
+        color: #94a0b2;
+      }
+      .stats-grid dd {
+        margin: 0;
+        color: #dce3ec;
+        text-align: right;
       }
       .row {
         display: flex;
@@ -96,19 +107,26 @@
         color: #9aa5b5;
       }
       #panel-toggle {
-        width: 32px;
-        height: 26px;
-        flex: 0 0 auto;
-        padding: 0;
-        border: 1px solid #ffffff14;
-        background: #ffffff08;
-        color: #94a0b2;
-        display: grid;
-        place-items: center;
+        width: 100%;
+        min-height: 26px;
+        padding: 4px 6px;
+        border: 0;
+        background: transparent;
+        color: #eef2f7;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      #panel-toggle .panel-title {
+        font-size: 16px;
+        font-weight: 700;
       }
       #panel-toggle svg {
+        flex: 0 0 auto;
         width: 14px;
         height: 14px;
+        color: #94a0b2;
         transform: rotate(180deg);
         transition: transform 160ms ease;
       }
@@ -118,15 +136,45 @@
       #panel-toggle:hover,
       #panel-toggle:focus-visible {
         background: #ffffff14;
+      }
+      #panel-toggle:hover svg,
+      #panel-toggle:focus-visible svg {
         color: #eef2f7;
       }
       input[type="range"] {
         width: 100%;
         accent-color: #4f91f7;
       }
+      .zoom-focus,
+      .zoom-options,
+      .zoom-option {
+        display: flex;
+        align-items: center;
+      }
+      .zoom-focus {
+        justify-content: space-between;
+        gap: 8px;
+      }
+      .zoom-options {
+        gap: 8px;
+      }
+      .zoom-option {
+        gap: 3px;
+        color: #c7d0dc;
+        font-size: 11px;
+        white-space: nowrap;
+        cursor: pointer;
+      }
+      input[type="radio"] {
+        margin: 0;
+        accent-color: #4f91f7;
+      }
       #error {
         color: #ff8f8f;
         white-space: pre-wrap;
+      }
+      #error:empty {
+        display: none;
       }
       #orientation-gizmo {
         position: absolute;
@@ -179,7 +227,6 @@
   <body>
     <div id="panel">
       <div id="panel-header">
-        <h1>GDSFactory FDTD</h1>
         <button
           id="panel-toggle"
           type="button"
@@ -188,6 +235,7 @@
           aria-label="Collapse controls"
           title="Collapse controls"
         >
+          <span class="panel-title">GDSFactory FDTD</span>
           <svg viewBox="0 0 20 20" fill="none" aria-hidden="true">
             <path
               d="m5 7.5 5 5 5-5"
@@ -200,7 +248,10 @@
         </button>
       </div>
       <div id="panel-body">
-        <div id="stats" class="section muted" hidden>Loading mesh...</div>
+        <div class="section">
+          <div class="muted">Physical groups</div>
+          <div id="groups"></div>
+        </div>
         <div id="slice-section" class="section" hidden>
           <div class="row">
             <label for="slice">Slice</label
@@ -208,14 +259,41 @@
           </div>
           <input id="slice" type="range" step="any" />
         </div>
-        <div class="section">
-          <div class="muted">Physical groups</div>
-          <div id="groups"></div>
-        </div>
         <div class="section muted">
-          Drag to rotate, scroll to zoom toward the cursor, right-drag to pan.
-          Slice views pan and zoom without rotation.
+          Drag to rotate, scroll to zoom, right-drag to pan. Slice views pan and
+          zoom without rotation.
         </div>
+        <div class="section">
+          <div
+            id="zoom-focus"
+            class="zoom-focus"
+            role="radiogroup"
+            aria-labelledby="zoom-focus-label"
+          >
+            <span id="zoom-focus-label" class="muted">Zoom toward</span>
+            <div class="zoom-options">
+              <label class="zoom-option" for="zoom-pointer">
+                <input
+                  id="zoom-pointer"
+                  type="radio"
+                  name="zoom-focus"
+                  value="pointer"
+                />
+                Pointer
+              </label>
+              <label class="zoom-option" for="zoom-center">
+                <input
+                  id="zoom-center"
+                  type="radio"
+                  name="zoom-focus"
+                  value="center"
+                />
+                View center
+              </label>
+            </div>
+          </div>
+        </div>
+        <div id="stats" class="section" hidden></div>
         <div id="error" class="section muted"></div>
       </div>
     </div>
@@ -308,7 +386,6 @@
       const showEdges =
         options.mode === "mesh" || options.mode === "mesh_slice";
       const statsPanel = document.getElementById("stats");
-      statsPanel.hidden = !showEdges;
       const axisIndex = { x: 0, y: 1, z: 2 }[options.axis];
       const axisVectors = [
         new THREE.Vector3(1, 0, 0),
@@ -326,15 +403,22 @@
         -1.5,
         1.8,
       ).normalize();
-      const physicalGroupPalette = [
-        0xff9fba, 0xb8b2b0, 0x55dfff, 0x69f0bd, 0xd6a4ff, 0xffe082, 0x7dd3fc,
-        0x9fe6cf,
-      ];
+      const physicalGroupPalette = [0x58c7a3, 0xff7a7a];
+      const largestGroupColor = 0xb8b2b0;
       const physicalGroupColors = new Map();
       const panel = document.getElementById("panel");
       const panelToggle = document.getElementById("panel-toggle");
+      const zoomPointer = document.getElementById("zoom-pointer");
+      const zoomCenter = document.getElementById("zoom-center");
       const orientationGizmo = document.getElementById("orientation-gizmo");
       orientationGizmo.hidden = isSlice;
+      zoomPointer.checked = options.zoomToCursor !== false;
+      zoomCenter.checked = !zoomPointer.checked;
+      for (const input of [zoomPointer, zoomCenter]) {
+        input.addEventListener("change", () => {
+          if (controls) controls.zoomToCursor = zoomPointer.checked;
+        });
+      }
 
       panelToggle.addEventListener("click", () => {
         const collapsed = panel.classList.toggle("collapsed");
@@ -348,6 +432,7 @@
       let controls;
       let cameraAnimation;
       let currentModel;
+      let currentLargestGroup = null;
       let groupRoots = new Map();
       let slicePosition = options.positionUm;
       let orthographicHalfHeight = 1;
@@ -643,6 +728,8 @@
 
       function colorFor(mesh, group) {
         if (isPortGroup(mesh, group)) return new THREE.Color(0xf4f7fb);
+        if (group === currentLargestGroup)
+          return new THREE.Color(largestGroupColor);
         if (!physicalGroupColors.has(group)) {
           physicalGroupColors.set(
             group,
@@ -766,13 +853,7 @@
           rawGeometry.dispose();
         }
         const color = colorFor(mesh, group);
-        const opacity = isLargestMaterial
-          ? isSlice
-            ? 0.55
-            : 0.35
-          : isSlice
-            ? 0.96
-            : 0.7;
+        const opacity = isLargestMaterial ? (isSlice ? 0.55 : 0.35) : 1;
         const material = new THREE.MeshStandardMaterial({
           color,
           roughness: 0.72,
@@ -781,9 +862,9 @@
             isSlice || group.startsWith("2_")
               ? THREE.DoubleSide
               : THREE.FrontSide,
-          transparent: true,
+          transparent: isLargestMaterial,
           opacity,
-          depthWrite: isSlice && !isLargestMaterial,
+          depthWrite: !isLargestMaterial,
           polygonOffset: true,
           polygonOffsetFactor: 1,
           polygonOffsetUnits: 1,
@@ -815,13 +896,64 @@
         groupRoots.set(group, groupRoot);
       }
 
+      function formatNumber(value, maximumFractionDigits = 2) {
+        return value.toLocaleString(undefined, { maximumFractionDigits });
+      }
+
+      function updateStats(mesh) {
+        const bounds = new THREE.Box3();
+        for (const point of mesh.nodes.values())
+          bounds.expandByPoint(new THREE.Vector3(...point));
+        const size = bounds.getSize(new THREE.Vector3()).toArray();
+        const stats = [
+          [
+            "Domain",
+            `${size.map((value) => formatNumber(value)).join(" × ")} µm`,
+          ],
+        ];
+        if (options.cellSizeNm) {
+          const pmlCells = options.pmlCells ?? 0;
+          const interiorGrid = size.map((value) =>
+            Math.ceil((value * 1000) / options.cellSizeNm),
+          );
+          const yeeGrid = interiorGrid.map((count) => count + 2 * pmlCells);
+          const totalCells = yeeGrid.reduce(
+            (product, count) => product * count,
+            1,
+          );
+          stats.push(
+            [
+              "Yee grid",
+              `\u2248 ${yeeGrid.map((value) => value.toLocaleString()).join(" × ")}`,
+            ],
+            ["Yee cells", `\u2248 ${totalCells.toLocaleString()}`],
+          );
+        }
+        const title = document.createElement("div");
+        title.className = "stats-title muted";
+        title.textContent = "Simulation estimate";
+        title.title =
+          "Yee-grid dimensions include PML cells on both sides of each axis.";
+        const list = document.createElement("dl");
+        list.className = "stats-grid";
+        for (const [label, value] of stats) {
+          const term = document.createElement("dt");
+          const description = document.createElement("dd");
+          term.textContent = label;
+          description.textContent = value;
+          list.append(term, description);
+        }
+        statsPanel.replaceChildren(title, list);
+        statsPanel.hidden = false;
+      }
+
       function buildModel(mesh) {
         disposeModel();
         groupRoots = new Map();
         const root = new THREE.Group();
         if (isSlice) {
           const groups = slicedGroups(mesh, slicePosition);
-          const largestGroup = largestMaterialGroup(mesh, groups);
+          currentLargestGroup = largestMaterialGroup(mesh, groups);
           for (const [group, data] of orderedGroupEntries(mesh, groups)) {
             addRenderable(
               root,
@@ -829,12 +961,12 @@
               group,
               new Float32Array(data.faces),
               new Float32Array(data.edges),
-              group === largestGroup,
+              group === currentLargestGroup,
             );
           }
         } else {
           const groups = surfaceGroups(mesh);
-          const largestGroup = largestMaterialGroup(mesh, groups);
+          currentLargestGroup = largestMaterialGroup(mesh, groups);
           for (const [group, tags] of orderedGroupEntries(mesh, groups)) {
             addRenderable(
               root,
@@ -842,7 +974,7 @@
               group,
               positionsForNodeTags(tags, mesh.nodes),
               null,
-              group === largestGroup,
+              group === currentLargestGroup,
             );
           }
         }
@@ -850,12 +982,7 @@
         currentModel = root;
         buildGroupControls(mesh);
         frameCamera(root);
-        const triangles = [...root.children].reduce(
-          (total, child) =>
-            total + child.children[0].geometry.attributes.position.count / 3,
-          0,
-        );
-        statsPanel.textContent = `${mesh.nodes.size.toLocaleString()} nodes \u00b7 ${Math.round(triangles).toLocaleString()} visible triangles`;
+        updateStats(mesh);
       }
 
       function buildGroupControls(mesh) {
@@ -884,7 +1011,7 @@
         controls.enableDamping = true;
         controls.dampingFactor = 0.06;
         controls.screenSpacePanning = true;
-        controls.zoomToCursor = true;
+        controls.zoomToCursor = zoomPointer.checked;
         controls.enableRotate = !isSlice;
       }
 
@@ -936,21 +1063,28 @@
       }
 
       function snapCamera(direction) {
-        if (!camera || !controls || isSlice) return;
+        if (!camera || !controls || !currentModel || isSlice) return;
         const normalizedDirection = direction.clone().normalize();
-        const center = controls.target.clone();
-        const distance = Math.max(camera.position.distanceTo(center), 0.001);
+        const startTarget = controls.target.clone();
+        const modelBox = new THREE.Box3().setFromObject(currentModel);
+        if (modelBox.isEmpty()) return;
+        const target = modelBox.getCenter(new THREE.Vector3());
+        const distance = Math.max(
+          camera.position.distanceTo(startTarget),
+          0.001,
+        );
         const targetUp =
           Math.abs(normalizedDirection.dot(zUp)) > 0.999
             ? new THREE.Vector3(0, 1, 0)
             : zUp.clone();
         cameraAnimation = {
-          center,
           duration: 0.35,
           elapsed: 0,
           startPosition: camera.position.clone(),
+          startTarget,
           startUp: camera.up.clone(),
-          targetPosition: center
+          target,
+          targetPosition: target
             .clone()
             .addScaledVector(normalizedDirection, distance),
           targetUp,
@@ -974,7 +1108,12 @@
         camera.up
           .lerpVectors(cameraAnimation.startUp, cameraAnimation.targetUp, eased)
           .normalize();
-        camera.lookAt(cameraAnimation.center);
+        controls.target.lerpVectors(
+          cameraAnimation.startTarget,
+          cameraAnimation.target,
+          eased,
+        );
+        camera.lookAt(controls.target);
         if (progress === 1) {
           cameraAnimation = undefined;
           controls.enabled = true;

--- a/src/gsim/fdtd/viz.py
+++ b/src/gsim/fdtd/viz.py
@@ -46,6 +46,9 @@ def plot_mesh(
     position_um: float | None = None,
     show_groups: Sequence[str] | None = None,
     hide_groups: Sequence[str] = (),
+    zoom_to_cursor: bool = True,
+    cell_size_nm: float | None = None,
+    pml_cells: int | None = None,
     height: int = 600,
 ) -> MeshViewer:
     """Build an interactive ZapFDTD-style viewer for a Gmsh mesh.
@@ -63,16 +66,23 @@ def plot_mesh(
         raise ValueError(f"axis must be 'x', 'y', or 'z', got {axis!r}")
     if position_um is not None and not isfinite(position_um):
         raise ValueError("position_um must be finite when provided")
+    if cell_size_nm is not None and (not isfinite(cell_size_nm) or cell_size_nm <= 0):
+        raise ValueError("cell_size_nm must be positive and finite when provided")
+    if pml_cells is not None and pml_cells < 0:
+        raise ValueError("pml_cells must be nonnegative when provided")
     if height <= 0:
         raise ValueError("height must be positive")
 
     template = files("gsim.fdtd").joinpath("assets/mesh-viewer.html").read_text("utf8")
     options = {
         "axis": axis,
+        "cellSizeNm": cell_size_nm,
         "hideGroups": list(hide_groups),
         "mode": mode,
+        "pmlCells": pml_cells,
         "positionUm": position_um,
         "showGroups": None if show_groups is None else list(show_groups),
+        "zoomToCursor": zoom_to_cursor,
     }
     html = template.replace(
         "__GSIM_MESH_DATA__", _script_json(path.read_text(encoding="utf8"))

--- a/src/gsim/fdtd/workflow.py
+++ b/src/gsim/fdtd/workflow.py
@@ -321,6 +321,7 @@ class Simulation(CloudWorkflowMixin, RuntimeConfigMixin):
         position_um: float | None = None,
         show_groups: Sequence[str] | None = None,
         hide_groups: Sequence[str] = (),
+        zoom_to_cursor: bool = True,
         height: int = 600,
     ) -> Any:
         """Render the current or a temporary mesh with the FDTD viewer."""
@@ -337,6 +338,9 @@ class Simulation(CloudWorkflowMixin, RuntimeConfigMixin):
                 position_um=position_um,
                 show_groups=show_groups,
                 hide_groups=hide_groups,
+                zoom_to_cursor=zoom_to_cursor,
+                cell_size_nm=self.solver.cell_size_nm,
+                pml_cells=self.domain.pml_cells,
                 height=height,
             )
 
@@ -351,6 +355,9 @@ class Simulation(CloudWorkflowMixin, RuntimeConfigMixin):
                     position_um=position_um,
                     show_groups=show_groups,
                     hide_groups=hide_groups,
+                    zoom_to_cursor=zoom_to_cursor,
+                    cell_size_nm=self.solver.cell_size_nm,
+                    pml_cells=self.domain.pml_cells,
                     height=height,
                 )
             finally:
@@ -362,6 +369,7 @@ class Simulation(CloudWorkflowMixin, RuntimeConfigMixin):
         show_mesh: bool = False,
         show_groups: Sequence[str] | None = None,
         hide_groups: Sequence[str] = (),
+        zoom_to_cursor: bool = True,
         height: int = 600,
     ) -> Any:
         """Show the 3D geometry, optionally with Gmsh surface edges."""
@@ -369,6 +377,7 @@ class Simulation(CloudWorkflowMixin, RuntimeConfigMixin):
             mode="mesh" if show_mesh else "surface",
             show_groups=show_groups,
             hide_groups=hide_groups,
+            zoom_to_cursor=zoom_to_cursor,
             height=height,
         )
 
@@ -380,6 +389,7 @@ class Simulation(CloudWorkflowMixin, RuntimeConfigMixin):
         show_mesh: bool = False,
         show_groups: Sequence[str] | None = None,
         hide_groups: Sequence[str] = (),
+        zoom_to_cursor: bool = True,
         height: int = 600,
     ) -> Any:
         """Show a filled cross-section, optionally with intersected cell edges."""
@@ -390,6 +400,7 @@ class Simulation(CloudWorkflowMixin, RuntimeConfigMixin):
             position_um=position_um,
             show_groups=show_groups,
             hide_groups=hide_groups,
+            zoom_to_cursor=zoom_to_cursor,
             height=height,
         )
 

--- a/tests/fdtd/test_viz.py
+++ b/tests/fdtd/test_viz.py
@@ -42,6 +42,8 @@ def test_viewer_embeds_mesh_and_slice_options(tmp_path: Path) -> None:
         axis="x",
         position_um=0.25,
         show_groups=["core"],
+        cell_size_nm=50,
+        pml_cells=8,
         height=420,
     )
     compact_html = "".join(viewer.html.split())
@@ -49,18 +51,33 @@ def test_viewer_embeds_mesh_and_slice_options(tmp_path: Path) -> None:
     assert isinstance(viewer, MeshViewer)
     assert '"mode":"mesh_slice"' in viewer.html
     assert '"positionUm":0.25' in viewer.html
+    assert '"zoomToCursor":true' in viewer.html
+    assert '"cellSizeNm":50' in viewer.html
+    assert '"pmlCells":8' in viewer.html
     assert "$MeshFormat\\n2.2" in viewer.html
     assert "__GSIM_" not in viewer.html
     assert 'id="mode"' not in viewer.html
-    assert 'id="stats" class="section muted" hidden' in viewer.html
+    assert 'id="stats" class="section" hidden' in viewer.html
     assert 'id="gizmo-center-target"' in viewer.html
     assert 'id="gizmo-x-target"' in viewer.html
     assert 'id="gizmo-y-target"' in viewer.html
     assert 'id="gizmo-z-target"' in viewer.html
     assert 'id="panel-toggle"' in viewer.html
+    assert '<span class="panel-title">GDSFactory FDTD</span>' in viewer.html
     assert 'aria-controls="panel-body"' in viewer.html
+    assert 'role="radiogroup"' in viewer.html
+    assert '<span id="zoom-focus-label" class="muted">Zoom toward</span>' in viewer.html
+    assert 'id="zoom-pointer"' in viewer.html
+    assert 'id="zoom-center"' in viewer.html
+    physical_groups_index = viewer.html.index(
+        '<div class="muted">Physical groups</div>'
+    )
+    zoom_controls_index = viewer.html.index('id="zoom-focus"')
+    stats_index = viewer.html.index('id="stats" class="section" hidden')
+    assert physical_groups_index < zoom_controls_index < stats_index
     assert 'd="m5 7.5 5 5 5-5"' in viewer.html
     assert 'panel.classList.toggle("collapsed")' in viewer.html
+    assert "#panel-toggle{width:100%;" in compact_html
     assert ".gizmo-axis{stroke:#4f9cff;" in compact_html
     assert ".gizmo-axis-targetcircle{fill:#4f9cff;" in compact_html
     assert "camera.up.copy(zUp)" in viewer.html
@@ -69,16 +86,30 @@ def test_viewer_embeds_mesh_and_slice_options(tmp_path: Path) -> None:
         in compact_html
     )
     assert "keyLight.position.set(3, -5, 4)" in viewer.html
-    assert "controls.zoomToCursor = true" in viewer.html
+    assert "zoomPointer.checked = options.zoomToCursor !== false" in viewer.html
+    assert "controls.zoomToCursor = zoomPointer.checked" in viewer.html
+    assert "const startTarget = controls.target.clone()" in viewer.html
+    assert (
+        "const modelBox = new THREE.Box3().setFromObject(currentModel)" in viewer.html
+    )
+    assert "controls.target.lerpVectors(" in viewer.html
     assert 'button.className = "group-button"' in viewer.html
     assert 'startsWith("port_")' in viewer.html
     assert "new THREE.Color(0xf4f7fb)" in viewer.html
-    assert "constphysicalGroupPalette=[0xff9fba,0xb8b2b0,0x55dfff" in compact_html
+    assert "constphysicalGroupPalette=[0x58c7a3,0xff7a7a];" in compact_html
+    assert "constlargestGroupColor=0xb8b2b0;" in compact_html
+    assert "if(group===currentLargestGroup)" in compact_html
+    assert 'title.textContent = "Simulation estimate"' in viewer.html
+    assert "\\u2248 ${totalCells.toLocaleString()}" in viewer.html
+    assert '"Grid / PML",' not in viewer.html
+    assert '"Transfer mesh",' not in viewer.html
     assert "setHSL" not in viewer.html
     assert "function tetrahedronVolume" in viewer.html
     assert "function largestMaterialGroup" in viewer.html
     assert "function orderedGroupEntries" in viewer.html
-    assert "constopacity=isLargestMaterial?isSlice?0.55:0.35:" in compact_html
+    assert "constopacity=isLargestMaterial?(isSlice?0.55:0.35):1;" in compact_html
+    assert "transparent:isLargestMaterial" in compact_html
+    assert "depthWrite:!isLargestMaterial" in compact_html
     assert 'height="420"' in viewer._repr_html_()
     assert viewer.save(tmp_path / "viewer.html").is_file()
 
@@ -93,10 +124,14 @@ def test_simulation_view_methods_reuse_last_mesh(tmp_path: Path) -> None:
     assert '"mode":"surface"' in simulation.plot_3d().html
     assert '"hideGroups":[]' in simulation.plot_3d().html
     assert '"mode":"mesh"' in simulation.plot_3d(show_mesh=True).html
+    assert '"cellSizeNm":60.0' in simulation.plot_3d().html
+    assert '"pmlCells":32' in simulation.plot_3d().html
+    assert '"zoomToCursor":false' in simulation.plot_3d(zoom_to_cursor=False).html
     slice_html = simulation.plot_2d().html
     assert '"mode":"slice"' in slice_html
     assert '"positionUm":0.2' in slice_html
     assert '"mode":"mesh_slice"' in simulation.plot_2d(show_mesh=True).html
+    assert '"zoomToCursor":false' in simulation.plot_2d(zoom_to_cursor=False).html
     assert not hasattr(simulation, "plot_mesh")
     assert not hasattr(simulation, "plot_mesh_slice")
 


### PR DESCRIPTION
Improve the interactive FDTD geometry viewer:

- add pointer/view-center zoom controls and recenter gizmo camera snaps
- make the full header collapsible and streamline the panel layout
- use opaque mint/coral groups with translucent grey reserved for the largest group
- show compact physical-domain and estimated Yee-grid/cell statistics