### PR TITLE
feat: generate FDTD materials from MaterialCards

### DIFF
--- a/docs/api/fdtd.md
+++ b/docs/api/fdtd.md
@@ -51,6 +51,35 @@ hole, or edge topology, meshing safely falls back to vertical slices bounded by
 Use `write(path)` to generate `mesh.msh` and `config.json` without submitting.
 The original flat constructor keywords remain accepted for compatibility.
 
+## Material cards and dispersion
+
+Every material referenced by the component stack or selected as the background
+must resolve to a `pdk_schema.MaterialCard`. Project PDK cards take precedence;
+gsim supplies fallback cards for common `Si`, `SiO2`, and `SiN` spellings.
+`gsim.fdtd` translates the card's optical model directly into the material entry
+expected by ZapFDTD:
+
+| MaterialCard optical model | ZapFDTD material entry |
+| --- | --- |
+| Scalar refractive index or permittivity | `refractive_index` |
+| Tabulated refractive index or permittivity | `dispersion.table` |
+| Sellmeier | `dispersion.sellmeier` |
+| Single-term Drude or Lorentz | `dispersion.drude_lorentz` |
+
+The source band must lie inside the card's validity and tabulated wavelength
+range. ZapFDTD performs the authoritative fit, passivity, stability, and
+accuracy checks when it builds the simulation. Consequently, a coarse table can
+still fail backend validation even when its JSON structure is valid.
+
+Continuous-wave and zero-span port sources do not provide the nonzero fitting
+band currently required by ZapFDTD, so they cannot be combined with a
+dispersive card. Unsupported card models, anisotropy, conductivity, and magnetic
+permeability fail explicitly rather than being reduced silently to a scalar.
+
+The legacy `materials(overrides={"si": 3.47})` shorthand remains supported. It
+creates a temporary constant-index `MaterialCard`; the serialization path still
+consumes the card rather than bypassing material resolution.
+
 Optional `x_bounds`, `y_bounds`, and `z_bounds` tuples set the non-PML physical
 domain in micrometers. Omitted axes remain automatically sized from the
 component, PDK stack, and padding. Explicit bounds must contain the geometry,

--- a/docs/api/fdtd.md
+++ b/docs/api/fdtd.md
@@ -57,9 +57,9 @@ Every material referenced by the component stack or selected as the background
 must resolve to a `pdk_schema.MaterialCard`. Project PDK cards take precedence;
 gsim supplies fallback cards for common `Si`, `SiO2`, and `SiN` spellings.
 `gsim.fdtd` translates the card's optical model directly into the material entry
-expected by ZapFDTD:
+expected by GDSFactory FDTD:
 
-| MaterialCard optical model | ZapFDTD material entry |
+| MaterialCard optical model | GDSFactory FDTD material entry |
 | --- | --- |
 | Scalar refractive index or permittivity | `refractive_index` |
 | Tabulated refractive index or permittivity | `dispersion.table` |
@@ -67,12 +67,12 @@ expected by ZapFDTD:
 | Single-term Drude or Lorentz | `dispersion.drude_lorentz` |
 
 The source band must lie inside the card's validity and tabulated wavelength
-range. ZapFDTD performs the authoritative fit, passivity, stability, and
+range. GDSFactory FDTD performs the authoritative fit, passivity, stability, and
 accuracy checks when it builds the simulation. Consequently, a coarse table can
 still fail backend validation even when its JSON structure is valid.
 
 Continuous-wave and zero-span port sources do not provide the nonzero fitting
-band currently required by ZapFDTD, so they cannot be combined with a
+band currently required by GDSFactory FDTD, so they cannot be combined with a
 dispersive card. Unsupported card models, anisotropy, conductivity, and magnetic
 permeability fail explicitly rather than being reduced silently to a scalar.
 
@@ -96,7 +96,7 @@ sim.domain(
 
 ## Setup visualization
 
-FDTD setup views use the ported ZapFDTD Three.js viewer and do not depend on
+FDTD setup views use the ported GDSFactory FDTD Three.js viewer and do not depend on
 PyVista. All physical groups are shown by default. Smaller material groups are
 listed first, followed by the largest volumetric group and then the ports.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ gf.gpdk.PDK.activate()
 component = gf.get_component("mmi1x2")
 
 simulation = fdtd.Simulation()
-simulation.materials(background="SiO2", overrides={"si": 3.4757})
+simulation.materials(background="SiO2")
 simulation.geometry(component)
 simulation.source(port="o1", wavelength_span_um=0.1)
 
@@ -38,7 +38,6 @@ result.plot_plotly()
 
 Over the next six months, we plan to add:
 
-- Material dispersion
 - Anisotropic materials
 - Periodic boundary conditions
 - Gradients for inverse design

--- a/nbs/fdtd_broadband_directional_coupler.ipynb
+++ b/nbs/fdtd_broadband_directional_coupler.ipynb
@@ -103,7 +103,7 @@
    "outputs": [],
    "source": [
     "simulation = fdtd.Simulation()\n",
-    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757})\n",
+    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757, \"SiO2\": 1.444})\n",
     "simulation.geometry(component)\n",
     "simulation.source(\n",
     "    port=\"o1\",\n",

--- a/nbs/fdtd_directional_coupler.ipynb
+++ b/nbs/fdtd_directional_coupler.ipynb
@@ -100,7 +100,7 @@
    "outputs": [],
    "source": [
     "simulation = fdtd.Simulation()\n",
-    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757})\n",
+    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757, \"SiO2\": 1.444})\n",
     "simulation.geometry(component)\n",
     "simulation.source(\n",
     "    port=\"o1\",\n",

--- a/nbs/fdtd_mmi_gpdk.ipynb
+++ b/nbs/fdtd_mmi_gpdk.ipynb
@@ -100,7 +100,7 @@
    "outputs": [],
    "source": [
     "simulation = fdtd.Simulation()\n",
-    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757})\n",
+    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757, \"SiO2\": 1.444})\n",
     "simulation.geometry(component)\n",
     "simulation.source(\n",
     "    port=\"o1\",\n",

--- a/nbs/fdtd_waveguide_crossing.ipynb
+++ b/nbs/fdtd_waveguide_crossing.ipynb
@@ -100,7 +100,7 @@
    "outputs": [],
    "source": [
     "simulation = fdtd.Simulation()\n",
-    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757})\n",
+    "simulation.materials(background=\"SiO2\", overrides={\"si\": 3.4757, \"SiO2\": 1.444})\n",
     "simulation.geometry(component)\n",
     "simulation.source(\n",
     "    port=\"o1\",\n",

--- a/src/gsim/common/materials/_helpers.py
+++ b/src/gsim/common/materials/_helpers.py
@@ -2,11 +2,10 @@
 
 from pdk_schema import (
     Band,
-    Index,
+    DispersionModel,
     MaterialCard,
     Provenance,
     Regime,
-    Sellmeier,
     Validity,
 )
 
@@ -29,7 +28,7 @@ def wavelength_validity(minimum_um: float, maximum_um: float) -> Validity:
 
 def material_card(
     name: str,
-    permittivity: Index | Sellmeier,
+    permittivity: DispersionModel,
     temperature_ref: float | None,
 ) -> MaterialCard:
     """Build a compact optical material card."""

--- a/src/gsim/common/materials/registry.py
+++ b/src/gsim/common/materials/registry.py
@@ -15,11 +15,14 @@ MaterialSource = Literal["project", "gsim"]
 
 GSIM_MATERIAL_CARDS: dict[str, MaterialCard] = {
     "Si": SI_SALZBERG.model_copy(update={"name": "Si"}),
+    "si": SI_SALZBERG.model_copy(update={"name": "si"}),
     "Si-Salzberg": SI_SALZBERG,
     "Si-Li-293K": SI_LI_293K,
     "SiN": SIN_LUKE.model_copy(update={"name": "SiN"}),
+    "sin": SIN_LUKE.model_copy(update={"name": "sin"}),
     "SiN-Luke": SIN_LUKE,
     "SiO2": SIO2_MALITSON.model_copy(update={"name": "SiO2"}),
+    "sio2": SIO2_MALITSON.model_copy(update={"name": "sio2"}),
     "SiO2-Malitson": SIO2_MALITSON,
 }
 

--- a/src/gsim/common/materials/snapshots.py
+++ b/src/gsim/common/materials/snapshots.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from itertools import pairwise
-from math import isfinite, sqrt
+from math import hypot, isfinite, pi, sqrt
 from typing import Any
 
-from pdk_schema import Index, MaterialCard, ScalarValue, Sellmeier, TabulatedValue
+from pdk_schema import (
+    Drude,
+    Index,
+    Lorentz,
+    MaterialCard,
+    Permittivity,
+    ScalarValue,
+    Sellmeier,
+    SellmeierPoleSquared,
+    TabulatedValue,
+)
+from scipy.constants import c as C0  # noqa: N812
 
 from gsim.common.materials.registry import MaterialSource, find_material_card
 
@@ -158,6 +169,21 @@ def _evaluate_permittivity(
                 f"Material {card.name!r} produced non-positive index squared."
             )
         return sqrt(index_squared), 0.0
+    if isinstance(model, SellmeierPoleSquared):
+        wavelength_squared = wavelength_um**2
+        index_squared = (
+            1.0
+            + model.offset
+            + sum(
+                term.b * wavelength_squared / (wavelength_squared - term.c_um2)
+                for term in model.terms
+            )
+        )
+        if index_squared <= 0:
+            raise MaterialModelError(
+                f"Material {card.name!r} produced non-positive index squared."
+            )
+        return sqrt(index_squared), 0.0
     if isinstance(model, Index):
         if isinstance(model.n, list):
             raise MaterialModelError(
@@ -171,9 +197,52 @@ def _evaluate_permittivity(
                 "Tensor extinction coefficients are not supported for passive FDTD."
             )
         return refractive_index, _evaluate_value(model.k, wavelength_um)
+    if isinstance(model, Permittivity):
+        if isinstance(model.eps_real, list) or isinstance(model.eps_imag, list):
+            raise MaterialModelError(
+                "Tensor permittivities are not supported for passive FDTD."
+            )
+        eps_real = _evaluate_value(model.eps_real, wavelength_um)
+        eps_imag = (
+            0.0
+            if model.eps_imag is None
+            else _evaluate_value(model.eps_imag, wavelength_um)
+        )
+        return _complex_index(eps_real, eps_imag)
+    angular_frequency = 2 * pi * C0 / (wavelength_um * 1e-6)
+    if isinstance(model, Drude):
+        permittivity = complex(model.eps_inf, 0.0)
+        for term in model.terms:
+            permittivity -= term.omega_p**2 / complex(
+                angular_frequency**2,
+                term.gamma * angular_frequency,
+            )
+        return _complex_index(permittivity.real, permittivity.imag)
+    if isinstance(model, Lorentz):
+        permittivity = complex(model.eps_inf, 0.0)
+        for term in model.terms:
+            permittivity += (
+                term.delta_eps
+                * term.omega_0**2
+                / complex(
+                    term.omega_0**2 - angular_frequency**2,
+                    -term.gamma * angular_frequency,
+                )
+            )
+        return _complex_index(permittivity.real, permittivity.imag)
     raise MaterialModelError(
         f"Unsupported optical model {type(model).__name__} for material {card.name!r}."
     )
+
+
+def _complex_index(eps_real: float, eps_imag: float) -> tuple[float, float]:
+    """Return the passive square root of one complex relative permittivity."""
+    magnitude = hypot(eps_real, eps_imag)
+    refractive_index = sqrt(max(0.0, (magnitude + eps_real) / 2))
+    extinction_coefficient = sqrt(max(0.0, (magnitude - eps_real) / 2))
+    if eps_imag < 0:
+        extinction_coefficient = -extinction_coefficient
+    return refractive_index, extinction_coefficient
 
 
 def resolve_material_snapshot(

--- a/src/gsim/fdtd/__init__.py
+++ b/src/gsim/fdtd/__init__.py
@@ -43,7 +43,7 @@ from gsim.gcloud import RunResult, register_result_parser
 
 
 def _parse_fdtd_result(run_result: RunResult) -> FDTDResult:
-    """Parse downloaded ZapFDTD JSON and sidecar outputs."""
+    """Parse downloaded GDSFactory FDTD JSON and sidecar outputs."""
     return FDTDResult.from_run_result(run_result)
 
 

--- a/src/gsim/fdtd/api.py
+++ b/src/gsim/fdtd/api.py
@@ -159,7 +159,7 @@ class Source(_MutableModel):
 
     @property
     def wavelength_halfspan_um(self) -> float:
-        """Return the half-span expected by the ZapFDTD runtime schema."""
+        """Return the half-span expected by the GDSFactory FDTD runtime schema."""
         return self.wavelength_span_um / 2
 
 

--- a/src/gsim/fdtd/api.py
+++ b/src/gsim/fdtd/api.py
@@ -79,13 +79,13 @@ class Geometry(BaseModel):
 
 
 class Material(_MutableModel):
-    """Lossless scalar material override at the source wavelength."""
+    """Compatibility shorthand for a constant-index MaterialCard override."""
 
     refractive_index: float = Field(gt=0)
 
 
 class Materials(_MutableModel):
-    """Background material and optional refractive-index overrides."""
+    """Background card selection and optional constant-card overrides."""
 
     background: str = Field(default="SiO2", min_length=1)
     overrides: dict[str, Material] = Field(default_factory=dict)

--- a/src/gsim/fdtd/config.py
+++ b/src/gsim/fdtd/config.py
@@ -8,6 +8,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from gsim.common.materials import MaterialSnapshot
+from gsim.fdtd.material_config import MaterialConfig, material_config_from_snapshot
 from gsim.fdtd.models import FDTDConfigError, MeshManifest
 
 
@@ -15,12 +16,6 @@ class _StrictModel(BaseModel):
     """Base model that rejects fields GDSFactory FDTD does not understand."""
 
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
-
-
-class MaterialConfig(_StrictModel):
-    """Scalar real optical material supported by GDSFactory FDTD schema v1."""
-
-    refractive_index: float = Field(gt=0)
 
 
 class RegionConfig(_StrictModel):
@@ -191,6 +186,28 @@ class ExcitationConfig(_StrictModel):
         return self
 
 
+def _source_wavelength_range_nm(
+    excitation: ExcitationConfig,
+) -> tuple[float, float] | None:
+    """Return the nonzero wavelength band ZapFDTD derives from the source."""
+    if excitation.waveform == "continuous_wave":
+        return None
+    center = excitation.center_wavelength
+    halfspan = excitation.wavelength_halfspan
+    if excitation.type == "eigenmode":
+        return (center - halfspan, center + halfspan) if halfspan > 0 else None
+    frequency_center = 1.0 / center
+    frequency_width = (
+        0.5 * (1.0 / (center - halfspan) - 1.0 / (center + halfspan))
+        if halfspan > 0
+        else frequency_center * 0.1
+    )
+    return (
+        1.0 / (frequency_center + frequency_width),
+        1.0 / (frequency_center - frequency_width),
+    )
+
+
 class GridConfig(_StrictModel):
     """Yee-grid and PML settings."""
 
@@ -252,18 +269,6 @@ class FDTDConfig(_StrictModel):
         return self
 
 
-def _material_config(snapshot: MaterialSnapshot) -> MaterialConfig:
-    """Convert one lossless scalar snapshot to the GDSFactory FDTD schema."""
-    if snapshot.extinction_coefficient != 0:
-        raise FDTDConfigError(
-            f"Material {snapshot.material_name!r} has extinction coefficient "
-            f"{snapshot.extinction_coefficient}; GDSFactory FDTD schema v1 "
-            "supports only "
-            "lossless real refractive indices."
-        )
-    return MaterialConfig(refractive_index=snapshot.refractive_index)
-
-
 def build_fdtd_config(
     manifest: MeshManifest,
     material_snapshots: Mapping[str, MaterialSnapshot],
@@ -287,12 +292,23 @@ def build_fdtd_config(
         raise FDTDConfigError(
             f"Background material {background_material!r} has no snapshot."
         )
+    resolved_excitation = excitation or ExcitationConfig(
+        type="gaussian_beam" if gaussian_beam is not None else "eigenmode",
+        center_wavelength=center_wavelength_nm,
+        wavelength_halfspan=wavelength_halfspan_nm,
+        num_wavelengths=num_wavelengths,
+        default_port=default_port,
+        gaussian_beam=gaussian_beam,
+    )
+    source_wavelength_range_nm = _source_wavelength_range_nm(resolved_excitation)
     materials = {
-        name: _material_config(snapshot)
+        name: material_config_from_snapshot(snapshot, source_wavelength_range_nm)
         for name, snapshot in material_snapshots.items()
     }
     return FDTDConfig(
-        background_refractive_index=materials[background_material].refractive_index,
+        background_refractive_index=material_snapshots[
+            background_material
+        ].refractive_index,
         materials=materials,
         geometry=GeometryConfig(
             volumes={
@@ -320,15 +336,7 @@ def build_fdtd_config(
                 for name, group in manifest.ports.items()
             },
         ),
-        excitation=excitation
-        or ExcitationConfig(
-            type="gaussian_beam" if gaussian_beam is not None else "eigenmode",
-            center_wavelength=center_wavelength_nm,
-            wavelength_halfspan=wavelength_halfspan_nm,
-            num_wavelengths=num_wavelengths,
-            default_port=default_port,
-            gaussian_beam=gaussian_beam,
-        ),
+        excitation=resolved_excitation,
         monitors=monitors or [],
         grid=GridConfig(
             nanometers_per_cell=nanometers_per_cell,

--- a/src/gsim/fdtd/config.py
+++ b/src/gsim/fdtd/config.py
@@ -189,7 +189,7 @@ class ExcitationConfig(_StrictModel):
 def _source_wavelength_range_nm(
     excitation: ExcitationConfig,
 ) -> tuple[float, float] | None:
-    """Return the nonzero wavelength band ZapFDTD derives from the source."""
+    """Return the nonzero wavelength band GDSFactory FDTD derives from the source."""
     if excitation.waveform == "continuous_wave":
         return None
     center = excitation.center_wavelength

--- a/src/gsim/fdtd/material_config.py
+++ b/src/gsim/fdtd/material_config.py
@@ -1,4 +1,4 @@
-"""Translate optical MaterialCards into ZapFDTD material configuration."""
+"""Translate optical MaterialCards into GDSFactory FDTD material configuration."""
 
 from __future__ import annotations
 
@@ -76,7 +76,7 @@ def _table_samples(
     if table.interp != "linear":
         raise _config_error(
             material_name,
-            f"{field} uses {table.interp!r} interpolation; ZapFDTD requires "
+            f"{field} uses {table.interp!r} interpolation; GDSFactory FDTD requires "
             "linear table semantics.",
         )
     wavelengths = _wavelengths_nm(coordinate.values, coordinate.unit, material_name)
@@ -106,7 +106,7 @@ def _require_fit_band(
         raise _config_error(
             material_name,
             "is dispersive, but the excitation does not provide the nonzero "
-            "frequency band required by ZapFDTD.",
+            "frequency band required by GDSFactory FDTD.",
         )
     return wavelength_range_nm
 
@@ -156,10 +156,11 @@ def _index_config(
     wavelength_range_nm: tuple[float, float] | None,
     material_name: str,
 ) -> MaterialConfig:
-    """Translate an index-authored card model to ZapFDTD."""
+    """Translate an index-authored card model to GDSFactory FDTD."""
     if model.conductivity is not None:
         raise _config_error(
-            material_name, "has Index conductivity, which ZapFDTD cannot encode."
+            material_name,
+            "has Index conductivity, which GDSFactory FDTD cannot encode.",
         )
     n_table = (
         _table_samples(model.n, material_name, "n")
@@ -234,11 +235,11 @@ def _permittivity_config(
     wavelength_range_nm: tuple[float, float] | None,
     material_name: str,
 ) -> MaterialConfig:
-    """Translate a permittivity-authored card model to ZapFDTD."""
+    """Translate a permittivity-authored card model to GDSFactory FDTD."""
     if model.conductivity is not None:
         raise _config_error(
             material_name,
-            "has Permittivity conductivity, which ZapFDTD cannot encode.",
+            "has Permittivity conductivity, which GDSFactory FDTD cannot encode.",
         )
     real_table = (
         _table_samples(model.eps_real, material_name, "eps_real")
@@ -316,16 +317,16 @@ def _sellmeier_config(
     wavelength_range_nm: tuple[float, float] | None,
     material_name: str,
 ) -> MaterialConfig:
-    """Translate either MaterialCard Sellmeier convention to ZapFDTD."""
+    """Translate either MaterialCard Sellmeier convention to GDSFactory FDTD."""
     if model.offset != 0:
         raise _config_error(
             material_name,
-            f"has Sellmeier offset {model.offset}; ZapFDTD requires offset 0.",
+            f"has Sellmeier offset {model.offset}; GDSFactory FDTD requires offset 0.",
         )
     if model.conductivity is not None:
         raise _config_error(
             material_name,
-            "has Sellmeier conductivity, which ZapFDTD cannot encode.",
+            "has Sellmeier conductivity, which GDSFactory FDTD cannot encode.",
         )
     fit_band = _require_fit_band(wavelength_range_nm, material_name)
     _validate_model_range(model, fit_band, material_name)
@@ -354,14 +355,14 @@ def _drude_lorentz_config(
     wavelength_range_nm: tuple[float, float] | None,
     material_name: str,
 ) -> MaterialConfig:
-    """Translate one MaterialCard Drude or Lorentz model to ZapFDTD."""
+    """Translate one MaterialCard Drude or Lorentz model to GDSFactory FDTD."""
     fit_band = _require_fit_band(wavelength_range_nm, material_name)
     _validate_model_range(model, fit_band, material_name)
     if isinstance(model, Drude):
         if len(model.terms) != 1:
             raise _config_error(
                 material_name,
-                "has multiple Drude terms; ZapFDTD accepts exactly one.",
+                "has multiple Drude terms; GDSFactory FDTD accepts exactly one.",
             )
         term = model.terms[0]
         drude = DrudeConfig(
@@ -395,18 +396,20 @@ def material_config_from_snapshot(
     snapshot: MaterialSnapshot,
     wavelength_range_nm: tuple[float, float] | None,
 ) -> MaterialConfig:
-    """Convert one resolved MaterialCard to ZapFDTD's material schema."""
+    """Convert one resolved MaterialCard to GDSFactory FDTD's material schema."""
     material_name = snapshot.material_name
     card: MaterialCard = snapshot.card
     if card.optical is None or card.optical.permittivity is None:
         raise _config_error(material_name, "has no optical permittivity model.")
     if card.optical.conductivity is not None:
         raise _config_error(
-            material_name, "has regime conductivity, which ZapFDTD cannot encode."
+            material_name,
+            "has regime conductivity, which GDSFactory FDTD cannot encode.",
         )
     if card.optical.permeability is not None:
         raise _config_error(
-            material_name, "has optical permeability, which ZapFDTD cannot encode."
+            material_name,
+            "has optical permeability, which GDSFactory FDTD cannot encode.",
         )
     model = card.optical.permittivity
     if isinstance(model, Index):
@@ -419,7 +422,7 @@ def material_config_from_snapshot(
         return _drude_lorentz_config(model, wavelength_range_nm, material_name)
     raise _config_error(
         material_name,
-        f"uses unsupported optical model {type(model).__name__} for ZapFDTD.",
+        f"uses unsupported optical model {type(model).__name__} for GDSFactory FDTD.",
     )
 
 

--- a/src/gsim/fdtd/material_config.py
+++ b/src/gsim/fdtd/material_config.py
@@ -1,0 +1,426 @@
+"""Translate optical MaterialCards into ZapFDTD material configuration."""
+
+from __future__ import annotations
+
+from math import hypot, isclose, sqrt
+from typing import Any
+
+from pdk_schema import (
+    Drude,
+    Index,
+    Lorentz,
+    MaterialCard,
+    Permittivity,
+    ScalarValue,
+    Sellmeier,
+    SellmeierPoleSquared,
+    TabulatedValue,
+)
+from scipy.constants import electron_volt, hbar
+
+from gsim.common.materials import MaterialSnapshot
+from gsim.fdtd.material_schema import (
+    DispersionConfig,
+    DrudeConfig,
+    DrudeLorentzConfig,
+    IndexTableConfig,
+    LorentzConfig,
+    MaterialConfig,
+    SellmeierConfig,
+)
+from gsim.fdtd.models import FDTDConfigError
+
+
+def _config_error(material_name: str, message: str) -> FDTDConfigError:
+    """Return one error scoped to a named material."""
+    return FDTDConfigError(f"Material {material_name!r} {message}")
+
+
+def _wavelengths_nm(values: list[float], unit: str, material_name: str) -> list[float]:
+    """Convert MaterialCard wavelength values to nanometers."""
+    scales = {"nm": 1.0, "um": 1000.0, "m": 1e9}
+    try:
+        scale = scales[unit]
+    except KeyError as error:
+        raise _config_error(
+            material_name, f"uses unsupported wavelength unit {unit!r}."
+        ) from error
+    return [float(value) * scale for value in values]
+
+
+def _dimensionless_scalar(value: Any, material_name: str, field: str) -> float:
+    """Extract one dimensionless scalar physical value."""
+    if not isinstance(value, ScalarValue) or value.unit != "":
+        raise _config_error(
+            material_name, f"{field} must be a dimensionless scalar or table."
+        )
+    return float(value.value)
+
+
+def _table_samples(
+    value: TabulatedValue,
+    material_name: str,
+    field: str,
+) -> tuple[list[float], list[float]]:
+    """Extract one linear wavelength table in nanometers."""
+    if value.unit != "":
+        raise _config_error(material_name, f"{field} values must be dimensionless.")
+    table = value.data
+    if tuple(table.dims) != ("wavelength",):
+        raise _config_error(
+            material_name, f"{field} must have one 'wavelength' dimension."
+        )
+    coordinate = table.coords.get("wavelength")
+    if coordinate is None:
+        raise _config_error(material_name, f"{field} has no wavelength coordinate.")
+    if table.interp != "linear":
+        raise _config_error(
+            material_name,
+            f"{field} uses {table.interp!r} interpolation; ZapFDTD requires "
+            "linear table semantics.",
+        )
+    wavelengths = _wavelengths_nm(coordinate.values, coordinate.unit, material_name)
+    values = [float(item) for item in table.values]
+    if len(wavelengths) != len(values):
+        raise _config_error(material_name, f"{field} has inconsistent table lengths.")
+    return wavelengths, values
+
+
+def _matching_grid(first: list[float], second: list[float], material_name: str) -> None:
+    """Require two tables to share one physical wavelength grid."""
+    if len(first) != len(second) or any(
+        not isclose(left, right, rel_tol=1e-12, abs_tol=1e-9)
+        for left, right in zip(first, second, strict=False)
+    ):
+        raise _config_error(
+            material_name, "n and k tables must use the same wavelength grid."
+        )
+
+
+def _require_fit_band(
+    wavelength_range_nm: tuple[float, float] | None,
+    material_name: str,
+) -> tuple[float, float]:
+    """Return a usable source band or reject a dispersive material."""
+    if wavelength_range_nm is None:
+        raise _config_error(
+            material_name,
+            "is dispersive, but the excitation does not provide the nonzero "
+            "frequency band required by ZapFDTD.",
+        )
+    return wavelength_range_nm
+
+
+def _validate_model_range(
+    model: Any,
+    wavelength_range_nm: tuple[float, float],
+    material_name: str,
+) -> None:
+    """Require the source band to lie within model validity."""
+    validity = getattr(model, "validity", None)
+    wavelength_band = (
+        None if validity is None else (validity.over or {}).get("wavelength")
+    )
+    if wavelength_band is None:
+        return
+    limits_nm = _wavelengths_nm(
+        [wavelength_band.min, wavelength_band.max],
+        wavelength_band.unit,
+        material_name,
+    )
+    lower, upper = wavelength_range_nm
+    if lower < limits_nm[0] or upper > limits_nm[1]:
+        raise _config_error(
+            material_name,
+            f"is valid from {limits_nm[0]:g} to {limits_nm[1]:g} nm, not over "
+            f"the source band {lower:g} to {upper:g} nm.",
+        )
+
+
+def _validate_table_coverage(
+    wavelengths_nm: list[float],
+    wavelength_range_nm: tuple[float, float],
+    material_name: str,
+) -> None:
+    """Require a material table to cover the complete source band."""
+    lower, upper = wavelength_range_nm
+    if min(wavelengths_nm) > lower or max(wavelengths_nm) < upper:
+        raise _config_error(
+            material_name,
+            f"table does not cover the source band {lower:g} to {upper:g} nm.",
+        )
+
+
+def _index_config(
+    model: Index,
+    wavelength_range_nm: tuple[float, float] | None,
+    material_name: str,
+) -> MaterialConfig:
+    """Translate an index-authored card model to ZapFDTD."""
+    if model.conductivity is not None:
+        raise _config_error(
+            material_name, "has Index conductivity, which ZapFDTD cannot encode."
+        )
+    n_table = (
+        _table_samples(model.n, material_name, "n")
+        if isinstance(model.n, TabulatedValue)
+        else None
+    )
+    k_table = (
+        _table_samples(model.k, material_name, "k")
+        if isinstance(model.k, TabulatedValue)
+        else None
+    )
+    if n_table is None and k_table is None:
+        refractive_index = _dimensionless_scalar(model.n, material_name, "n")
+        extinction = (
+            0.0
+            if model.k is None
+            else _dimensionless_scalar(model.k, material_name, "k")
+        )
+        if extinction == 0:
+            return MaterialConfig(refractive_index=refractive_index)
+        wavelengths_nm = list(_require_fit_band(wavelength_range_nm, material_name))
+        n_values = [refractive_index] * len(wavelengths_nm)
+        k_values = [extinction] * len(wavelengths_nm)
+    else:
+        reference_table = n_table if n_table is not None else k_table
+        if reference_table is None:
+            raise AssertionError("table branch requires n or k samples")
+        wavelengths_nm = list(reference_table[0])
+        if n_table is not None and k_table is not None:
+            _matching_grid(n_table[0], k_table[0], material_name)
+        n_values = (
+            n_table[1]
+            if n_table is not None
+            else [_dimensionless_scalar(model.n, material_name, "n")]
+            * len(wavelengths_nm)
+        )
+        k_values = (
+            k_table[1]
+            if k_table is not None
+            else [
+                0.0
+                if model.k is None
+                else _dimensionless_scalar(model.k, material_name, "k")
+            ]
+            * len(wavelengths_nm)
+        )
+    fit_band = _require_fit_band(wavelength_range_nm, material_name)
+    _validate_model_range(model, fit_band, material_name)
+    _validate_table_coverage(wavelengths_nm, fit_band, material_name)
+    samples = sorted(zip(wavelengths_nm, n_values, k_values, strict=True))
+    return MaterialConfig(
+        dispersion=DispersionConfig(
+            table=IndexTableConfig(
+                wavelength_nm=[sample[0] for sample in samples],
+                n=[sample[1] for sample in samples],
+                k=[sample[2] for sample in samples],
+            )
+        )
+    )
+
+
+def _complex_index(eps_real: float, eps_imag: float) -> tuple[float, float]:
+    """Return the passive square root of complex relative permittivity."""
+    magnitude = hypot(eps_real, eps_imag)
+    refractive_index = sqrt(max(0.0, (magnitude + eps_real) / 2))
+    extinction = sqrt(max(0.0, (magnitude - eps_real) / 2))
+    return refractive_index, extinction if eps_imag >= 0 else -extinction
+
+
+def _permittivity_config(
+    model: Permittivity,
+    wavelength_range_nm: tuple[float, float] | None,
+    material_name: str,
+) -> MaterialConfig:
+    """Translate a permittivity-authored card model to ZapFDTD."""
+    if model.conductivity is not None:
+        raise _config_error(
+            material_name,
+            "has Permittivity conductivity, which ZapFDTD cannot encode.",
+        )
+    real_table = (
+        _table_samples(model.eps_real, material_name, "eps_real")
+        if isinstance(model.eps_real, TabulatedValue)
+        else None
+    )
+    imag_table = (
+        _table_samples(model.eps_imag, material_name, "eps_imag")
+        if isinstance(model.eps_imag, TabulatedValue)
+        else None
+    )
+    if real_table is None and imag_table is None:
+        eps_real = _dimensionless_scalar(model.eps_real, material_name, "eps_real")
+        eps_imag = (
+            0.0
+            if model.eps_imag is None
+            else _dimensionless_scalar(model.eps_imag, material_name, "eps_imag")
+        )
+        refractive_index, extinction = _complex_index(eps_real, eps_imag)
+        if extinction == 0 and refractive_index > 0:
+            return MaterialConfig(refractive_index=refractive_index)
+        wavelengths_nm = list(_require_fit_band(wavelength_range_nm, material_name))
+        indices = [(refractive_index, extinction)] * len(wavelengths_nm)
+    else:
+        reference_table = real_table if real_table is not None else imag_table
+        if reference_table is None:
+            raise AssertionError("table branch requires real or imaginary samples")
+        wavelengths_nm = list(reference_table[0])
+        if real_table is not None and imag_table is not None:
+            _matching_grid(real_table[0], imag_table[0], material_name)
+        real_values = (
+            real_table[1]
+            if real_table is not None
+            else [_dimensionless_scalar(model.eps_real, material_name, "eps_real")]
+            * len(wavelengths_nm)
+        )
+        imag_values = (
+            imag_table[1]
+            if imag_table is not None
+            else [
+                0.0
+                if model.eps_imag is None
+                else _dimensionless_scalar(model.eps_imag, material_name, "eps_imag")
+            ]
+            * len(wavelengths_nm)
+        )
+        indices = [
+            _complex_index(real, imag)
+            for real, imag in zip(real_values, imag_values, strict=True)
+        ]
+    fit_band = _require_fit_band(wavelength_range_nm, material_name)
+    _validate_model_range(model, fit_band, material_name)
+    _validate_table_coverage(wavelengths_nm, fit_band, material_name)
+    samples = sorted(
+        (
+            (wavelength, refractive_index, extinction)
+            for wavelength, (refractive_index, extinction) in zip(
+                wavelengths_nm, indices, strict=True
+            )
+        )
+    )
+    return MaterialConfig(
+        dispersion=DispersionConfig(
+            table=IndexTableConfig(
+                wavelength_nm=[sample[0] for sample in samples],
+                n=[sample[1] for sample in samples],
+                k=[sample[2] for sample in samples],
+            )
+        )
+    )
+
+
+def _sellmeier_config(
+    model: Sellmeier | SellmeierPoleSquared,
+    wavelength_range_nm: tuple[float, float] | None,
+    material_name: str,
+) -> MaterialConfig:
+    """Translate either MaterialCard Sellmeier convention to ZapFDTD."""
+    if model.offset != 0:
+        raise _config_error(
+            material_name,
+            f"has Sellmeier offset {model.offset}; ZapFDTD requires offset 0.",
+        )
+    if model.conductivity is not None:
+        raise _config_error(
+            material_name,
+            "has Sellmeier conductivity, which ZapFDTD cannot encode.",
+        )
+    fit_band = _require_fit_band(wavelength_range_nm, material_name)
+    _validate_model_range(model, fit_band, material_name)
+    if isinstance(model, Sellmeier):
+        coefficients = [term.c_um**2 for term in model.terms]
+    else:
+        coefficients = [term.c_um2 for term in model.terms]
+    return MaterialConfig(
+        dispersion=DispersionConfig(
+            wavelength_range_nm=fit_band,
+            sellmeier=SellmeierConfig(
+                b=[term.b for term in model.terms],
+                c_um2=coefficients,
+            ),
+        )
+    )
+
+
+def _angular_frequency_to_ev(value: float) -> float:
+    """Convert angular frequency in radians per second to energy in eV."""
+    return float(value) * hbar / electron_volt
+
+
+def _drude_lorentz_config(
+    model: Drude | Lorentz,
+    wavelength_range_nm: tuple[float, float] | None,
+    material_name: str,
+) -> MaterialConfig:
+    """Translate one MaterialCard Drude or Lorentz model to ZapFDTD."""
+    fit_band = _require_fit_band(wavelength_range_nm, material_name)
+    _validate_model_range(model, fit_band, material_name)
+    if isinstance(model, Drude):
+        if len(model.terms) != 1:
+            raise _config_error(
+                material_name,
+                "has multiple Drude terms; ZapFDTD accepts exactly one.",
+            )
+        term = model.terms[0]
+        drude = DrudeConfig(
+            plasma_energy_ev=_angular_frequency_to_ev(term.omega_p),
+            damping_ev=_angular_frequency_to_ev(term.gamma),
+        )
+        lorentz = None
+    else:
+        drude = None
+        lorentz = [
+            LorentzConfig(
+                delta_eps=term.delta_eps,
+                resonance_ev=_angular_frequency_to_ev(term.omega_0),
+                damping_ev=_angular_frequency_to_ev(term.gamma),
+            )
+            for term in model.terms
+        ]
+    return MaterialConfig(
+        dispersion=DispersionConfig(
+            wavelength_range_nm=fit_band,
+            drude_lorentz=DrudeLorentzConfig(
+                eps_inf=model.eps_inf,
+                drude=drude,
+                lorentz=lorentz,
+            ),
+        )
+    )
+
+
+def material_config_from_snapshot(
+    snapshot: MaterialSnapshot,
+    wavelength_range_nm: tuple[float, float] | None,
+) -> MaterialConfig:
+    """Convert one resolved MaterialCard to ZapFDTD's material schema."""
+    material_name = snapshot.material_name
+    card: MaterialCard = snapshot.card
+    if card.optical is None or card.optical.permittivity is None:
+        raise _config_error(material_name, "has no optical permittivity model.")
+    if card.optical.conductivity is not None:
+        raise _config_error(
+            material_name, "has regime conductivity, which ZapFDTD cannot encode."
+        )
+    if card.optical.permeability is not None:
+        raise _config_error(
+            material_name, "has optical permeability, which ZapFDTD cannot encode."
+        )
+    model = card.optical.permittivity
+    if isinstance(model, Index):
+        return _index_config(model, wavelength_range_nm, material_name)
+    if isinstance(model, Permittivity):
+        return _permittivity_config(model, wavelength_range_nm, material_name)
+    if isinstance(model, (Sellmeier, SellmeierPoleSquared)):
+        return _sellmeier_config(model, wavelength_range_nm, material_name)
+    if isinstance(model, (Drude, Lorentz)):
+        return _drude_lorentz_config(model, wavelength_range_nm, material_name)
+    raise _config_error(
+        material_name,
+        f"uses unsupported optical model {type(model).__name__} for ZapFDTD.",
+    )
+
+
+__all__ = ["MaterialConfig", "material_config_from_snapshot"]

--- a/src/gsim/fdtd/material_schema.py
+++ b/src/gsim/fdtd/material_schema.py
@@ -1,0 +1,136 @@
+"""Strict ZapFDTD material wire-schema models."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class _StrictModel(BaseModel):
+    """Reject unknown fields and non-finite values at the Zap boundary."""
+
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
+
+
+class IndexTableConfig(_StrictModel):
+    """ZapFDTD tabulated complex refractive index."""
+
+    wavelength_nm: list[float] = Field(min_length=1)
+    n: list[float] = Field(min_length=1)
+    k: list[float] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_samples(self) -> Self:
+        """Require physical samples on one unambiguous wavelength grid."""
+        if len(self.wavelength_nm) != len(self.n) or len(self.n) != len(self.k):
+            raise ValueError("wavelength_nm, n, and k must have equal lengths")
+        if any(wavelength <= 0 for wavelength in self.wavelength_nm):
+            raise ValueError("table wavelengths must be positive")
+        if len(set(self.wavelength_nm)) != len(self.wavelength_nm):
+            raise ValueError("table wavelengths must be unique")
+        if any(value < 0 for value in self.n):
+            raise ValueError("table refractive indices cannot be negative")
+        if any(value < 0 for value in self.k):
+            raise ValueError("table extinction coefficients cannot be negative")
+        return self
+
+
+class SellmeierConfig(_StrictModel):
+    """ZapFDTD Sellmeier coefficients."""
+
+    b: list[float] = Field(min_length=1)
+    c_um2: list[float] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_terms(self) -> Self:
+        """Require one pole position for every oscillator strength."""
+        if len(self.b) != len(self.c_um2):
+            raise ValueError("Sellmeier b and c_um2 must have equal lengths")
+        return self
+
+
+class DrudeConfig(_StrictModel):
+    """ZapFDTD free-carrier term, with energies in electron-volts."""
+
+    plasma_energy_ev: float = Field(gt=0)
+    damping_ev: float = Field(ge=0)
+
+
+class LorentzConfig(_StrictModel):
+    """ZapFDTD bound-resonance term, with energies in electron-volts."""
+
+    delta_eps: float
+    resonance_ev: float = Field(gt=0)
+    damping_ev: float = Field(ge=0)
+
+
+class DrudeLorentzConfig(_StrictModel):
+    """ZapFDTD combined Drude-Lorentz parameterization."""
+
+    eps_inf: float = 1.0
+    drude: DrudeConfig | None = None
+    lorentz: list[LorentzConfig] | None = None
+
+    @model_validator(mode="after")
+    def validate_contributions(self) -> Self:
+        """Require at least one actual dispersive contribution."""
+        if self.drude is None and not self.lorentz:
+            raise ValueError("Drude-Lorentz needs a Drude or Lorentz term")
+        return self
+
+
+class DispersionConfig(_StrictModel):
+    """One of the three dispersion shapes accepted by ZapFDTD."""
+
+    wavelength_range_nm: tuple[float, float] | None = None
+    table: IndexTableConfig | None = None
+    sellmeier: SellmeierConfig | None = None
+    drude_lorentz: DrudeLorentzConfig | None = None
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> Self:
+        """Enforce ZapFDTD's exact-one shape and range rules."""
+        shapes = (self.table, self.sellmeier, self.drude_lorentz)
+        if sum(shape is not None for shape in shapes) != 1:
+            raise ValueError(
+                "dispersion must contain exactly one of table, sellmeier, or "
+                "drude_lorentz"
+            )
+        if self.table is not None:
+            if self.wavelength_range_nm is not None:
+                raise ValueError("table dispersion cannot set wavelength_range_nm")
+            return self
+        if self.wavelength_range_nm is None:
+            raise ValueError("closed-form dispersion needs wavelength_range_nm")
+        lower, upper = self.wavelength_range_nm
+        if lower <= 0 or upper <= lower:
+            raise ValueError("wavelength_range_nm must satisfy 0 < lower < upper")
+        return self
+
+
+class MaterialConfig(_StrictModel):
+    """One scalar or dispersive material entry accepted by ZapFDTD."""
+
+    refractive_index: float | None = Field(default=None, gt=0)
+    dispersion: DispersionConfig | None = None
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> Self:
+        """Require exactly one scalar or dispersive representation."""
+        if (self.refractive_index is None) == (self.dispersion is None):
+            raise ValueError(
+                "material needs exactly one of refractive_index or dispersion"
+            )
+        return self
+
+
+__all__ = [
+    "DispersionConfig",
+    "DrudeConfig",
+    "DrudeLorentzConfig",
+    "IndexTableConfig",
+    "LorentzConfig",
+    "MaterialConfig",
+    "SellmeierConfig",
+]

--- a/src/gsim/fdtd/material_schema.py
+++ b/src/gsim/fdtd/material_schema.py
@@ -1,4 +1,4 @@
-"""Strict ZapFDTD material wire-schema models."""
+"""Strict GDSFactory FDTD material wire-schema models."""
 
 from __future__ import annotations
 
@@ -8,13 +8,13 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class _StrictModel(BaseModel):
-    """Reject unknown fields and non-finite values at the Zap boundary."""
+    """Reject unknown fields and non-finite values at the GDSFactory FDTD boundary."""
 
     model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
 
 class IndexTableConfig(_StrictModel):
-    """ZapFDTD tabulated complex refractive index."""
+    """GDSFactory FDTD tabulated complex refractive index."""
 
     wavelength_nm: list[float] = Field(min_length=1)
     n: list[float] = Field(min_length=1)
@@ -37,7 +37,7 @@ class IndexTableConfig(_StrictModel):
 
 
 class SellmeierConfig(_StrictModel):
-    """ZapFDTD Sellmeier coefficients."""
+    """GDSFactory FDTD Sellmeier coefficients."""
 
     b: list[float] = Field(min_length=1)
     c_um2: list[float] = Field(min_length=1)
@@ -51,14 +51,14 @@ class SellmeierConfig(_StrictModel):
 
 
 class DrudeConfig(_StrictModel):
-    """ZapFDTD free-carrier term, with energies in electron-volts."""
+    """GDSFactory FDTD free-carrier term, with energies in electron-volts."""
 
     plasma_energy_ev: float = Field(gt=0)
     damping_ev: float = Field(ge=0)
 
 
 class LorentzConfig(_StrictModel):
-    """ZapFDTD bound-resonance term, with energies in electron-volts."""
+    """GDSFactory FDTD bound-resonance term, with energies in electron-volts."""
 
     delta_eps: float
     resonance_ev: float = Field(gt=0)
@@ -66,7 +66,7 @@ class LorentzConfig(_StrictModel):
 
 
 class DrudeLorentzConfig(_StrictModel):
-    """ZapFDTD combined Drude-Lorentz parameterization."""
+    """GDSFactory FDTD combined Drude-Lorentz parameterization."""
 
     eps_inf: float = 1.0
     drude: DrudeConfig | None = None
@@ -81,7 +81,7 @@ class DrudeLorentzConfig(_StrictModel):
 
 
 class DispersionConfig(_StrictModel):
-    """One of the three dispersion shapes accepted by ZapFDTD."""
+    """One of the three dispersion shapes accepted by GDSFactory FDTD."""
 
     wavelength_range_nm: tuple[float, float] | None = None
     table: IndexTableConfig | None = None
@@ -90,7 +90,7 @@ class DispersionConfig(_StrictModel):
 
     @model_validator(mode="after")
     def validate_shape(self) -> Self:
-        """Enforce ZapFDTD's exact-one shape and range rules."""
+        """Enforce GDSFactory FDTD's exact-one shape and range rules."""
         shapes = (self.table, self.sellmeier, self.drude_lorentz)
         if sum(shape is not None for shape in shapes) != 1:
             raise ValueError(
@@ -110,7 +110,7 @@ class DispersionConfig(_StrictModel):
 
 
 class MaterialConfig(_StrictModel):
-    """One scalar or dispersive material entry accepted by ZapFDTD."""
+    """One scalar or dispersive material entry accepted by GDSFactory FDTD."""
 
     refractive_index: float | None = Field(default=None, gt=0)
     dispersion: DispersionConfig | None = None

--- a/src/gsim/fdtd/normalization.py
+++ b/src/gsim/fdtd/normalization.py
@@ -67,7 +67,7 @@ def gaussian_coupling_efficiency(
 ) -> CouplingEfficiencyResult:
     """Normalize raw port power by the analytic Gaussian-beam source power.
 
-    The pulse transform and power expression match ZapFDTD and the
+    The pulse transform and power expression match GDSFactory FDTD and the
     FDTD-Bench focusing-grating-coupler reference flow. Samples whose analytic
     source power is more than ``noise_floor_db`` below its peak are masked.
     """
@@ -145,7 +145,7 @@ def fiber_coupling_efficiency(
 def _frequency_parameters(
     center_wavelength: float, wavelength_halfspan: float
 ) -> tuple[float, float]:
-    """Reproduce ZapFDTD's pulse center and width parameters."""
+    """Reproduce GDSFactory FDTD's pulse center and width parameters."""
     frequency_center = 1 / center_wavelength
     if wavelength_halfspan <= 0:
         return frequency_center, frequency_center * 0.1
@@ -165,7 +165,7 @@ def _source_spectrum(
     frequency_width: float,
     amplitude: float,
 ) -> np.ndarray:
-    """Return ZapFDTD's closed-form Gaussian-pulse Fourier transform."""
+    """Return GDSFactory FDTD's closed-form Gaussian-pulse Fourier transform."""
     frequency_max_offset = frequency_width * 2 ** (-1.5)
     scale_factor = 2 * frequency_max_offset
     if scale_factor <= 0:

--- a/src/gsim/fdtd/results.py
+++ b/src/gsim/fdtd/results.py
@@ -1,4 +1,4 @@
-"""Typed loading, tabulation, and plotting of ZapFDTD output."""
+"""Typed loading, tabulation, and plotting of GDSFactory FDTD output."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ class ComplexTrace:
     def from_samples(
         cls, samples: list[Mapping[str, Any]], valid: np.ndarray
     ) -> ComplexTrace:
-        """Build a trace from ZapFDTD's list-of-records representation."""
+        """Build a trace from GDSFactory FDTD's list-of-records representation."""
         values = np.asarray(
             [complex(sample.get("re", 0), sample.get("im", 0)) for sample in samples]
         )
@@ -339,7 +339,7 @@ class MonitorResults(dict[str, PlaneMonitorResult]):
 
 @dataclass
 class FDTDResult:
-    """Complete typed result from one ZapFDTD cloud run."""
+    """Complete typed result from one GDSFactory FDTD cloud run."""
 
     excitation_type: str
     excited_port: str | None
@@ -420,7 +420,7 @@ class FDTDResult:
 
     @classmethod
     def from_run_result(cls, run_result: Any) -> FDTDResult:
-        """Locate and parse ZapFDTD output downloaded by :mod:`gsim.gcloud`."""
+        """Locate and parse GDSFactory FDTD output downloaded by :mod:`gsim.gcloud`."""
         candidates = [
             Path(path)
             for name, path in run_result.files.items()

--- a/src/gsim/fdtd/runtime.py
+++ b/src/gsim/fdtd/runtime.py
@@ -1,4 +1,4 @@
-"""Translation from public FDTD concerns to the ZapFDTD runtime schema."""
+"""Translation from public FDTD concerns to the GDSFactory FDTD runtime schema."""
 
 from __future__ import annotations
 
@@ -63,7 +63,7 @@ def _vector_bounds(center: Vector3, half_size: Vector3) -> tuple[Vector3, Vector
 
 
 class RuntimeConfigMixin:
-    """Serialize sources, monitors, and solver controls for ZapFDTD."""
+    """Serialize sources, monitors, and solver controls for GDSFactory FDTD."""
 
     source: SourceType
     resolved: ResolvedPassivePcell

--- a/src/gsim/fdtd/viz.py
+++ b/src/gsim/fdtd/viz.py
@@ -1,4 +1,4 @@
-"""Interactive Three.js views of ZapFDTD Gmsh simulation meshes."""
+"""Interactive Three.js views of GDSFactory FDTD Gmsh simulation meshes."""
 
 from __future__ import annotations
 
@@ -51,11 +51,11 @@ def plot_mesh(
     pml_cells: int | None = None,
     height: int = 600,
 ) -> MeshViewer:
-    """Build an interactive ZapFDTD-style viewer for a Gmsh mesh.
+    """Build an interactive GDSFactory FDTD-style viewer for a Gmsh mesh.
 
     The mesh is embedded in the returned HTML, so the source ``.msh`` file is
     no longer needed once this function returns. Three.js is loaded from the
-    same public CDN used by the original ZapFDTD viewer.
+    same public CDN used by the original GDSFactory FDTD viewer.
     """
     path = Path(mesh_path)
     if not path.is_file():

--- a/tests/fdtd/test_api.py
+++ b/tests/fdtd/test_api.py
@@ -12,6 +12,16 @@ from pydantic import ValidationError
 from gsim import fdtd, gcloud
 
 
+def test_gpdk_material_resolves_through_builtin_material_card() -> None:
+    gf.gpdk.PDK.activate()
+    simulation = fdtd.Simulation(pdk=gf.gpdk.PDK)
+
+    resolved = simulation.geometry(gf.gpdk.PDK.get_component("mmi1x2"))
+
+    assert resolved.materials["si"].card.name == "si"
+    assert resolved.materials["si"].card.optical is not None
+
+
 def test_material_override_participates_in_gpdk_resolution() -> None:
     gf.gpdk.PDK.activate()
     simulation = fdtd.Simulation(pdk=gf.gpdk.PDK)

--- a/tests/fdtd/test_config.py
+++ b/tests/fdtd/test_config.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
-
 import pytest
 from pydantic import ValidationError
 
@@ -16,7 +14,6 @@ from gsim.fdtd.config import (
     build_fdtd_config,
 )
 from gsim.fdtd.models import (
-    FDTDConfigError,
     MeshGroup,
     MeshManifest,
     PortMeshGroup,
@@ -92,26 +89,27 @@ def test_config_uses_manifest_tags_and_rejects_extra_fields() -> None:
         FDTDConfig.model_validate(document)
 
 
-def test_config_rejects_lossy_scalar_materials() -> None:
+def test_config_serializes_canonical_cards_not_mutated_snapshots() -> None:
     silicon = resolve_material_snapshot("Si", 1.55, {})
     silica = resolve_material_snapshot("SiO2", 1.55, {})
-    lossy_silicon = replace(silicon, extinction_coefficient=0.01)
+    config = build_fdtd_config(
+        _manifest(),
+        {"Si": silicon, "SiO2": silica},
+        background_material="SiO2",
+        center_wavelength_nm=1550,
+        wavelength_halfspan_nm=50,
+        num_wavelengths=3,
+        default_port="o1",
+        nanometers_per_cell=31.25,
+        pml_cells=16,
+        max_timesteps=None,
+        energy_decay_fraction=1e-6,
+        max_wall_seconds=3600,
+    )
 
-    with pytest.raises(FDTDConfigError, match="lossless real"):
-        build_fdtd_config(
-            _manifest(),
-            {"Si": lossy_silicon, "SiO2": silica},
-            background_material="SiO2",
-            center_wavelength_nm=1550,
-            wavelength_halfspan_nm=50,
-            num_wavelengths=3,
-            default_port="o1",
-            nanometers_per_cell=31.25,
-            pml_cells=16,
-            max_timesteps=None,
-            energy_decay_fraction=1e-6,
-            max_wall_seconds=3600,
-        )
+    assert config.materials["Si"].dispersion is not None
+    assert config.materials["Si"].dispersion.sellmeier is not None
+    assert config.materials["Si"].refractive_index is None
 
 
 def test_config_supports_gaussian_beam_and_fiber_monitor() -> None:

--- a/tests/fdtd/test_material_config.py
+++ b/tests/fdtd/test_material_config.py
@@ -1,4 +1,4 @@
-"""Tests for the MaterialCard-to-ZapFDTD material adapter."""
+"""Tests for the MaterialCard-to-GDSFactory FDTD material adapter."""
 
 from __future__ import annotations
 
@@ -44,7 +44,7 @@ def test_scalar_index_card_stays_nondispersive() -> None:
     assert config.model_dump(exclude_none=True) == {"refractive_index": 2.0}
 
 
-def test_sellmeier_card_maps_to_zap_coefficients() -> None:
+def test_sellmeier_card_maps_to_fdtd_coefficients() -> None:
     snapshot = resolve_material_snapshot("SiO2", 1.55, {})
 
     config = material_config_from_snapshot(snapshot, (1500.0, 1600.0))
@@ -152,7 +152,7 @@ def test_dispersive_card_requires_a_source_band() -> None:
         material_config_from_snapshot(snapshot, None)
 
 
-def test_zap_material_config_requires_exactly_one_shape() -> None:
+def test_fdtd_material_config_requires_exactly_one_shape() -> None:
     with pytest.raises(ValidationError, match="exactly one"):
         MaterialConfig()
 

--- a/tests/fdtd/test_material_config.py
+++ b/tests/fdtd/test_material_config.py
@@ -1,0 +1,166 @@
+"""Tests for the MaterialCard-to-ZapFDTD material adapter."""
+
+from __future__ import annotations
+
+import pytest
+from pdk_schema import (
+    Drude,
+    DrudeTerm,
+    Index,
+    Lorentz,
+    LorentzTerm,
+    Permittivity,
+    ScalarValue,
+)
+from pydantic import ValidationError
+from scipy.constants import electron_volt, hbar
+
+from gsim.common.materials import resolve_material_snapshot
+from gsim.common.materials._helpers import material_card, wavelength_validity
+from gsim.fdtd.material_config import MaterialConfig, material_config_from_snapshot
+from gsim.fdtd.models import FDTDConfigError
+
+
+def _angular_frequency(energy_ev: float) -> float:
+    return energy_ev * electron_volt / hbar
+
+
+def test_scalar_index_card_stays_nondispersive() -> None:
+    card = material_card(
+        name="constant",
+        temperature_ref=None,
+        permittivity=Index(
+            validity=None,
+            variation=None,
+            conductivity=None,
+            n=ScalarValue(unit="", value=2.0),
+            k=None,
+        ),
+    )
+    snapshot = resolve_material_snapshot("constant", 1.55, {"constant": card})
+
+    config = material_config_from_snapshot(snapshot, (1500.0, 1600.0))
+
+    assert config.model_dump(exclude_none=True) == {"refractive_index": 2.0}
+
+
+def test_sellmeier_card_maps_to_zap_coefficients() -> None:
+    snapshot = resolve_material_snapshot("SiO2", 1.55, {})
+
+    config = material_config_from_snapshot(snapshot, (1500.0, 1600.0))
+
+    assert config.dispersion is not None
+    assert config.dispersion.wavelength_range_nm == (1500.0, 1600.0)
+    sellmeier = config.dispersion.sellmeier
+    assert sellmeier is not None
+    assert sellmeier.b == [0.6961663, 0.4079426, 0.8974794]
+    assert sellmeier.c_um2 == pytest.approx([0.0684043**2, 0.1162414**2, 9.896161**2])
+
+
+def test_tabulated_index_card_maps_wavelengths_and_loss() -> None:
+    snapshot = resolve_material_snapshot("Si-Li-293K", 1.55, {})
+
+    config = material_config_from_snapshot(snapshot, (1500.0, 1600.0))
+
+    assert config.dispersion is not None
+    table = config.dispersion.table
+    assert table is not None
+    index = table.wavelength_nm.index(1550.0)
+    assert table.n[index] == 3.4757
+    assert set(table.k) == {0.0}
+
+
+def test_drude_and_lorentz_cards_map_rad_per_second_to_ev() -> None:
+    drude_card = material_card(
+        name="metal",
+        temperature_ref=None,
+        permittivity=Drude(
+            validity=wavelength_validity(0.4, 2.0),
+            variation=None,
+            eps_inf=1.0,
+            terms=(
+                DrudeTerm(
+                    omega_p=_angular_frequency(9.03),
+                    gamma=_angular_frequency(0.053),
+                ),
+            ),
+        ),
+    )
+    lorentz_card = material_card(
+        name="resonant",
+        temperature_ref=None,
+        permittivity=Lorentz(
+            validity=wavelength_validity(0.4, 2.0),
+            variation=None,
+            eps_inf=2.0,
+            terms=(
+                LorentzTerm(
+                    delta_eps=1.09,
+                    omega_0=_angular_frequency(2.7),
+                    gamma=_angular_frequency(1.2),
+                ),
+            ),
+        ),
+    )
+
+    drude = material_config_from_snapshot(
+        resolve_material_snapshot("metal", 1.55, {"metal": drude_card}),
+        (1500.0, 1600.0),
+    )
+    lorentz = material_config_from_snapshot(
+        resolve_material_snapshot("resonant", 1.55, {"resonant": lorentz_card}),
+        (1500.0, 1600.0),
+    )
+
+    assert drude.dispersion is not None
+    drude_lorentz = drude.dispersion.drude_lorentz
+    assert drude_lorentz is not None
+    assert drude_lorentz.drude is not None
+    assert drude_lorentz.drude.plasma_energy_ev == pytest.approx(9.03)
+    assert drude_lorentz.drude.damping_ev == pytest.approx(0.053)
+    assert lorentz.dispersion is not None
+    lorentz_terms = lorentz.dispersion.drude_lorentz
+    assert lorentz_terms is not None
+    assert lorentz_terms.lorentz is not None
+    assert lorentz_terms.lorentz[0].resonance_ev == pytest.approx(2.7)
+    assert lorentz_terms.lorentz[0].damping_ev == pytest.approx(1.2)
+
+
+def test_scalar_permittivity_card_maps_to_refractive_index() -> None:
+    card = material_card(
+        name="dielectric",
+        temperature_ref=None,
+        permittivity=Permittivity(
+            validity=None,
+            variation=None,
+            conductivity=None,
+            eps_real=ScalarValue(unit="", value=4.0),
+            eps_imag=None,
+        ),
+    )
+    snapshot = resolve_material_snapshot("dielectric", 1.55, {"dielectric": card})
+
+    config = material_config_from_snapshot(snapshot, (1500.0, 1600.0))
+
+    assert config.refractive_index == 2.0
+
+
+def test_dispersive_card_requires_a_source_band() -> None:
+    snapshot = resolve_material_snapshot("SiO2", 1.55, {})
+
+    with pytest.raises(FDTDConfigError, match="nonzero frequency band"):
+        material_config_from_snapshot(snapshot, None)
+
+
+def test_zap_material_config_requires_exactly_one_shape() -> None:
+    with pytest.raises(ValidationError, match="exactly one"):
+        MaterialConfig()
+
+    with pytest.raises(ValidationError, match="exactly one"):
+        MaterialConfig(
+            refractive_index=1.5,
+            dispersion={
+                "wavelength_range_nm": (1500, 1600),
+                "sellmeier": {"b": [1.0], "c_um2": [0.01]},
+            },
+        )

--- a/tests/fdtd/test_results.py
+++ b/tests/fdtd/test_results.py
@@ -1,4 +1,4 @@
-"""Tests for typed ZapFDTD results, tables, and monitor plots."""
+"""Tests for typed GDSFactory FDTD results, tables, and monitor plots."""
 
 from __future__ import annotations
 

--- a/tests/fdtd/test_simulation.py
+++ b/tests/fdtd/test_simulation.py
@@ -76,10 +76,14 @@ def test_write_uses_project_material_then_fallback_and_valid_mesh(
     assert document["schema_version"] == 1
     assert document["mesh_file"] == "mesh.msh"
     assert document["length_scale_meters"] == 1e-9
-    assert document["materials"]["Si"]["refractive_index"] == pytest.approx(3.4757)
-    assert document["materials"]["SiO2"]["refractive_index"] == pytest.approx(
-        1.4440236217
-    )
+    silicon_table = document["materials"]["Si"]["dispersion"]["table"]
+    silicon_index = silicon_table["wavelength_nm"].index(1550.0)
+    assert silicon_table["n"][silicon_index] == pytest.approx(3.4757)
+    assert set(silicon_table["k"]) == {0.0}
+    silica = document["materials"]["SiO2"]["dispersion"]
+    assert silica["wavelength_range_nm"] == [1500.0, 1600.0]
+    assert silica["sellmeier"]["b"] == [0.6961663, 0.4079426, 0.8974794]
+    assert document["background_refractive_index"] == pytest.approx(1.4440236217)
     assert document["geometry"]["ports"]["o1"]["normal"] == [-1, 0, 0]
     assert document["geometry"]["ports"]["o2"]["normal"] == [1, 0, 0]
 

--- a/tests/fdtd/test_viz.py
+++ b/tests/fdtd/test_viz.py
@@ -1,4 +1,4 @@
-"""Tests for the ZapFDTD-derived interactive Gmsh viewer."""
+"""Tests for the GDSFactory FDTD-derived interactive Gmsh viewer."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
Summary

- Treat resolved MaterialCards as the canonical FDTD material definitions.
- Serialize scalar, tabulated, Sellmeier, Drude, and Lorentz optical models to the FDTD schema while retaining the center-wavelength background index for sizing.
- Add strict schema validation, common lowercase material aliases, documentation, and adapter coverage.

Validation

- Full test suite: 1050 passed, 1 skipped.
- Changed-file pre-commit checks passed.
- A generated gpdk MMI config completed a fresh FDTD dry run successfully.