### PR TITLE
feat(meep): use reduced Malitson as default SiO2

### DIFF
--- a/docs/api/meep.md
+++ b/docs/api/meep.md
@@ -9,6 +9,12 @@ nondispersive, while Sellmeier, Lorentz, and Drude models are serialized as
 Meep susceptibility terms. There is no solver-level automatic dispersion
 threshold.
 
+The built-in `SiO2` fallback is a lossless two-pole reduction of Malitson's
+fused-silica model over 0.4–2.0 µm. The original three-pole Malitson model and
+the Arosa and de la Fuente model remain available as `SiO2-Malitson` and
+`SiO2-Arosa`, respectively. Project PDK material cards take precedence over
+these fallbacks.
+
 Use the public validator before constructing a simulation when accepting cards
 from another source:
 

--- a/docs/api/meep.md
+++ b/docs/api/meep.md
@@ -1,5 +1,28 @@
 # Meep API
 
+## Material cards
+
+`gsim.meep` resolves each material name from the active project's
+`MaterialCard` registry, then falls back to gsim's built-in cards. The model
+authored in the card is authoritative: scalar index or permittivity remains
+nondispersive, while Sellmeier, Lorentz, and Drude models are serialized as
+Meep susceptibility terms. There is no solver-level automatic dispersion
+threshold.
+
+Use the public validator before constructing a simulation when accepting cards
+from another source:
+
+```python
+from gsim.meep import validate_meep_material_card
+
+validate_meep_material_card(card, wavelength_range_um=(1.5, 1.6))
+```
+
+The adapter rejects tabulated, polynomial, external-reference, Cauchy, Debye,
+and pole-residue dispersion because those representations require a causal
+Lorentz/Drude fit before Meep can use them. It also rejects unsupported loss,
+magnetic, and perturbation fields rather than silently dropping them.
+
 ## Simulation
 
 ::: gsim.meep.Simulation
@@ -22,6 +45,10 @@
         - wait_for_results
 
 ## Configuration
+
+::: gsim.meep.validate_meep_material_card
+    options:
+      show_source: false
 
 ::: gsim.meep.Geometry
     options:

--- a/src/gsim/common/materials/__init__.py
+++ b/src/gsim/common/materials/__init__.py
@@ -9,7 +9,11 @@ from gsim.common.materials.registry import (
 from gsim.common.materials.si_li_293k import SI_LI_293K
 from gsim.common.materials.si_salzberg import SI_SALZBERG
 from gsim.common.materials.sin_luke import SIN_LUKE
-from gsim.common.materials.sio2_malitson import SIO2_MALITSON
+from gsim.common.materials.sio2_arosa import SIO2_AROSA
+from gsim.common.materials.sio2_malitson import (
+    SIO2_MALITSON,
+    SIO2_MALITSON_2POLE,
+)
 from gsim.common.materials.snapshots import (
     MaterialModelError,
     MaterialNotFoundError,
@@ -22,7 +26,9 @@ from gsim.common.materials.snapshots import (
 __all__ = [
     "GSIM_MATERIAL_CARDS",
     "SIN_LUKE",
+    "SIO2_AROSA",
     "SIO2_MALITSON",
+    "SIO2_MALITSON_2POLE",
     "SI_LI_293K",
     "SI_SALZBERG",
     "MaterialModelError",

--- a/src/gsim/common/materials/_helpers.py
+++ b/src/gsim/common/materials/_helpers.py
@@ -1,13 +1,18 @@
 """Helpers shared by the built-in material cards."""
 
+from typing import Literal
+
 from pdk_schema import (
     Band,
+    Citation,
     DispersionModel,
     MaterialCard,
     Provenance,
     Regime,
     Validity,
 )
+
+ProvenanceSource = Literal["foundry", "gdsfactory", "user", "literature"]
 
 
 def wavelength_validity(minimum_um: float, maximum_um: float) -> Validity:
@@ -30,17 +35,23 @@ def material_card(
     name: str,
     permittivity: DispersionModel,
     temperature_ref: float | None,
+    *,
+    citations: tuple[Citation, ...] = (),
+    provenance_comment: str | None = None,
+    provenance_source: ProvenanceSource = "literature",
+    provenance_url: str | None = None,
+    provenance_info: dict[str, object] | None = None,
 ) -> MaterialCard:
     """Build a compact optical material card."""
     provenance = Provenance(
-        source="literature",
+        source=provenance_source,
         label=name,
         maturity="empirical",
-        citations=[],
-        comment=None,
-        url=None,
+        citations=list(citations),
+        comment=provenance_comment,
+        url=provenance_url,
         data_url=None,
-        info={},
+        info={} if provenance_info is None else provenance_info,
     )
     return MaterialCard(
         name=name,

--- a/src/gsim/common/materials/registry.py
+++ b/src/gsim/common/materials/registry.py
@@ -9,7 +9,11 @@ from pdk_schema import MaterialCard
 from gsim.common.materials.si_li_293k import SI_LI_293K
 from gsim.common.materials.si_salzberg import SI_SALZBERG
 from gsim.common.materials.sin_luke import SIN_LUKE
-from gsim.common.materials.sio2_malitson import SIO2_MALITSON
+from gsim.common.materials.sio2_arosa import SIO2_AROSA
+from gsim.common.materials.sio2_malitson import (
+    SIO2_MALITSON,
+    SIO2_MALITSON_2POLE,
+)
 
 MaterialSource = Literal["project", "gsim"]
 
@@ -21,9 +25,11 @@ GSIM_MATERIAL_CARDS: dict[str, MaterialCard] = {
     "SiN": SIN_LUKE.model_copy(update={"name": "SiN"}),
     "sin": SIN_LUKE.model_copy(update={"name": "sin"}),
     "SiN-Luke": SIN_LUKE,
-    "SiO2": SIO2_MALITSON.model_copy(update={"name": "SiO2"}),
-    "sio2": SIO2_MALITSON.model_copy(update={"name": "sio2"}),
+    "SiO2": SIO2_MALITSON_2POLE.model_copy(update={"name": "SiO2"}),
+    "sio2": SIO2_MALITSON_2POLE.model_copy(update={"name": "sio2"}),
+    "SiO2-Arosa": SIO2_AROSA,
     "SiO2-Malitson": SIO2_MALITSON,
+    "SiO2-Malitson-2Pole": SIO2_MALITSON_2POLE,
 }
 
 

--- a/src/gsim/common/materials/sio2_arosa.py
+++ b/src/gsim/common/materials/sio2_arosa.py
@@ -1,0 +1,38 @@
+"""Arosa and de la Fuente fused-silica model."""
+
+from pdk_schema import Citation, Sellmeier, SellmeierTerm
+
+from gsim.common.materials._helpers import material_card, wavelength_validity
+
+AROSA_FIT_CITATION = Citation(
+    role="fit",
+    doi="10.1364/OL.395510",
+    journal="Opt. Lett. 45, 4268-4271 (2020)",
+    authors="Y. Arosa; R. de la Fuente",
+    url="https://doi.org/10.1364/OL.395510",
+)
+
+SIO2_AROSA = material_card(
+    name="SiO2-Arosa",
+    temperature_ref=None,
+    permittivity=Sellmeier(
+        validity=wavelength_validity(0.26, 1.7),
+        variation=None,
+        conductivity=None,
+        terms=(
+            SellmeierTerm(b=0.9310, c_um=0.079),
+            SellmeierTerm(b=0.1735, c_um=0.130),
+            SellmeierTerm(b=2.1121, c_um=14.918),
+        ),
+        offset=0.0,
+    ),
+    citations=(AROSA_FIT_CITATION,),
+    provenance_comment=(
+        "Lossless three-term Sellmeier fit to measured fused-silica phase and "
+        "group indices."
+    ),
+    provenance_url="https://doi.org/10.1364/OL.395510",
+    provenance_info={"coefficient_source_table": 1},
+)
+
+__all__ = ["SIO2_AROSA"]

--- a/src/gsim/common/materials/sio2_malitson.py
+++ b/src/gsim/common/materials/sio2_malitson.py
@@ -1,8 +1,16 @@
 """Malitson fused-silica model."""
 
-from pdk_schema import Sellmeier, SellmeierTerm
+from pdk_schema import Citation, Lorentz, LorentzTerm, Sellmeier, SellmeierTerm
 
 from gsim.common.materials._helpers import material_card, wavelength_validity
+
+MALITSON_FIT_CITATION = Citation(
+    role="fit",
+    doi="10.1364/JOSA.55.001205",
+    journal="J. Opt. Soc. Am. 55, 1205-1209 (1965)",
+    authors="I. H. Malitson",
+    url="https://doi.org/10.1364/JOSA.55.001205",
+)
 
 SIO2_MALITSON = material_card(
     name="SiO2-Malitson",
@@ -18,6 +26,56 @@ SIO2_MALITSON = material_card(
         ),
         offset=0.0,
     ),
+    citations=(MALITSON_FIT_CITATION,),
+    provenance_comment=(
+        "Three-term lossless Sellmeier fit for optical-quality fused silica."
+    ),
+    provenance_url="https://doi.org/10.1364/JOSA.55.001205",
+    provenance_info={"coefficient_source_page": 1205},
 )
 
-__all__ = ["SIO2_MALITSON"]
+SIO2_MALITSON_2POLE = material_card(
+    name="SiO2-Malitson-2Pole",
+    temperature_ref=293.0,
+    permittivity=Lorentz(
+        validity=wavelength_validity(0.4, 2.0),
+        variation=None,
+        eps_inf=1.2648942846816222,
+        terms=(
+            LorentzTerm(
+                delta_eps=0.8392240453423187,
+                omega_0=1.8433977875628328e16,
+                gamma=0.0,
+            ),
+            LorentzTerm(
+                delta_eps=0.9045823938713766,
+                omega_0=1.8964034770858616e14,
+                gamma=0.0,
+            ),
+        ),
+    ),
+    citations=(MALITSON_FIT_CITATION,),
+    provenance_comment=(
+        "Lossless two-pole reduction of the Malitson model for time-domain "
+        "simulation from 400 to 2000 nm."
+    ),
+    provenance_source="gdsfactory",
+    provenance_url="https://doi.org/10.1364/JOSA.55.001205",
+    provenance_info={
+        "derived_from": "SiO2-Malitson",
+        "fit_band_um": [0.4, 2.0],
+        "fit_grid": "801 geometrically spaced wavelengths",
+        "fit_objective": "least squares in real relative permittivity",
+        "fit_constraints": (
+            "eps_inf >= 1; positive strengths; UV pole below 0.4 um; "
+            "IR pole above 2.0 um"
+        ),
+        "fit_max_abs_delta_n": 5.418048441008239e-7,
+        "fit_rms_delta_n": 1.1324175621670019e-7,
+        "pole_wavelengths_um": [0.1021836729987205, 9.932757401412259],
+        "fit_coefficient_origin": "derived in gsim; not published",
+        "reference_coefficient_source_page": 1205,
+    },
+)
+
+__all__ = ["SIO2_MALITSON", "SIO2_MALITSON_2POLE"]

--- a/src/gsim/meep/__init__.py
+++ b/src/gsim/meep/__init__.py
@@ -10,10 +10,6 @@ Example::
 
     sim = meep.Simulation()
     sim.geometry(component=ybranch)
-    sim.materials = {
-        "si": Material(permittivity=12.0),
-        "SiO2": Material(permittivity=2.1),
-    }
     sim.source(port="o1", wavelength=1.55, wavelength_span=0.01)
     sim.num_freqs = 11
     sim.monitors = ["o1", "o2"]
@@ -23,6 +19,11 @@ Example::
 """
 
 from gsim.gcloud import RunResult, register_result_parser
+from gsim.meep.material_cards import (
+    MeepMaterialCompatibilityError,
+    material_data_from_card,
+    validate_meep_material_card,
+)
 from gsim.meep.mode_solver import (
     mode_x_grid,
     mode_y_grid,
@@ -79,6 +80,7 @@ __all__ = [
     "DomainConfig",
     "Geometry",
     "Material",
+    "MeepMaterialCompatibilityError",
     "ModeResult",
     "ModeSolver",
     "ModeSource",
@@ -90,6 +92,7 @@ __all__ = [
     "SourceConfig",
     "Symmetry",
     "WavelengthConfig",
+    "material_data_from_card",
     "mode_x_grid",
     "mode_y_grid",
     "mode_z_grid",
@@ -98,4 +101,5 @@ __all__ = [
     "solve_slab_mode",
     "solve_slab_modes",
     "solve_slab_wavelength_sweep",
+    "validate_meep_material_card",
 ]

--- a/src/gsim/meep/material_cards.py
+++ b/src/gsim/meep/material_cards.py
@@ -1,0 +1,352 @@
+"""Validate and translate optical MaterialCards for MEEP."""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+from pdk_schema import (
+    Drude,
+    Index,
+    Lorentz,
+    MaterialCard,
+    Permittivity,
+    ScalarValue,
+    Sellmeier,
+    SellmeierPoleSquared,
+)
+from scipy.constants import c as C0  # noqa: N812
+
+from gsim.meep.models.config import MaterialData, SusceptibilityConfig
+
+
+class MeepMaterialCompatibilityError(ValueError):
+    """Raised when a MaterialCard cannot be represented exactly by MEEP."""
+
+
+def _compatibility_error(
+    material_name: str, message: str
+) -> MeepMaterialCompatibilityError:
+    """Return a compatibility error scoped to one material."""
+    return MeepMaterialCompatibilityError(f"Material {material_name!r} {message}")
+
+
+def _dimensionless_scalar(value: object, material_name: str, field: str) -> float:
+    """Extract a dimensionless scalar or raise a compatibility error."""
+    if not isinstance(value, ScalarValue) or value.unit != "":
+        raise _compatibility_error(
+            material_name,
+            f"{field} must be a dimensionless scalar for MEEP; "
+            "tabulated, polynomial, external-reference, and tensor values "
+            "require a causal Lorentz/Drude fit.",
+        )
+    return float(value.value)
+
+
+def _wavelength_to_um(value: float, unit: str, material_name: str) -> float:
+    """Convert one supported wavelength value to micrometers."""
+    scale = {"m": 1e6, "um": 1.0, "nm": 1e-3}.get(unit)
+    if scale is None:
+        raise _compatibility_error(
+            material_name, f"uses unsupported wavelength unit {unit!r}."
+        )
+    return float(value) * scale
+
+
+def _frequency_to_meep(value: float, unit: str, material_name: str) -> float:
+    """Convert a frequency value to MEEP units with one micrometer as length."""
+    scale = {
+        "Hz": 1.0,
+        "MHz": 1e6,
+        "GHz": 1e9,
+        "THz": 1e12,
+    }.get(unit)
+    if scale is not None:
+        return float(value) * scale * 1e-6 / C0
+    if unit == "rad/s":
+        return float(value) * 1e-6 / (2 * math.pi * C0)
+    raise _compatibility_error(
+        material_name, f"uses unsupported frequency unit {unit!r}."
+    )
+
+
+def _model_frequency_range(model: object, material_name: str) -> list[float] | None:
+    """Return a model validity interval in MEEP frequency units."""
+    validity = getattr(model, "validity", None)
+    ranges = {} if validity is None else (validity.over or {})
+    wavelength_band = ranges.get("wavelength")
+    if wavelength_band is not None:
+        lower_um = _wavelength_to_um(
+            wavelength_band.min, wavelength_band.unit, material_name
+        )
+        upper_um = _wavelength_to_um(
+            wavelength_band.max, wavelength_band.unit, material_name
+        )
+        if lower_um <= 0 or upper_um <= lower_um:
+            raise _compatibility_error(
+                material_name, "has an invalid wavelength validity range."
+            )
+        return [1.0 / upper_um, 1.0 / lower_um]
+
+    frequency_band = ranges.get("frequency")
+    if frequency_band is not None:
+        lower = _frequency_to_meep(
+            frequency_band.min, frequency_band.unit, material_name
+        )
+        upper = _frequency_to_meep(
+            frequency_band.max, frequency_band.unit, material_name
+        )
+        if lower <= 0 or upper <= lower:
+            raise _compatibility_error(
+                material_name, "has an invalid frequency validity range."
+            )
+        return [lower, upper]
+    return None
+
+
+def _validate_source_range(
+    model: object,
+    wavelength_range_um: tuple[float, float] | None,
+    material_name: str,
+) -> None:
+    """Require the simulation band to lie inside model validity."""
+    if wavelength_range_um is None:
+        return
+    lower_um, upper_um = wavelength_range_um
+    if lower_um <= 0 or upper_um < lower_um:
+        raise _compatibility_error(
+            material_name,
+            "received an invalid simulation wavelength range; expected "
+            "0 < lower <= upper.",
+        )
+    model_range = _model_frequency_range(model, material_name)
+    if model_range is None:
+        return
+    source_range = [1.0 / upper_um, 1.0 / lower_um]
+    if source_range[0] < model_range[0] or source_range[1] > model_range[1]:
+        raise _compatibility_error(
+            material_name,
+            f"is not valid over the simulation band {lower_um:g} to {upper_um:g} um.",
+        )
+
+
+def _validate_card_envelope(card: MaterialCard, material_name: str) -> object:
+    """Validate fields shared by every supported optical model."""
+    if card.optical is None or card.optical.permittivity is None:
+        raise _compatibility_error(material_name, "has no optical permittivity model.")
+    if card.optical.conductivity is not None:
+        raise _compatibility_error(
+            material_name, "has regime conductivity, which is not yet supported."
+        )
+    if card.optical.permeability is not None:
+        raise _compatibility_error(
+            material_name, "has optical permeability, which is not yet supported."
+        )
+    if card.optical.perturbations:
+        raise _compatibility_error(
+            material_name,
+            "has optical perturbations, but gsim.meep has no operating-condition "
+            "inputs for applying them.",
+        )
+    model = card.optical.permittivity
+    if getattr(model, "conductivity", None) is not None:
+        raise _compatibility_error(
+            material_name, "has model conductivity, which is not yet supported."
+        )
+    return model
+
+
+def validate_meep_material_card(
+    card: MaterialCard,
+    wavelength_range_um: tuple[float, float] | None = None,
+    *,
+    material_name: str | None = None,
+) -> None:
+    """Validate that an optical MaterialCard has an exact MEEP representation.
+
+    Constant, Sellmeier, Lorentz, and Drude models are accepted. Model-free
+    wavelength-dependent data and Cauchy, Debye, or pole-residue models are
+    rejected because MEEP requires a causal Lorentz/Drude fit for those forms.
+
+    Args:
+        card: Material card to validate.
+        wavelength_range_um: Optional inclusive simulation band in micrometers.
+        material_name: Registry name used in error messages.
+
+    Raises:
+        MeepMaterialCompatibilityError: If the card cannot be encoded exactly.
+    """
+    name = material_name or card.name
+    model = _validate_card_envelope(card, name)
+    _validate_source_range(model, wavelength_range_um, name)
+
+    if isinstance(model, Index):
+        refractive_index = _dimensionless_scalar(model.n, name, "n")
+        if refractive_index <= 0:
+            raise _compatibility_error(name, "has a non-positive refractive index.")
+        if model.k is not None and _dimensionless_scalar(model.k, name, "k") != 0:
+            raise _compatibility_error(
+                name,
+                "has a nonzero constant extinction coefficient; MEEP requires "
+                "a causal Lorentz/Drude loss model.",
+            )
+        return
+
+    if isinstance(model, Permittivity):
+        epsilon = _dimensionless_scalar(model.eps_real, name, "eps_real")
+        if epsilon <= 0:
+            raise _compatibility_error(name, "has non-positive permittivity.")
+        if (
+            model.eps_imag is not None
+            and _dimensionless_scalar(model.eps_imag, name, "eps_imag") != 0
+        ):
+            raise _compatibility_error(
+                name,
+                "has nonzero constant imaginary permittivity; MEEP requires "
+                "a causal Lorentz/Drude loss model.",
+            )
+        return
+
+    if isinstance(model, (Sellmeier, SellmeierPoleSquared)):
+        if 1.0 + model.offset <= 0:
+            raise _compatibility_error(name, "has non-positive epsilon infinity.")
+        pole_positions = (
+            [abs(term.c_um) for term in model.terms]
+            if isinstance(model, Sellmeier)
+            else [term.c_um2 for term in model.terms]
+        )
+        if any(position <= 0 for position in pole_positions):
+            raise _compatibility_error(
+                name, "has a non-positive Sellmeier pole position."
+            )
+        return
+
+    if isinstance(model, (Lorentz, Drude)):
+        if model.eps_inf <= 0:
+            raise _compatibility_error(name, "has non-positive epsilon infinity.")
+        return
+
+    raise _compatibility_error(
+        name,
+        f"uses unsupported optical model {type(model).__name__}; provide a "
+        "constant, Sellmeier, Lorentz, or Drude card.",
+    )
+
+
+def _angular_frequency_to_meep(angular_frequency: float) -> float:
+    """Convert radians per second to MEEP frequency units (1/um)."""
+    return angular_frequency * 1e-6 / (2 * math.pi * C0)
+
+
+def material_data_from_card(
+    card: MaterialCard,
+    wavelength_range_um: tuple[float, float] | None = None,
+    *,
+    material_name: str | None = None,
+) -> MaterialData:
+    """Translate a compatible MaterialCard into serialized MEEP data."""
+    name = material_name or card.name
+    validate_meep_material_card(card, wavelength_range_um, material_name=name)
+    optical = card.optical
+    if optical is None or optical.permittivity is None:  # pragma: no cover
+        raise AssertionError("MaterialCard validation did not reject an empty model.")
+    model = optical.permittivity
+
+    if isinstance(model, Index):
+        refractive_index = _dimensionless_scalar(model.n, name, "n")
+        return MaterialData(epsilon_diag=[refractive_index**2] * 3)
+    if isinstance(model, Permittivity):
+        epsilon = _dimensionless_scalar(model.eps_real, name, "eps_real")
+        return MaterialData(epsilon_diag=[epsilon] * 3)
+
+    susceptibilities: list[SusceptibilityConfig] = []
+    if isinstance(model, Sellmeier):
+        epsilon_inf = 1.0 + model.offset
+        susceptibilities = [
+            SusceptibilityConfig(
+                kind="lorentzian",
+                frequency=1.0 / abs(term.c_um),
+                gamma=0.0,
+                sigma=term.b,
+            )
+            for term in model.terms
+            if term.b != 0
+        ]
+    elif isinstance(model, SellmeierPoleSquared):
+        epsilon_inf = 1.0 + model.offset
+        susceptibilities = [
+            SusceptibilityConfig(
+                kind="lorentzian",
+                frequency=1.0 / math.sqrt(term.c_um2),
+                gamma=0.0,
+                sigma=term.b,
+            )
+            for term in model.terms
+            if term.b != 0
+        ]
+    elif isinstance(model, Lorentz):
+        epsilon_inf = model.eps_inf
+        susceptibilities = [
+            SusceptibilityConfig(
+                kind="lorentzian",
+                frequency=_angular_frequency_to_meep(term.omega_0),
+                gamma=_angular_frequency_to_meep(term.gamma),
+                sigma=term.delta_eps,
+            )
+            for term in model.terms
+            if term.delta_eps != 0
+        ]
+    elif isinstance(model, Drude):
+        epsilon_inf = model.eps_inf
+        susceptibilities = [
+            SusceptibilityConfig(
+                kind="drude",
+                frequency=_angular_frequency_to_meep(term.omega_p),
+                gamma=_angular_frequency_to_meep(term.gamma),
+                sigma=1.0,
+            )
+            for term in model.terms
+        ]
+    else:  # pragma: no cover - guarded by validation
+        raise TypeError(f"Unhandled compatible model {type(model).__name__}")
+
+    return MaterialData(
+        epsilon_diag=[epsilon_inf] * 3,
+        epsilon_susceptibilities=susceptibilities or None,
+        valid_freq_range=_model_frequency_range(model, name),
+    )
+
+
+def warn_if_material_may_be_unstable(
+    material_name: str,
+    material_data: MaterialData,
+    resolution: int,
+    *,
+    courant: float = 0.5,
+) -> None:
+    """Warn when a Lorentz resonance exceeds MEEP's rough stability limit."""
+    maximum_frequency = resolution / (math.pi * courant)
+    unstable = [
+        term.frequency
+        for term in material_data.epsilon_susceptibilities or []
+        if term.kind == "lorentzian" and term.frequency >= maximum_frequency
+    ]
+    if not unstable:
+        return
+    minimum_resolution = math.floor(math.pi * courant * max(unstable)) + 1
+    warnings.warn(
+        f"Material {material_name!r} has a Lorentz pole at "
+        f"{max(unstable):.4g} 1/um, above MEEP's rough stability limit for "
+        f"resolution={resolution} and Courant={courant}. Use resolution >= "
+        f"{minimum_resolution}.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+
+__all__ = [
+    "MeepMaterialCompatibilityError",
+    "material_data_from_card",
+    "validate_meep_material_card",
+    "warn_if_material_may_be_unstable",
+]

--- a/src/gsim/meep/materials.py
+++ b/src/gsim/meep/materials.py
@@ -1,47 +1,30 @@
-"""Material resolution for MEEP simulation.
-
-Resolves material names from the common materials database to optical
-properties needed for photonic FDTD simulation. Supports three-tier
-resolution: user override > PDK overlay > built-in database.
-
-Tensor fields on ResolvedMaterial (permittivity, conductivity, loss_tangent,
-permeability) accept scalar (isotropic) or list-of-3 (anisotropic). This
-module maps them to MEEP-specific MaterialData fields:
-
-    - ``permittivity`` scalar/list -> ``epsilon_diag``
-    - ``permeability`` scalar/list -> ``mu_diag``
-    - ``conductivity`` scalar/list -> ``D_conductivity`` / ``D_conductivity_diag``
-    - ``loss_tangent`` scalar/list -> ``D_conductivity`` (converted at sim freq)
-    - ``material_axes`` -> ``epsilon_offdiag`` (rotation of the tensor)
-
-Dispersion rendering (RFC: dispersion flag on the Simulation):
-    - ``dispersion="auto"``: evaluate deps/eps across source bandwidth; enable
-      susceptibility poles per material when > threshold (default 0.5%).
-    - ``dispersion="true"``: force full dispersion for all materials.
-    - ``dispersion="false"``: force constant-epsilon for speed.
-"""
+"""Resolve MEEP materials from canonical MaterialCards and explicit overrides."""
 
 from __future__ import annotations
 
 import math
-import warnings
+from collections.abc import Mapping
 
+from pdk_schema import MaterialCard
 from scipy.constants import c as C0  # noqa: N812
 
+from gsim.common.materials import (
+    MaterialNotFoundError,
+    find_material_card,
+    resolve_material_snapshot,
+)
 from gsim.common.stack.materials import (
-    DispersionModel,
     MaterialProperties,
     ResolvedMaterial,
     _as_list,
     _is_tensor,
     _normalize_material_keys,
-    get_material_properties,
-    resolve_material_at_wavelength,
-    should_enable_dispersion,
 )
-from gsim.meep.models.config import LorentzianPoleConfig, MaterialData
-
-_EPS0_SI = 8.854187817e-12
+from gsim.meep.material_cards import (
+    material_data_from_card,
+    warn_if_material_may_be_unstable,
+)
+from gsim.meep.models.config import MaterialData
 
 
 def loss_tangent_to_conductivity(
@@ -49,507 +32,184 @@ def loss_tangent_to_conductivity(
     permittivity: float,
     freq_hz: float,
 ) -> float:
-    """Convert loss tangent to MEEP D_conductivity at a given frequency.
+    """Convert loss tangent to MEEP's dimensionless D-conductivity.
 
-    sigma = 2*pi*f * eps0 * eps_r * tan(delta)
-
-    This conversion is exact at the center frequency and approximate
-    elsewhere, which is appropriate for narrowband simulations.
-
-    Args:
-        loss_tangent: Loss tangent tan(delta)
-        permittivity: Relative permittivity eps_r
-        freq_hz: Frequency in Hz
-
-    Returns:
-        Conductivity in S/m
+    ``permittivity`` is retained in the signature for API compatibility; it
+    cancels when physical conductivity is normalized to MEEP units.
     """
-    return 2.0 * math.pi * freq_hz * _EPS0_SI * permittivity * loss_tangent
-
-
-def sellmeier_to_lorentzian_poles(
-    model: DispersionModel,
-) -> list[LorentzianPoleConfig]:
-    """Convert a Sellmeier dispersion model to MEEP Lorentzian susceptibility poles.
-
-    The Sellmeier equation n^2(lambda) = eps_inf + sum(Bi*lam^2/(lam^2-Ci))
-    maps to the Lorentzian form eps(w) = eps_inf + sum(sigma_i/(w0i^2 - w^2))
-    with gamma=0 (lossless poles) via:
-
-    - w0_i = 1/sqrt(C_i)  (resonance frequency in 1/um, since C is in um^2)
-    - sigma_i = B_i * w0_i^2  (oscillator strength)
-
-    Args:
-        model: A DispersionModel of type "sellmeier" with sellmeier_terms.
-
-    Returns:
-        List of LorentzianPoleConfig for MEEP epsilon_susceptibilities.
-    """
-    if model.type != "sellmeier" or not model.sellmeier_terms:
-        return []
-
-    poles: list[LorentzianPoleConfig] = []
-    for term in model.sellmeier_terms:
-        if term.C <= 0:
-            continue
-        w0 = 1.0 / math.sqrt(term.C)
-        sigma = term.B * w0**2
-        pole = LorentzianPoleConfig(
-            frequency=w0,
-            gamma=0.0,
-            sigma=sigma,
-            sigma_diagonal=term.sigma_diagonal,
-        )
-        poles.append(pole)
-
-    return poles
-
-
-def lorentzian_to_meep_poles(
-    model: DispersionModel,
-) -> list[LorentzianPoleConfig]:
-    """Convert a Lorentzian dispersion model to MEEP LorentzianPoleConfig.
-
-    Direct mapping: frequency, gamma, sigma, sigma_diagonal transfer as-is.
-
-    Args:
-        model: A DispersionModel of type "lorentzian" with lorentzian_terms.
-
-    Returns:
-        List of LorentzianPoleConfig for MEEP epsilon_susceptibilities.
-    """
-    if model.type != "lorentzian" or not model.lorentzian_terms:
-        return []
-
-    poles: list[LorentzianPoleConfig] = []
-    for term in model.lorentzian_terms:
-        pole = LorentzianPoleConfig(
-            frequency=term.frequency,
-            gamma=term.gamma,
-            sigma=term.sigma,
-            sigma_diagonal=term.sigma_diagonal,
-        )
-        poles.append(pole)
-
-    return poles
-
-
-def dispersion_model_to_meep_poles(
-    model: DispersionModel,
-) -> list[LorentzianPoleConfig]:
-    """Convert any DispersionModel to MEEP Lorentzian susceptibility poles.
-
-    Dispatches to the appropriate converter based on model type.
-    Returns empty list for constant-type models (no dispersive poles).
-
-    Args:
-        model: A DispersionModel (sellmeier, lorentzian, or constant).
-
-    Returns:
-        List of LorentzianPoleConfig for MEEP epsilon_susceptibilities.
-    """
-    if model.type == "sellmeier":
-        return sellmeier_to_lorentzian_poles(model)
-    if model.type == "lorentzian":
-        return lorentzian_to_meep_poles(model)
-    return []
-
-
-def _validity_to_freq_range(
-    model: DispersionModel,
-) -> list[float] | None:
-    """Extract validity range as [f_min, f_max] in MEEP units (1/um).
-
-    Args:
-        model: DispersionModel with a validity range.
-
-    Returns:
-        [f_min, f_max] in 1/um, or None if unspecified.
-    """
-    v = model.validity
-    if v.valid_wavelength is not None:
-        wl_min, wl_max = v.valid_wavelength
-        if wl_min > 0 and wl_max > 0:
-            return [1.0 / wl_max, 1.0 / wl_min]
-    if v.valid_frequency is not None:
-        f_min_hz, f_max_hz = v.valid_frequency
-        f_min = f_min_hz * 1e-6 / C0
-        f_max = f_max_hz * 1e-6 / C0
-        return [f_min, f_max]
-    return None
+    del permittivity
+    meep_frequency = freq_hz * 1e-6 / C0
+    return 2.0 * math.pi * meep_frequency * loss_tangent
 
 
 def _is_identity_axes(material_axes: list[list[float]] | None) -> bool:
-    """Check if material_axes represents the identity rotation."""
+    """Check whether material axes describe the identity rotation."""
     if material_axes is None:
         return True
     identity = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
-    for row, ref in zip(material_axes, identity, strict=False):
-        for v, r in zip(row, ref, strict=False):
-            if abs(v - r) > 1e-10:
-                return False
-    return True
+    return all(
+        abs(value - reference) <= 1e-10
+        for row, expected_row in zip(material_axes, identity, strict=False)
+        for value, reference in zip(row, expected_row, strict=False)
+    )
 
 
 def _rotate_diagonal_tensor(
-    diag: list[float],
-    material_axes: list[list[float]],
+    diagonal: list[float], material_axes: list[list[float]]
 ) -> list[float]:
-    """Rotate a diagonal tensor by material_axes, returning off-diagonal components.
-
-    Given a diagonal tensor T = diag(d1, d2, d3) and rotation matrix R,
-    the rotated tensor is T' = R T R^T. Returns the [u, v, w] off-diagonal
-    components in MEEP convention: epsilon_offdiag = [T'01, T'02, T'12].
-
-    Args:
-        diag: Diagonal components [d1, d2, d3]
-        material_axes: 3x3 rotation matrix (rows = new axis vectors)
-
-    Returns:
-        Off-diagonal components [T'01, T'02, T'12]
-    """
+    """Rotate a diagonal tensor and return MEEP's three off-diagonal terms."""
     rotated = [[0.0] * 3 for _ in range(3)]
-    for i in range(3):
-        for j in range(3):
-            for k in range(3):
-                rotated[i][j] += material_axes[i][k] * diag[k] * material_axes[j][k]
-
+    for row in range(3):
+        for column in range(3):
+            rotated[row][column] = sum(
+                material_axes[row][axis] * diagonal[axis] * material_axes[column][axis]
+                for axis in range(3)
+            )
     return [rotated[0][1], rotated[0][2], rotated[1][2]]
 
 
 def _resolved_to_material_data(
     resolved: ResolvedMaterial,
     wavelength_um: float,
-    dispersive_model: DispersionModel | None = None,
 ) -> MaterialData:
-    """Convert a ResolvedMaterial to a MaterialData with full tensor support.
-
-    When ``dispersive_model`` is provided, populates
-    ``epsilon_susceptibilities`` with Lorentzian poles and ``valid_freq_range``
-    from the model's validity bounds. The epsilon_inf field is derived from
-    the model's epsilon_inf, and epsilon_diag is set to [eps_inf]*3.
-
-    Args:
-        resolved: Evaluated material properties from the dispersion resolver
-        wavelength_um: Simulation wavelength in um (for loss tangent conversion)
-        dispersive_model: Optional DispersionModel for dispersive rendering
-
-    Returns:
-        MaterialData suitable for the MEEP config JSON
-    """
+    """Convert an explicit scalar/tensor override to MEEP material data."""
     if resolved.permittivity is None:
         raise ValueError("ResolvedMaterial has no permittivity")
-
-    data = MaterialData()
-
-    if dispersive_model is not None:
-        poles = dispersion_model_to_meep_poles(dispersive_model)
-        if poles:
-            data.epsilon_susceptibilities = poles
-        freq_range = _validity_to_freq_range(dispersive_model)
-        if freq_range is not None:
-            data.valid_freq_range = freq_range
-        eps_inf = dispersive_model.epsilon_inf
-        data.epsilon_diag = [eps_inf] * 3
-    else:
-        data.epsilon_diag = _as_list(resolved.permittivity, 3)
+    epsilon_diagonal = _as_list(resolved.permittivity, 3)
+    data = MaterialData(epsilon_diag=epsilon_diagonal)
 
     if resolved.permeability is not None:
         data.mu_diag = _as_list(resolved.permeability, 3)
 
-    freq_hz = C0 / (wavelength_um * 1e-6)
-
-    cond_scalar = resolved.conductivity_scalar
-    if cond_scalar is not None and cond_scalar > 0:
-        if _is_tensor(resolved.conductivity):
-            data.D_conductivity_diag = _as_list(resolved.conductivity, 3)
-        else:
-            data.D_conductivity = cond_scalar
-
-    lt_scalar = resolved.loss_tangent_scalar
-    has_cond = data.D_conductivity is not None or data.D_conductivity_diag is not None
-    if lt_scalar is not None and lt_scalar > 0 and not has_cond:
+    frequency_hz = C0 / (wavelength_um * 1e-6)
+    loss_tangent = resolved.loss_tangent_scalar
+    if loss_tangent is not None and loss_tangent > 0:
         if _is_tensor(resolved.loss_tangent):
-            eps_diag = _as_list(resolved.permittivity, 3) or [1.0] * 3
-            lt_list = _as_list(resolved.loss_tangent, 3)
             data.D_conductivity_diag = [
-                loss_tangent_to_conductivity(lt, eps, freq_hz)
-                for lt, eps in zip(
-                    lt_list or [],
-                    eps_diag,
-                    strict=False,
-                )
+                loss_tangent_to_conductivity(value, 1.0, frequency_hz)
+                for value in _as_list(resolved.loss_tangent, 3) or []
             ]
         else:
-            eps_r = resolved.permittivity_scalar or 1.0
             data.D_conductivity = loss_tangent_to_conductivity(
-                lt_scalar, eps_r, freq_hz
+                loss_tangent,
+                resolved.permittivity_scalar or 1.0,
+                frequency_hz,
             )
 
     if (
         resolved.material_axes is not None
         and not _is_identity_axes(resolved.material_axes)
-        and data.epsilon_diag is not None
+        and epsilon_diagonal is not None
     ):
         data.epsilon_offdiag = _rotate_diagonal_tensor(
-            data.epsilon_diag, resolved.material_axes
+            epsilon_diagonal, resolved.material_axes
         )
-
     return data
 
 
-def _find_dispersion_model(
-    props: MaterialProperties,
+def _override_data(
+    material_name: str,
+    normalized_overrides: Mapping[str, MaterialProperties],
     wavelength_um: float,
-) -> DispersionModel | None:
-    """Find the best dispersion model for a material at a given wavelength.
+) -> MaterialData | None:
+    """Resolve a case-normalized explicit override, if present."""
+    properties = normalized_overrides.get(material_name.lower())
+    if properties is None:
+        return None
+    resolved = properties.evaluate_at_wavelength(wavelength_um)
+    if resolved.behavior == "conductive":
+        raise ValueError(
+            f"Material override {material_name!r} is conductive and cannot be "
+            "used as a passive optical medium."
+        )
+    return _resolved_to_material_data(resolved, wavelength_um)
 
-    Scans dispersion_models for one whose validity covers the wavelength.
-    Falls back to models with unspecified validity. Returns None if no
-    model covers the wavelength.
 
-    Args:
-        props: MaterialProperties with optional dispersion_models
-        wavelength_um: Target wavelength in um
-
-    Returns:
-        DispersionModel if found, else None
-    """
-    for model in props.dispersion_models:
-        if model.validity.covers_wavelength(wavelength_um):
-            return model
-    for model in props.dispersion_models:
-        if model.validity.is_unspecified:
-            return model
-    return None
+def _center_wavelength_data(
+    material_name: str,
+    wavelength_um: float,
+    project_material_cards: Mapping[str, MaterialCard] | None,
+) -> MaterialData:
+    """Evaluate a MaterialCard at one wavelength for mode solving and plots."""
+    snapshot = resolve_material_snapshot(
+        material_name,
+        wavelength_um,
+        project_material_cards,
+    )
+    epsilon_real = snapshot.refractive_index**2 - snapshot.extinction_coefficient**2
+    return MaterialData(epsilon_diag=[epsilon_real] * 3)
 
 
 def resolve_materials(
     used_material_names: set[str],
     overrides: dict[str, MaterialProperties] | None = None,
-    wavelength_um: float | None = None,
-    overlay: dict[str, MaterialProperties] | None = None,
+    wavelength_um: float = 1.55,
+    project_material_cards: Mapping[str, MaterialCard] | None = None,
 ) -> dict[str, MaterialData]:
-    """Resolve material names to optical properties for MEEP.
+    """Resolve center-wavelength material data from project-first cards.
 
-    Only resolves materials that actually have geometry (i.e., polygons
-    extracted from the component). Materials present in the GDS but
-    missing optical data emit a warning and are excluded from the config.
-
-    When ``wavelength_um`` is provided, uses the frequency-aware dispersion
-    resolver to evaluate Sellmeier/Lorentzian models at the target wavelength
-    and populates anisotropic tensor fields (epsilon_diag, mu_diag,
-    D_conductivity, epsilon_offdiag) from the resolved material.
-
-    Args:
-        used_material_names: Material names that appear in extracted geometry
-        overrides: User-supplied material property overrides (from set_material())
-        wavelength_um: Target wavelength in um. None = use legacy scalar lookup.
-        overlay: PDK overlay dict (foundry-specific values).
-
-    Returns:
-        Dict mapping material name to MaterialData
+    This nondispersive snapshot path is used by mode solving and index plots.
+    Production FDTD configuration uses :func:`resolve_fdtd_materials` so that
+    authored Sellmeier, Lorentz, and Drude dispersion is preserved.
     """
-    overrides = overrides or {}
     normalized_overrides = _normalize_material_keys(
-        overrides, used_names=used_material_names, label="overrides"
+        overrides or {}, used_names=used_material_names, label="overrides"
     )
     materials: dict[str, MaterialData] = {}
-
     for name in sorted(used_material_names):
-        if name.lower() in normalized_overrides:
-            props = normalized_overrides[name.lower()]
-            if wavelength_um is not None:
-                resolved = props.evaluate_at_wavelength(wavelength_um)
-                if resolved.behavior == "conductive":
-                    continue
-                if resolved.permittivity is not None:
-                    materials[name] = _resolved_to_material_data(
-                        resolved, wavelength_um
-                    )
-                    continue
-            else:
-                cond = props.conductivity
-                if isinstance(cond, list):
-                    cond = cond[0]
-                if cond is not None and cond >= ResolvedMaterial.CONDUCTIVITY_THRESHOLD:
-                    continue
-            if props.permittivity is None:
-                warnings.warn(
-                    f"Material override '{name}' has no permittivity -- "
-                    f"skipping. Use set_material('{name}', permittivity=...)",
-                    stacklevel=2,
-                )
-                continue
-            materials[name] = MaterialData(
-                epsilon_diag=_as_list(props.permittivity, 3),
-            )
+        if name.lower() == "air":
+            materials[name] = MaterialData(epsilon_diag=[1.0, 1.0, 1.0])
             continue
-
-        db_props = get_material_properties(name)
-
-        if wavelength_um is not None:
-            resolved = resolve_material_at_wavelength(
-                name, wavelength_um, overlay=overlay
-            )
-            if resolved is not None and resolved.behavior == "conductive":
-                continue
-            if resolved is not None and resolved.permittivity is not None:
-                materials[name] = _resolved_to_material_data(resolved, wavelength_um)
-                continue
-        else:
-            if db_props is not None and db_props.permittivity is not None:
-                materials[name] = MaterialData(
-                    epsilon_diag=_as_list(db_props.permittivity, 3),
-                )
-                continue
-
-        if db_props is None:
-            warnings.warn(
-                f"Material '{name}' not found in database. "
-                f"Use sim.set_material('{name}', permittivity=...) to add it.",
-                stacklevel=2,
-            )
-        else:
-            warnings.warn(
-                f"Material '{name}' has no permittivity data "
-                f"-- layer will be omitted from simulation. "
-                f"Use sim.set_material('{name}', permittivity=...) to include it.",
-                stacklevel=2,
-            )
-
+        override = _override_data(name, normalized_overrides, wavelength_um)
+        materials[name] = override or _center_wavelength_data(
+            name, wavelength_um, project_material_cards
+        )
     return materials
 
 
-def resolve_materials_with_dispersion(
+def resolve_fdtd_materials(
     used_material_names: set[str],
     overrides: dict[str, MaterialProperties] | None = None,
-    wavelength_um: float = 1.55,
-    bandwidth_um: float = 0.1,
-    dispersion: str = "auto",
-    overlay: dict[str, MaterialProperties] | None = None,
-    threshold: float = 0.005,
+    *,
+    wavelength_um: float,
+    wavelength_span_um: float,
+    resolution: int,
+    project_material_cards: Mapping[str, MaterialCard] | None = None,
 ) -> dict[str, MaterialData]:
-    """Resolve materials with dispersion-aware evaluation.
-
-    Uses the frequency-aware resolver and the ``dispersion`` flag to decide
-    whether each material should use constant or dispersive rendering.
-
-    ``dispersion="auto"``: For each material, evaluate deps/eps across the
-    source bandwidth. If > threshold, populate epsilon_susceptibilities with
-    Lorentzian poles from the Sellmeier/Lorentzian model. Otherwise, use
-    constant-epsilon rendering.
-
-    ``dispersion="true"``: Force full dispersion for all materials that have
-    dispersive models in the database.
-
-    ``dispersion="false"``: Force constant-epsilon for all materials.
-
-    Args:
-        used_material_names: Material names that appear in extracted geometry
-        overrides: User-supplied material property overrides
-        wavelength_um: Center wavelength in um
-        bandwidth_um: Source bandwidth in um
-        dispersion: "auto", "true", or "false"
-        overlay: PDK overlay dict (foundry-specific values)
-        threshold: deps/eps threshold for auto-dispersion (default 0.5%)
-
-    Returns:
-        Dict mapping material name to MaterialData
-    """
-    overrides = overrides or {}
+    """Resolve full authored dispersion for a MEEP time-domain simulation."""
+    lower_wavelength = wavelength_um - wavelength_span_um / 2
+    upper_wavelength = wavelength_um + wavelength_span_um / 2
+    if lower_wavelength <= 0:
+        raise ValueError("The source wavelength span reaches a non-positive value.")
+    wavelength_range = (lower_wavelength, upper_wavelength)
     normalized_overrides = _normalize_material_keys(
-        overrides, used_names=used_material_names, label="overrides"
+        overrides or {}, used_names=used_material_names, label="overrides"
     )
     materials: dict[str, MaterialData] = {}
-    force_dispersion = dispersion == "true"
-    force_nodispersion = dispersion == "false"
-
     for name in sorted(used_material_names):
-        resolved: ResolvedMaterial | None
-        props: MaterialProperties | None = None
-
-        if name.lower() in normalized_overrides:
-            override_props = normalized_overrides[name.lower()]
-            resolved = override_props.evaluate_at_wavelength(wavelength_um)
-            props = override_props
-        else:
-            resolved = resolve_material_at_wavelength(
-                name, wavelength_um, overlay=overlay
-            )
-            from gsim.common.stack.materials import _resolve_with_overlay
-
-            props = _resolve_with_overlay(name, overlay)
-
-        if resolved is not None and resolved.behavior == "conductive":
+        if name.lower() == "air":
+            materials[name] = MaterialData(epsilon_diag=[1.0, 1.0, 1.0])
             continue
-
-        if resolved is None or resolved.permittivity is None:
-            warnings.warn(
-                f"Material '{name}' has no permittivity data -- "
-                f"layer will be omitted from simulation.",
-                stacklevel=2,
-            )
+        override = _override_data(name, normalized_overrides, wavelength_um)
+        if override is not None:
+            materials[name] = override
             continue
-
-        if force_nodispersion:
-            materials[name] = _resolved_to_material_data(resolved, wavelength_um)
-            continue
-
-        dispersive_model: DispersionModel | None = None
-        if props is not None:
-            dispersive_model = _find_dispersion_model(props, wavelength_um)
-
-        if dispersive_model is None or dispersive_model.type == "constant":
-            materials[name] = _resolved_to_material_data(resolved, wavelength_um)
-            continue
-
-        if force_dispersion:
-            materials[name] = _resolved_to_material_data(
-                resolved, wavelength_um, dispersive_model=dispersive_model
-            )
-            continue
-
-        need_disp = should_enable_dispersion(
-            name, wavelength_um, bandwidth_um, threshold, overrides, overlay
+        try:
+            card, _source = find_material_card(name, project_material_cards)
+        except KeyError as error:
+            raise MaterialNotFoundError(error.args[0]) from error
+        material_data = material_data_from_card(
+            card,
+            wavelength_range,
+            material_name=name,
         )
-        if need_disp:
-            materials[name] = _resolved_to_material_data(
-                resolved, wavelength_um, dispersive_model=dispersive_model
-            )
-        else:
-            materials[name] = _resolved_to_material_data(resolved, wavelength_um)
-
+        warn_if_material_may_be_unstable(name, material_data, resolution)
+        materials[name] = material_data
     return materials
 
 
-def check_dispersion_needs(
-    used_material_names: set[str],
-    overrides: dict[str, MaterialProperties] | None = None,
-    wavelength_um: float = 1.55,
-    bandwidth_um: float = 0.1,
-    threshold: float = 0.005,
-    overlay: dict[str, MaterialProperties] | None = None,
-) -> dict[str, bool]:
-    """Check which materials need dispersion for the given bandwidth.
-
-    Args:
-        used_material_names: Material names that appear in extracted geometry
-        overrides: User-supplied material property overrides
-        wavelength_um: Center wavelength in um
-        bandwidth_um: Source bandwidth in um
-        threshold: Fractional index variation threshold (default 0.5%)
-        overlay: PDK overlay dict (foundry-specific values)
-
-    Returns:
-        Dict mapping material name to whether dispersion is needed
-    """
-    overrides = overrides or {}
-    result: dict[str, bool] = {}
-
-    for name in sorted(used_material_names):
-        result[name] = should_enable_dispersion(
-            name, wavelength_um, bandwidth_um, threshold, overrides, overlay
-        )
-
-    return result
+__all__ = [
+    "loss_tangent_to_conductivity",
+    "resolve_fdtd_materials",
+    "resolve_materials",
+]

--- a/src/gsim/meep/mode_solver.py
+++ b/src/gsim/meep/mode_solver.py
@@ -50,17 +50,29 @@ _MAX_MATERIAL_CACHE = 64
 def _resolve_materials_cached(
     used_materials: set[str],
     overrides: dict | None = None,
-    wavelength_um: float | None = None,
-    overlay: dict | None = None,
+    wavelength_um: float = 1.55,
 ) -> dict[str, MaterialData]:
     """:func:`resolve_materials` with a process-local LRU cache."""
+    from gsim.common.materials import get_project_material_cards
     from gsim.meep.materials import resolve_materials
 
-    key = (frozenset(used_materials), wavelength_um)
+    project_material_cards = get_project_material_cards()
+    card_signature = tuple(
+        sorted(
+            (name, card.model_dump_json())
+            for name, card in project_material_cards.items()
+        )
+    )
+    key = (frozenset(used_materials), wavelength_um, card_signature)
     cached = _MATERIAL_CACHE.get(key)
     if cached is not None:
         return cached
-    result = resolve_materials(used_materials, overrides, wavelength_um, overlay)
+    result = resolve_materials(
+        used_materials,
+        overrides,
+        wavelength_um,
+        project_material_cards,
+    )
     if len(_MATERIAL_CACHE) >= _MAX_MATERIAL_CACHE:
         _MATERIAL_CACHE.pop(next(iter(_MATERIAL_CACHE)))
     _MATERIAL_CACHE[key] = result

--- a/src/gsim/meep/models/__init__.py
+++ b/src/gsim/meep/models/__init__.py
@@ -24,6 +24,7 @@ from gsim.meep.models.config import (
     SimConfig,
     SourceConfig,
     StoppingConfig,
+    SusceptibilityConfig,
     SymmetryEntry,
     WavelengthConfig,
 )
@@ -56,6 +57,7 @@ __all__ = [
     "SimConfig",
     "SourceConfig",
     "StoppingConfig",
+    "SusceptibilityConfig",
     "Symmetry",
     "SymmetryEntry",
     "WavelengthConfig",

--- a/src/gsim/meep/models/api.py
+++ b/src/gsim/meep/models/api.py
@@ -591,23 +591,6 @@ class FDTD(BaseModel):
             object.__setattr__(self, name, getattr(validated, name))
         return self
 
-    # Dispersion control
-    dispersion: Literal["auto", "true", "false"] = Field(
-        default="auto",
-        description=(
-            "Dispersion mode: 'auto' evaluates deps/eps across the source "
-            "bandwidth and enables dispersion per material when >0.5%; 'true' "
-            "forces full dispersion for all materials; 'false' forces "
-            "constant-epsilon for speed."
-        ),
-    )
-    dispersion_threshold: float = Field(
-        default=0.005,
-        gt=0,
-        lt=1,
-        description="deps/eps threshold for auto-dispersion (default 0.5%).",
-    )
-
     # Diagnostics — output control for plots, fields, animations
     save_geometry: bool = Field(default=True)
     save_fields: bool = Field(default=True)

--- a/src/gsim/meep/models/config.py
+++ b/src/gsim/meep/models/config.py
@@ -338,14 +338,15 @@ class LayerStackEntry(BaseModel):
     sidewall_angle: float = Field(default=0.0, description="Sidewall angle in degrees")
 
 
-class LorentzianPoleConfig(BaseModel):
-    """One Lorentzian susceptibility pole for the config JSON."""
+class SusceptibilityConfig(BaseModel):
+    """One MEEP electric susceptibility for the config JSON."""
 
-    model_config = ConfigDict(validate_assignment=True)
+    model_config = ConfigDict(validate_assignment=True, allow_inf_nan=False)
 
+    kind: Literal["lorentzian", "drude"] = "lorentzian"
     frequency: float = Field(gt=0, description="Resonance frequency (1/um)")
     gamma: float = Field(ge=0, description="Damping rate (1/um)")
-    sigma: float = Field(gt=0, description="Oscillator strength")
+    sigma: float = Field(description="Oscillator strength")
     sigma_diagonal: list[float] | None = Field(
         default=None, description="Anisotropic strength [sx, sy, sz]"
     )
@@ -376,8 +377,8 @@ class MaterialData(BaseModel):
     D_conductivity_diag: list[float] | None = Field(
         default=None, description="Anisotropic conductivity diagonal"
     )
-    epsilon_susceptibilities: list[LorentzianPoleConfig] | None = Field(
-        default=None, description="Lorentzian susceptibility poles for dispersion"
+    epsilon_susceptibilities: list[SusceptibilityConfig] | None = Field(
+        default=None, description="Lorentzian or Drude susceptibility terms"
     )
     valid_freq_range: list[float] | None = Field(
         default=None, description="Validity range [f_min, f_max] in 1/um"

--- a/src/gsim/meep/script.py
+++ b/src/gsim/meep/script.py
@@ -59,14 +59,51 @@ def build_materials(config):
     """Build MEEP material objects from config."""
     materials = {}
     for name, props in config["materials"].items():
-        eps_diag = props.get("epsilon_diag")
-        if eps_diag is not None:
-            if len(set(eps_diag)) == 1:
-                materials[name] = mp.Medium(epsilon=eps_diag[0])
+        medium_args = {}
+        for config_name, meep_name in (
+            ("epsilon_diag", "epsilon_diag"),
+            ("epsilon_offdiag", "epsilon_offdiag"),
+            ("mu_diag", "mu_diag"),
+            ("D_conductivity_diag", "D_conductivity_diag"),
+        ):
+            values = props.get(config_name)
+            if values is not None:
+                medium_args[meep_name] = mp.Vector3(*values)
+
+        conductivity = props.get("D_conductivity")
+        if conductivity is not None:
+            medium_args["D_conductivity"] = conductivity
+
+        susceptibilities = []
+        for term in props.get("epsilon_susceptibilities") or []:
+            susceptibility_args = {
+                "frequency": term["frequency"],
+                "gamma": term["gamma"],
+            }
+            sigma_diagonal = term.get("sigma_diagonal")
+            if sigma_diagonal is None:
+                susceptibility_args["sigma"] = term["sigma"]
             else:
-                materials[name] = mp.Medium(epsilon_diag=eps_diag)
-        else:
-            materials[name] = mp.Medium(epsilon=1.0)
+                susceptibility_args["sigma_diag"] = mp.Vector3(*sigma_diagonal)
+            susceptibility_type = (
+                mp.DrudeSusceptibility
+                if term.get("kind", "lorentzian") == "drude"
+                else mp.LorentzianSusceptibility
+            )
+            susceptibilities.append(susceptibility_type(**susceptibility_args))
+        if susceptibilities:
+            medium_args["E_susceptibilities"] = susceptibilities
+
+        valid_frequency_range = props.get("valid_freq_range")
+        if valid_frequency_range is not None:
+            medium_args["valid_freq_range"] = mp.FreqRange(
+                min=valid_frequency_range[0],
+                max=valid_frequency_range[1],
+            )
+
+        if not medium_args:
+            medium_args["epsilon"] = 1.0
+        materials[name] = mp.Medium(**medium_args)
     return materials
 
 

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -332,26 +332,9 @@ class Simulation(BaseModel):
     _config_dir: Path | None = PrivateAttr(default=None)
     _input_hash: str | None = PrivateAttr(default=None)
 
-    # PDK overlay (foundry-specific material values, loaded from YAML)
-    _pdk_overlay: dict[str, Any] | None = PrivateAttr(default=None)
-
     # -------------------------------------------------------------------------
     # Validators
     # -------------------------------------------------------------------------
-
-    def load_pdk_overlay(self, path: str | Path) -> None:
-        """Load a PDK overlay YAML file for foundry-specific material values.
-
-        PDK overlays augment the built-in MATERIALS_DB with foundry measurements.
-        They take priority over the built-in DB but lower priority than
-        user overrides set via ``sim.materials``.
-
-        Args:
-            path: Path to a YAML overlay file (see :func:`load_overlay` for format).
-        """
-        from gsim.common.stack.overlays import load_overlay
-
-        self._pdk_overlay = load_overlay(path)
 
     @field_validator("materials", mode="before")
     @classmethod
@@ -409,8 +392,9 @@ class Simulation(BaseModel):
                 "fiber source requires solver.mode='2d' (with y_cut set for "
                 "the XZ plane) — currently mode='3d'"
             )
-        self.fiber_source = FiberSource(**kwargs)
-        return self.fiber_source
+        fiber_source = FiberSource(**kwargs)
+        self.fiber_source = fiber_source
+        return fiber_source
 
     # -------------------------------------------------------------------------
     # Validation
@@ -989,10 +973,22 @@ class Simulation(BaseModel):
         if stack is None:
             raise ValueError("Stack resolution failed.")
 
-        # Collect material names from stack layers and dielectrics.
+        # Collect only populated physical layers. PDK stacks commonly include
+        # metal levels that are absent from a passive photonic component.
         used_materials: set[str] = set()
-        for layer in stack.layers.values():
-            used_materials.add(layer.material)
+        component = self.geometry.component
+        if component is not None:
+            from gsim.meep.physical_layers import materialize_physical_layers
+
+            physical_export = materialize_physical_layers(component, stack)
+            populated_layers = {
+                tuple(layer) for layer in physical_export.component.layers
+            }
+            for layer in physical_export.stack.layers.values():
+                if tuple(layer.gds_layer) in populated_layers:
+                    used_materials.add(layer.material)
+        else:
+            used_materials.update(layer.material for layer in stack.layers.values())
         for diel in stack.dielectrics:
             used_materials.add(diel["material"])
 
@@ -1000,7 +996,6 @@ class Simulation(BaseModel):
             used_materials,
             overrides=self._material_overrides(),
             wavelength_um=wavelength,
-            overlay=self._pdk_overlay,
         )
 
         return stack, material_data
@@ -1278,7 +1273,6 @@ class Simulation(BaseModel):
         """
         import math
 
-        from gsim.meep.materials import resolve_materials
         from gsim.meep.models.config import (
             FiberSourceConfig,
             LayerStackEntry,
@@ -1415,6 +1409,7 @@ class Simulation(BaseModel):
         # Build layer stack entries
         layer_stack_entries = []
         used_materials: set[str] = set()
+        populated_layers = {tuple(layer) for layer in component.layers}
         for layer_name, layer in stack.layers.items():
             layer_stack_entries.append(
                 LayerStackEntry(
@@ -1426,7 +1421,8 @@ class Simulation(BaseModel):
                     sidewall_angle=layer.sidewall_angle,
                 )
             )
-            used_materials.add(layer.material)
+            if tuple(layer.gds_layer) in populated_layers:
+                used_materials.add(layer.material)
 
         # Build dielectric entries
         dielectric_entries = []
@@ -1489,29 +1485,20 @@ class Simulation(BaseModel):
                 "or call sim.source_fiber(...)."
             )
 
-        # Resolve materials (three-tier: user override > PDK overlay > built-in DB)
+        # Resolve materials. Explicit per-simulation constants take priority;
+        # otherwise project-first MaterialCards are authoritative.
         active_source = (
             self.fiber_source if self.fiber_source is not None else self.source
         )
-        if self.solver.dispersion != "false":
-            from gsim.meep.materials import resolve_materials_with_dispersion
+        from gsim.meep.materials import resolve_fdtd_materials
 
-            material_data = resolve_materials_with_dispersion(
-                used_materials,
-                overrides=self._material_overrides(),
-                wavelength_um=active_source.wavelength,
-                bandwidth_um=active_source.wavelength_span,
-                dispersion=self.solver.dispersion,
-                overlay=self._pdk_overlay,
-                threshold=self.solver.dispersion_threshold,
-            )
-        else:
-            material_data = resolve_materials(
-                used_materials,
-                overrides=self._material_overrides(),
-                wavelength_um=active_source.wavelength,
-                overlay=self._pdk_overlay,
-            )
+        material_data = resolve_fdtd_materials(
+            used_materials,
+            overrides=self._material_overrides(),
+            wavelength_um=active_source.wavelength,
+            wavelength_span_um=active_source.wavelength_span,
+            resolution=resolution_cfg.pixels_per_um,
+        )
 
         fwidth = source_cfg.compute_fwidth(wl_cfg.fcen, wl_cfg.df)
         source_for_config = source_cfg.model_copy(update={"fwidth": fwidth})
@@ -2054,7 +2041,6 @@ class Simulation(BaseModel):
             used_materials,
             overrides=self._material_overrides(),
             wavelength_um=result.config.wavelength.wavelength,
-            overlay=self._pdk_overlay,
         )
         kwargs["wavelength"] = result.config.wavelength.wavelength
         kwargs["is_3d"] = result.config.is_3d

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -987,7 +987,9 @@ class Simulation(BaseModel):
             for layer in physical_export.stack.layers.values():
                 if tuple(layer.gds_layer) in populated_layers:
                     used_materials.add(layer.material)
-        else:
+        elif not stack.dielectrics:
+            # Slab-mode configs serialize declared dielectrics when available;
+            # only stacks without them fall back to every physical layer.
             used_materials.update(layer.material for layer in stack.layers.values())
         for diel in stack.dielectrics:
             used_materials.add(diel["material"])

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -2034,9 +2034,10 @@ class Simulation(BaseModel):
         """Add center-wavelength material and simulation context to a plot."""
         from gsim.meep.materials import resolve_materials
 
-        used_materials = {entry.material for entry in result.config.layer_stack} | {
-            dielectric["material"] for dielectric in result.config.dielectrics
-        }
+        # ``layer_stack`` contains every layer declared by the PDK, including
+        # unpopulated metal layers.  The built material map is already limited
+        # to materials that occur in the simulation geometry.
+        used_materials = set(result.config.materials)
         kwargs["material_data"] = resolve_materials(
             used_materials,
             overrides=self._material_overrides(),

--- a/tests/common/materials/test_snapshots.py
+++ b/tests/common/materials/test_snapshots.py
@@ -5,6 +5,7 @@ from pdk_schema import MaterialCard
 
 from gsim.common.materials import (
     GSIM_MATERIAL_CARDS,
+    SIO2_MALITSON_2POLE,
     MaterialModelError,
     MaterialNotFoundError,
     WavelengthOutOfRangeError,
@@ -18,7 +19,9 @@ from gsim.common.materials import (
         ("Si-Salzberg", 3.477723756),
         ("Si-Li-293K", 3.4757),
         ("SiN-Luke", 1.996279731714),
+        ("SiO2-Arosa", 1.443988881535),
         ("SiO2-Malitson", 1.444023622),
+        ("SiO2-Malitson-2Pole", 1.444023534167),
     ],
 )
 def test_material_snapshots_at_telecom_wavelength(
@@ -54,7 +57,28 @@ def test_project_card_overrides_fallback_and_missing_card_uses_fallback() -> Non
     assert silicon.source == "project"
     assert silicon.refractive_index == pytest.approx(3.4757)
     assert silica.source == "gsim"
-    assert silica.refractive_index == pytest.approx(1.444023622)
+    assert silica.refractive_index == pytest.approx(1.444023534167)
+
+
+def test_default_sio2_card_uses_two_pole_malitson() -> None:
+    assert GSIM_MATERIAL_CARDS["SiO2"].optical == SIO2_MALITSON_2POLE.optical
+
+
+def test_two_pole_malitson_matches_reference_over_fit_band() -> None:
+    wavelengths_um = [0.4 * 5 ** (index / 800) for index in range(801)]
+    index_errors = [
+        abs(
+            resolve_material_snapshot(
+                "SiO2-Malitson-2Pole", wavelength_um, {}
+            ).refractive_index
+            - resolve_material_snapshot(
+                "SiO2-Malitson", wavelength_um, {}
+            ).refractive_index
+        )
+        for wavelength_um in wavelengths_um
+    ]
+
+    assert max(index_errors) == pytest.approx(5.418048441008239e-7)
 
 
 def test_invalid_project_card_does_not_silently_fallback() -> None:

--- a/tests/fdtd/test_material_config.py
+++ b/tests/fdtd/test_material_config.py
@@ -45,7 +45,7 @@ def test_scalar_index_card_stays_nondispersive() -> None:
 
 
 def test_sellmeier_card_maps_to_fdtd_coefficients() -> None:
-    snapshot = resolve_material_snapshot("SiO2", 1.55, {})
+    snapshot = resolve_material_snapshot("SiO2-Malitson", 1.55, {})
 
     config = material_config_from_snapshot(snapshot, (1500.0, 1600.0))
 

--- a/tests/fdtd/test_simulation.py
+++ b/tests/fdtd/test_simulation.py
@@ -82,8 +82,9 @@ def test_write_uses_project_material_then_fallback_and_valid_mesh(
     assert set(silicon_table["k"]) == {0.0}
     silica = document["materials"]["SiO2"]["dispersion"]
     assert silica["wavelength_range_nm"] == [1500.0, 1600.0]
-    assert silica["sellmeier"]["b"] == [0.6961663, 0.4079426, 0.8974794]
-    assert document["background_refractive_index"] == pytest.approx(1.4440236217)
+    assert silica["drude_lorentz"]["eps_inf"] == pytest.approx(1.2648942847)
+    assert len(silica["drude_lorentz"]["lorentz"]) == 2
+    assert document["background_refractive_index"] == pytest.approx(1.4440235342)
     assert document["geometry"]["ports"]["o1"]["normal"] == [-1, 0, 0]
     assert document["geometry"]["ports"]["o2"]["normal"] == [1, 0, 0]
 

--- a/tests/meep/test_material_cards.py
+++ b/tests/meep/test_material_cards.py
@@ -1,0 +1,216 @@
+"""Tests for MaterialCard compatibility validation and MEEP conversion."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pdk_schema import (
+    Cauchy,
+    CauchyTerm,
+    Debye,
+    DebyeTerm,
+    Drude,
+    DrudeTerm,
+    Index,
+    Lorentz,
+    LorentzTerm,
+    Permittivity,
+    Pole,
+    PoleResidue,
+    ScalarValue,
+    SellmeierPoleSquared,
+    SellmeierSquaredTerm,
+)
+from scipy.constants import c as C0  # noqa: N812
+
+from gsim.common.materials import SI_LI_293K, SI_SALZBERG, SIO2_MALITSON
+from gsim.common.materials._helpers import material_card
+from gsim.meep.material_cards import (
+    MeepMaterialCompatibilityError,
+    material_data_from_card,
+    validate_meep_material_card,
+)
+
+
+def _index_card(name: str = "constant", *, k: float | None = None):
+    """Return a scalar index-authored card for tests."""
+    return material_card(
+        name=name,
+        temperature_ref=None,
+        permittivity=Index(
+            validity=None,
+            variation=None,
+            conductivity=None,
+            n=ScalarValue(unit="", value=2.0),
+            k=None if k is None else ScalarValue(unit="", value=k),
+        ),
+    )
+
+
+def test_builtin_si_and_sio2_cards_are_meep_compatible() -> None:
+    validate_meep_material_card(SI_SALZBERG, (1.5, 1.6))
+    validate_meep_material_card(SIO2_MALITSON, (1.5, 1.6))
+
+
+def test_scalar_index_card_becomes_nondispersive_epsilon() -> None:
+    material = material_data_from_card(_index_card())
+
+    assert material.epsilon_diag == [4.0, 4.0, 4.0]
+    assert material.epsilon_susceptibilities is None
+
+
+def test_scalar_permittivity_card_stays_nondispersive() -> None:
+    card = material_card(
+        name="dielectric",
+        temperature_ref=None,
+        permittivity=Permittivity(
+            validity=None,
+            variation=None,
+            conductivity=None,
+            eps_real=ScalarValue(unit="", value=4.0),
+            eps_imag=None,
+        ),
+    )
+
+    material = material_data_from_card(card)
+
+    assert material.epsilon_diag == [4.0, 4.0, 4.0]
+
+
+def test_sellmeier_maps_exactly_to_lorentz_terms() -> None:
+    material = material_data_from_card(SIO2_MALITSON, (1.5, 1.6))
+
+    terms = material.epsilon_susceptibilities or []
+    assert material.epsilon_diag == [1.0, 1.0, 1.0]
+    assert [term.frequency for term in terms] == pytest.approx(
+        [1 / 0.0684043, 1 / 0.1162414, 1 / 9.896161]
+    )
+    assert [term.sigma for term in terms] == pytest.approx(
+        [0.6961663, 0.4079426, 0.8974794]
+    )
+    assert {term.gamma for term in terms} == {0.0}
+
+
+def test_squared_sellmeier_poles_are_not_squared_twice() -> None:
+    card = material_card(
+        name="squared",
+        temperature_ref=None,
+        permittivity=SellmeierPoleSquared(
+            validity=None,
+            variation=None,
+            conductivity=None,
+            terms=(SellmeierSquaredTerm(b=0.5, c_um2=0.04),),
+            offset=0.25,
+        ),
+    )
+
+    material = material_data_from_card(card)
+
+    assert material.epsilon_diag == [1.25, 1.25, 1.25]
+    term = (material.epsilon_susceptibilities or [])[0]
+    assert term.frequency == pytest.approx(5.0)
+    assert term.sigma == 0.5
+
+
+def test_lorentz_and_drude_terms_convert_si_frequencies() -> None:
+    lorentz_card = material_card(
+        name="lorentz",
+        temperature_ref=None,
+        permittivity=Lorentz(
+            validity=None,
+            variation=None,
+            eps_inf=2.0,
+            terms=(LorentzTerm(delta_eps=1.2, omega_0=2e15, gamma=1e13),),
+        ),
+    )
+    drude_card = material_card(
+        name="drude",
+        temperature_ref=None,
+        permittivity=Drude(
+            validity=None,
+            variation=None,
+            eps_inf=3.0,
+            terms=(DrudeTerm(omega_p=3e15, gamma=2e13),),
+        ),
+    )
+
+    lorentz = material_data_from_card(lorentz_card)
+    drude = material_data_from_card(drude_card)
+
+    conversion = 1e-6 / (2 * math.pi * C0)
+    lorentz_term = (lorentz.epsilon_susceptibilities or [])[0]
+    drude_term = (drude.epsilon_susceptibilities or [])[0]
+    assert lorentz.epsilon_diag == [2.0, 2.0, 2.0]
+    assert lorentz_term.kind == "lorentzian"
+    assert lorentz_term.frequency == pytest.approx(2e15 * conversion)
+    assert lorentz_term.gamma == pytest.approx(1e13 * conversion)
+    assert lorentz_term.sigma == 1.2
+    assert drude.epsilon_diag == [3.0, 3.0, 3.0]
+    assert drude_term.kind == "drude"
+    assert drude_term.frequency == pytest.approx(3e15 * conversion)
+    assert drude_term.gamma == pytest.approx(2e13 * conversion)
+    assert drude_term.sigma == 1.0
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        Cauchy(
+            validity=None,
+            variation=None,
+            conductivity=None,
+            a=1.5,
+            terms=(CauchyTerm(b=0.01, power=-2),),
+        ),
+        Debye(
+            validity=None,
+            variation=None,
+            eps_inf=2.0,
+            terms=(DebyeTerm(delta_eps=1.0, tau=1e-12),),
+        ),
+        PoleResidue(
+            validity=None,
+            variation=None,
+            eps_inf=2.0,
+            poles=(Pole(a=(1.0, 2.0), c=(3.0, 4.0)),),
+        ),
+    ],
+)
+def test_non_native_closed_form_models_are_rejected(model) -> None:
+    card = material_card(name="unsupported", temperature_ref=None, permittivity=model)
+
+    with pytest.raises(MeepMaterialCompatibilityError, match="unsupported optical"):
+        validate_meep_material_card(card)
+
+
+def test_tabulated_index_requires_causal_fit() -> None:
+    with pytest.raises(MeepMaterialCompatibilityError, match="causal Lorentz/Drude"):
+        validate_meep_material_card(SI_LI_293K, (1.5, 1.6))
+
+
+def test_constant_extinction_requires_causal_fit() -> None:
+    with pytest.raises(MeepMaterialCompatibilityError, match="extinction coefficient"):
+        validate_meep_material_card(_index_card(k=0.01))
+
+
+def test_model_conductivity_is_rejected_explicitly() -> None:
+    card = material_card(
+        name="conductive",
+        temperature_ref=None,
+        permittivity=Index(
+            validity=None,
+            variation=None,
+            conductivity=ScalarValue(unit="S/m", value=1.0),
+            n=ScalarValue(unit="", value=2.0),
+            k=None,
+        ),
+    )
+
+    with pytest.raises(MeepMaterialCompatibilityError, match="model conductivity"):
+        validate_meep_material_card(card)
+
+
+def test_source_band_must_fit_material_validity() -> None:
+    with pytest.raises(MeepMaterialCompatibilityError, match="simulation band"):
+        validate_meep_material_card(SI_SALZBERG, (1.2, 1.3))

--- a/tests/meep/test_material_cards.py
+++ b/tests/meep/test_material_cards.py
@@ -24,7 +24,13 @@ from pdk_schema import (
 )
 from scipy.constants import c as C0  # noqa: N812
 
-from gsim.common.materials import SI_LI_293K, SI_SALZBERG, SIO2_MALITSON
+from gsim.common.materials import (
+    SI_LI_293K,
+    SI_SALZBERG,
+    SIO2_AROSA,
+    SIO2_MALITSON,
+    SIO2_MALITSON_2POLE,
+)
 from gsim.common.materials._helpers import material_card
 from gsim.meep.material_cards import (
     MeepMaterialCompatibilityError,
@@ -51,6 +57,8 @@ def _index_card(name: str = "constant", *, k: float | None = None):
 def test_builtin_si_and_sio2_cards_are_meep_compatible() -> None:
     validate_meep_material_card(SI_SALZBERG, (1.5, 1.6))
     validate_meep_material_card(SIO2_MALITSON, (1.5, 1.6))
+    validate_meep_material_card(SIO2_MALITSON_2POLE, (1.5, 1.6))
+    validate_meep_material_card(SIO2_AROSA, (1.5, 1.6))
 
 
 def test_scalar_index_card_becomes_nondispersive_epsilon() -> None:
@@ -90,6 +98,14 @@ def test_sellmeier_maps_exactly_to_lorentz_terms() -> None:
         [0.6961663, 0.4079426, 0.8974794]
     )
     assert {term.gamma for term in terms} == {0.0}
+
+
+def test_reduced_malitson_maps_to_two_lorentz_terms() -> None:
+    material = material_data_from_card(SIO2_MALITSON_2POLE, (1.5, 1.6))
+
+    assert material.epsilon_diag == pytest.approx([1.2648942846816222] * 3)
+    assert material.epsilon_susceptibilities is not None
+    assert len(material.epsilon_susceptibilities) == 2
 
 
 def test_squared_sellmeier_poles_are_not_squared_twice() -> None:

--- a/tests/meep/test_material_resolution.py
+++ b/tests/meep/test_material_resolution.py
@@ -1,528 +1,148 @@
-"""Tests for MEEP material resolution with anisotropic tensors and dispersion."""
+"""Tests for project-first MEEP material resolution."""
 
 from __future__ import annotations
 
 import math
 
 import pytest
+from scipy.constants import c as C0  # noqa: N812
 
-from gsim.common.stack.materials import (
-    DispersionModel,
-    LorentzianTerm,
-    MaterialProperties,
-    ResolvedMaterial,
-    SellmeierTerm,
-    ValidityRange,
-)
+from gsim.common.materials import MaterialNotFoundError
+from gsim.common.stack.materials import MaterialProperties, ResolvedMaterial
+from gsim.meep.material_cards import MeepMaterialCompatibilityError
 from gsim.meep.materials import (
-    _find_dispersion_model,
     _is_identity_axes,
     _resolved_to_material_data,
     _rotate_diagonal_tensor,
-    _validity_to_freq_range,
-    dispersion_model_to_meep_poles,
-    lorentzian_to_meep_poles,
     loss_tangent_to_conductivity,
+    resolve_fdtd_materials,
     resolve_materials,
-    resolve_materials_with_dispersion,
-    sellmeier_to_lorentzian_poles,
 )
 
 
-class TestLossTangentToConductivity:
-    def test_zero_loss_tangent(self):
-        assert loss_tangent_to_conductivity(0.0, 4.1, 5e9) == 0.0
-
-    def test_conversion_at_5ghz(self):
-        sigma = loss_tangent_to_conductivity(0.001, 4.1, 5e9)
-        expected = 2.0 * math.pi * 5e9 * 8.854187817e-12 * 4.1 * 0.001
-        assert sigma == pytest.approx(expected, rel=1e-6)
-
-    def test_conversion_at_10ghz(self):
-        sigma = loss_tangent_to_conductivity(0.01, 9.3, 10e9)
-        expected = 2.0 * math.pi * 10e9 * 8.854187817e-12 * 9.3 * 0.01
-        assert sigma == pytest.approx(expected, rel=1e-6)
-
-    def test_higher_frequency_higher_conductivity(self):
-        s1 = loss_tangent_to_conductivity(0.01, 4.0, 1e9)
-        s2 = loss_tangent_to_conductivity(0.01, 4.0, 10e9)
-        assert s2 > s1
-
-
-class TestIsIdentityAxes:
-    def test_none_is_identity(self):
-        assert _is_identity_axes(None) is True
-
-    def test_identity_matrix(self):
-        identity = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
-        assert _is_identity_axes(identity) is True
-
-    def test_rotated_is_not_identity(self):
-        rotated = [[0.8, 0.6, 0.0], [-0.6, 0.8, 0.0], [0.0, 0.0, 1.0]]
-        assert _is_identity_axes(rotated) is False
-
-
-class TestRotateDiagonalTensor:
-    def test_identity_rotation_preserves_zero_offdiag(self):
-        identity = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
-        offdiag = _rotate_diagonal_tensor([9.3, 9.3, 11.5], identity)
-        for v in offdiag:
-            assert abs(v) < 1e-10
-
-    def test_90_degree_rotation(self):
-        axes = [[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
-        offdiag = _rotate_diagonal_tensor([1.0, 2.0, 3.0], axes)
-        for v in offdiag:
-            assert abs(v) < 1e-10
-
-    def test_sapphire_rotation_produces_offdiag(self):
-        axes = [[0.8, 0.6, 0.0], [-0.6, 0.8, 0.0], [0.0, 0.0, 1.0]]
-        offdiag = _rotate_diagonal_tensor([9.3, 9.3, 11.5], axes)
-        assert abs(offdiag[0]) < 1e-10
-        assert abs(offdiag[2]) < 1e-10
-
-
-class TestResolvedToMaterialData:
-    def test_scalar_material(self):
-        resolved = ResolvedMaterial(permittivity=3.47**2)
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.epsilon_diag == pytest.approx([3.47**2] * 3)
-
-    def test_anisotropic_permittivity(self):
-        resolved = ResolvedMaterial(permittivity=[9.3, 9.3, 11.5])
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.epsilon_diag == pytest.approx([9.3, 9.3, 11.5])
-
-    def test_permeability(self):
-        resolved = ResolvedMaterial(
-            permittivity=1.77**2, permeability=[0.99999975, 0.99999975, 0.99999979]
-        )
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.mu_diag is not None
-        assert len(data.mu_diag) == 3
-
-    def test_loss_tangent_to_conductivity_conversion(self):
-        resolved = ResolvedMaterial(permittivity=1.77**2, loss_tangent=3e-5)
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.D_conductivity is not None
-        assert data.D_conductivity > 0
-
-    def test_conductivity_direct(self):
-        resolved = ResolvedMaterial(permittivity=1.0, conductivity=1e5)
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.D_conductivity == 1e5
-
-    def test_tensor_conductivity(self):
-        resolved = ResolvedMaterial(permittivity=1.0, conductivity=[1e4, 1e4, 1e5])
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.D_conductivity_diag == pytest.approx([1e4, 1e4, 1e5])
-
-    def test_anisotropic_loss_tangent(self):
-        resolved = ResolvedMaterial(
-            permittivity=[9.3, 9.3, 11.5], loss_tangent=[3e-5, 3e-5, 8.6e-5]
-        )
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.D_conductivity_diag is not None
-        assert len(data.D_conductivity_diag) == 3
-        assert data.D_conductivity_diag[0] > 0
-        assert data.D_conductivity_diag[2] > data.D_conductivity_diag[0]
-
-    def test_material_axes_rotation(self):
-        resolved = ResolvedMaterial(
-            permittivity=[9.3, 9.3, 11.5],
-            material_axes=[[0.8, 0.6, 0.0], [-0.6, 0.8, 0.0], [0.0, 0.0, 1.0]],
-        )
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.epsilon_offdiag is not None
-
-    def test_identity_axes_no_offdiag(self):
-        resolved = ResolvedMaterial(
-            permittivity=[9.3, 9.3, 11.5],
-            material_axes=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
-        )
-        data = _resolved_to_material_data(resolved, 1.55)
-        assert data.epsilon_offdiag is None
-
-    def test_no_permittivity_raises(self):
-        resolved = ResolvedMaterial()
-        with pytest.raises(ValueError, match="no permittivity"):
-            _resolved_to_material_data(resolved, 1.55)
-
-
-class TestResolveMaterialsWithTensors:
-    def test_sapphire_resolves_with_tensors(self):
-        materials = resolve_materials({"sapphire"}, wavelength_um=1.55)
-        assert "sapphire" in materials
-        sapph = materials["sapphire"]
-        assert sapph.epsilon_diag is not None
-        assert sapph.mu_diag is not None
-
-    def test_conductor_skipped(self):
-        materials = resolve_materials({"aluminum"}, wavelength_um=1.55)
-        assert "aluminum" not in materials
-
-    def test_isotropic_material_no_tensors(self):
-        materials = resolve_materials({"SiO2"}, wavelength_um=1.55)
-        assert "SiO2" in materials
-        sio2 = materials["SiO2"]
-        assert sio2.epsilon_diag is not None
-
-
-class TestSellmeierToLorentzian:
-    def test_sio2_sellmeier_produces_poles(self):
-        model = DispersionModel(
-            type="sellmeier",
-            sellmeier_terms=[
-                SellmeierTerm(B=0.696, C=0.0684**2),
-                SellmeierTerm(B=0.408, C=0.1162**2),
-                SellmeierTerm(B=0.897, C=9.896**2),
-            ],
-            validity=ValidityRange(valid_wavelength=(0.21, 3.71)),
-        )
-        poles = sellmeier_to_lorentzian_poles(model)
-        assert len(poles) == 3
-        for pole in poles:
-            assert pole.gamma == 0.0
-            assert pole.frequency > 0
-            assert pole.sigma > 0
-
-    def test_sellmeier_pole_frequencies(self):
-        model = DispersionModel(
-            type="sellmeier",
-            sellmeier_terms=[
-                SellmeierTerm(B=0.696, C=0.0684**2),
-            ],
-        )
-        poles = sellmeier_to_lorentzian_poles(model)
-        assert len(poles) == 1
-        expected_w0 = 1.0 / math.sqrt(0.0684**2)
-        assert poles[0].frequency == pytest.approx(expected_w0, rel=1e-6)
-
-    def test_sellmeier_sigma(self):
-        model = DispersionModel(
-            type="sellmeier",
-            sellmeier_terms=[
-                SellmeierTerm(B=0.696, C=0.0684**2),
-            ],
-        )
-        poles = sellmeier_to_lorentzian_poles(model)
-        w0 = 1.0 / math.sqrt(0.0684**2)
-        expected_sigma = 0.696 * w0**2
-        assert poles[0].sigma == pytest.approx(expected_sigma, rel=1e-6)
-
-    def test_sellmeier_anisotropic_sigma(self):
-        model = DispersionModel(
-            type="sellmeier",
-            sellmeier_terms=[
-                SellmeierTerm(B=0.696, C=0.0684**2, sigma_diagonal=[1.0, 1.0, 2.0]),
-            ],
-        )
-        poles = sellmeier_to_lorentzian_poles(model)
-        assert poles[0].sigma_diagonal == [1.0, 1.0, 2.0]
-
-    def test_constant_model_no_poles(self):
-        model = DispersionModel(type="constant", permittivity=4.1)
-        poles = dispersion_model_to_meep_poles(model)
-        assert poles == []
-
-    def test_lorentzian_direct_mapping(self):
-        model = DispersionModel(
-            type="lorentzian",
-            lorentzian_terms=[
-                LorentzianTerm(frequency=0.5, gamma=0.01, sigma=1.0),
-            ],
-            epsilon_inf=1.5,
-        )
-        poles = lorentzian_to_meep_poles(model)
-        assert len(poles) == 1
-        assert poles[0].frequency == 0.5
-        assert poles[0].gamma == 0.01
-        assert poles[0].sigma == 1.0
-
-    def test_zero_c_skipped(self):
-        model = DispersionModel(
-            type="sellmeier",
-            sellmeier_terms=[
-                SellmeierTerm(B=0.5, C=0.0),
-            ],
-        )
-        poles = sellmeier_to_lorentzian_poles(model)
-        assert poles == []
-
-
-class TestValidityToFreqRange:
-    def test_wavelength_validity(self):
-        model = DispersionModel(
-            type="sellmeier",
-            sellmeier_terms=[SellmeierTerm(B=1.0, C=0.1)],
-            validity=ValidityRange(valid_wavelength=(0.5, 2.0)),
-        )
-        freq_range = _validity_to_freq_range(model)
-        assert freq_range is not None
-        assert len(freq_range) == 2
-        assert freq_range[0] == pytest.approx(1.0 / 2.0)
-        assert freq_range[1] == pytest.approx(1.0 / 0.5)
-
-    def test_unspecified_validity(self):
-        model = DispersionModel(
-            type="constant", permittivity=4.1, validity=ValidityRange()
-        )
-        freq_range = _validity_to_freq_range(model)
-        assert freq_range is None
-
-
-class TestFindDispersionModel:
-    def test_finds_covering_model(self):
-        props = MaterialProperties(
-            permittivity=4.1,
-            dispersion_models=[
-                DispersionModel(
-                    type="sellmeier",
-                    sellmeier_terms=[SellmeierTerm(B=1.0, C=0.1)],
-                    validity=ValidityRange(valid_wavelength=(0.5, 2.0)),
-                ),
-                DispersionModel(
-                    type="constant",
-                    permittivity=4.1,
-                    validity=ValidityRange(valid_frequency=(0, 10e9)),
-                ),
-            ],
-        )
-        model = _find_dispersion_model(props, 1.55)
-        assert model is not None
-        assert model.type == "sellmeier"
-
-    def test_falls_back_to_unspecified(self):
-        props = MaterialProperties(
-            permittivity=4.1,
-            dispersion_models=[
-                DispersionModel(
-                    type="constant",
-                    permittivity=4.1,
-                    validity=ValidityRange(),
-                    source="unspecified",
-                ),
-            ],
-        )
-        model = _find_dispersion_model(props, 1.55)
-        assert model is not None
-        assert model.source == "unspecified"
-
-    def test_no_model_at_wavelength(self):
-        props = MaterialProperties(
-            permittivity=4.1,
-            dispersion_models=[
-                DispersionModel(
-                    type="constant",
-                    permittivity=4.1,
-                    validity=ValidityRange(valid_frequency=(0, 10e9)),
-                ),
-            ],
-        )
-        model = _find_dispersion_model(props, 1.55)
-        assert model is None
-
-    def test_no_dispersion_models(self):
-        props = MaterialProperties(permittivity=4.1)
-        model = _find_dispersion_model(props, 1.55)
-        assert model is None
-
-
-class TestDispersiveMaterialData:
-    def test_dispersive_rendering_populates_susceptibilities(self):
-        model = DispersionModel(
-            type="sellmeier",
-            sellmeier_terms=[
-                SellmeierTerm(B=0.696, C=0.0684**2),
-                SellmeierTerm(B=0.408, C=0.1162**2),
-                SellmeierTerm(B=0.897, C=9.896**2),
-            ],
-            validity=ValidityRange(valid_wavelength=(0.21, 3.71)),
-            epsilon_inf=1.0,
-        )
-        resolved = ResolvedMaterial(permittivity=1.44**2)
-        data = _resolved_to_material_data(resolved, 1.55, dispersive_model=model)
-        assert data.epsilon_susceptibilities is not None
-        assert len(data.epsilon_susceptibilities) == 3
-        assert data.valid_freq_range is not None
-
-    def test_constant_model_no_susceptibilities(self):
-        model = DispersionModel(type="constant", permittivity=4.1)
-        resolved = ResolvedMaterial(permittivity=1.44**2)
-        data = _resolved_to_material_data(resolved, 1.55, dispersive_model=model)
-        assert data.epsilon_susceptibilities is None
-
-    def test_epsilon_inf_in_dispersive_mode(self):
-        model = DispersionModel(
-            type="sellmeier",
-            sellmeier_terms=[SellmeierTerm(B=1.0, C=0.1)],
-            epsilon_inf=2.0,
-        )
-        resolved = ResolvedMaterial(permittivity=2.25)
-        data = _resolved_to_material_data(resolved, 1.55, dispersive_model=model)
-        assert data.epsilon_diag == [2.0, 2.0, 2.0]
-
-
-class TestResolveMaterialsWithDispersion:
-    def test_auto_silicon_wide_bandwidth_gets_dispersion(self):
-        materials = resolve_materials_with_dispersion(
-            {"silicon"}, wavelength_um=1.55, bandwidth_um=0.5, dispersion="auto"
-        )
-        assert "silicon" in materials
-        si = materials["silicon"]
-        assert si.epsilon_susceptibilities is not None
-
-    def test_auto_sio2_narrow_bandwidth_no_dispersion(self):
-        materials = resolve_materials_with_dispersion(
-            {"SiO2"}, wavelength_um=1.55, bandwidth_um=0.1, dispersion="auto"
-        )
-        assert "SiO2" in materials
-        sio2 = materials["SiO2"]
-        assert sio2.epsilon_susceptibilities is None
-
-    def test_force_true_dispersion(self):
-        materials = resolve_materials_with_dispersion(
-            {"SiO2"}, wavelength_um=1.55, bandwidth_um=0.1, dispersion="true"
-        )
-        assert "SiO2" in materials
-        sio2 = materials["SiO2"]
-        assert sio2.epsilon_susceptibilities is not None
-
-    def test_force_false_no_dispersion(self):
-        materials = resolve_materials_with_dispersion(
-            {"silicon"}, wavelength_um=1.55, bandwidth_um=0.5, dispersion="false"
-        )
-        assert "silicon" in materials
-        si = materials["silicon"]
-        assert si.epsilon_susceptibilities is None
-
-    def test_conductor_skipped(self):
-        materials = resolve_materials_with_dispersion(
-            {"aluminum"}, wavelength_um=1.55, dispersion="true"
-        )
-        assert "aluminum" not in materials
-
-    def test_auto_germanium_gets_dispersion(self):
-        materials = resolve_materials_with_dispersion(
-            {"germanium"}, wavelength_um=3.0, bandwidth_um=1.0, dispersion="auto"
-        )
-        assert "germanium" in materials
-        ge = materials["germanium"]
-        assert ge.epsilon_susceptibilities is not None
-
-
-class TestResolveMaterialsCaseInsensitive:
-    """Override key matching must be case-insensitive (issue #163)."""
-
-    def test_override_with_different_case_matches(self):
-        """User set_material('sio2', ...) matches stack material 'SiO2'."""
-        overrides = {
-            "sio2": MaterialProperties(permittivity=3.9),
-        }
-        materials = resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
-        assert "SiO2" in materials
-        assert materials["SiO2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
-
-    def test_override_with_upper_case_matches_lower_stack(self):
-        """User set_material('SIO2', ...) matches stack material 'sio2'."""
-        overrides = {
-            "SIO2": MaterialProperties(permittivity=3.9),
-        }
-        materials = resolve_materials({"sio2"}, overrides=overrides, wavelength_um=1.55)
-        assert "sio2" in materials
-        assert materials["sio2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
-
-    def test_override_with_mixed_case_and_whitespace(self):
-        """Mixed case and whitespace in override keys normalize correctly."""
-        overrides = {
-            "  SiO2  ": MaterialProperties(permittivity=3.9),
-        }
-        materials = resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
-        assert "SiO2" in materials
-        assert materials["SiO2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
-
-    def test_override_without_wavelength_legacy(self):
-        """Case-insensitive override works in legacy (no wavelength) path."""
-        overrides = {
-            "sio2": MaterialProperties(permittivity=3.9),
-        }
-        materials = resolve_materials({"SiO2"}, overrides=overrides)
-        assert "SiO2" in materials
-        assert materials["SiO2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
-
-    def test_duplicate_override_keys_warn(self):
-        """Two overrides that normalize to same key emit a warning."""
-        overrides = {
-            "SiO2": MaterialProperties(permittivity=3.9),
-            "sio2": MaterialProperties(permittivity=4.0),
-        }
-        with pytest.warns(UserWarning, match="Duplicate material entries"):
-            resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
-
-    def test_unmatched_override_key_warns(self):
-        """Override key that matches no stack material emits a warning."""
-        overrides = {
-            "made_up_material": MaterialProperties(permittivity=5.0),
-        }
-        with pytest.warns(UserWarning, match="do not match any material"):
-            resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
-
-    def test_unmatched_override_does_not_break_resolution(self):
-        """Unmatched override key warns but does not prevent resolution of
-        other materials."""
-        overrides = {
-            "unknown_key": MaterialProperties(permittivity=5.0),
-        }
-        with pytest.warns(UserWarning, match="do not match any material"):
-            materials = resolve_materials(
-                {"SiO2"}, overrides=overrides, wavelength_um=1.55
-            )
-        assert "SiO2" in materials
-
-
-class TestResolveMaterialsWithDispersionCaseInsensitive:
-    """resolved_materials_with_dispersion override matching must be
-    case-insensitive."""
-
-    def test_override_case_insensitive(self):
-        overrides = {
-            "SIO2": MaterialProperties(
-                permittivity=3.9,
-                dispersion_models=[
-                    DispersionModel(type="constant", permittivity=3.9),
-                ],
-            ),
-        }
-        materials = resolve_materials_with_dispersion(
-            {"sio2"},
-            overrides=overrides,
+def test_loss_tangent_converts_to_meep_d_conductivity() -> None:
+    frequency_hz = C0 / 1.55e-6
+
+    conductivity = loss_tangent_to_conductivity(0.001, 4.1, frequency_hz)
+
+    expected = 2 * math.pi * (1 / 1.55) * 0.001
+    assert conductivity == pytest.approx(expected)
+
+
+def test_identity_material_axes_are_detected() -> None:
+    identity = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+    assert _is_identity_axes(None)
+    assert _is_identity_axes(identity)
+    assert not _is_identity_axes([[0.8, 0.6, 0.0], [-0.6, 0.8, 0.0], [0.0, 0.0, 1.0]])
+
+
+def test_rotated_tensor_produces_meep_off_diagonal_terms() -> None:
+    axes = [[0.8, 0.6, 0.0], [-0.6, 0.8, 0.0], [0.0, 0.0, 1.0]]
+
+    off_diagonal = _rotate_diagonal_tensor([9.0, 4.0, 2.0], axes)
+
+    assert off_diagonal[0] != 0
+    assert off_diagonal[1:] == pytest.approx([0.0, 0.0])
+
+
+def test_explicit_override_supports_tensor_permittivity() -> None:
+    resolved = ResolvedMaterial(
+        permittivity=[9.0, 4.0, 2.0],
+        material_axes=[[0.8, 0.6, 0.0], [-0.6, 0.8, 0.0], [0.0, 0.0, 1.0]],
+    )
+
+    material = _resolved_to_material_data(resolved, 1.55)
+
+    assert material.epsilon_diag == [9.0, 4.0, 2.0]
+    assert material.epsilon_offdiag is not None
+
+
+def test_center_wavelength_resolution_uses_builtin_cards() -> None:
+    materials = resolve_materials({"Si", "SiO2"}, wavelength_um=1.55)
+
+    assert materials["Si"].epsilon_diag == pytest.approx([12.0945625246] * 3)
+    assert materials["SiO2"].epsilon_diag == pytest.approx([1.4440236217**2] * 3)
+    assert materials["Si"].epsilon_susceptibilities is None
+
+
+def test_fdtd_resolution_preserves_sellmeier_poles() -> None:
+    materials = resolve_fdtd_materials(
+        {"Si", "SiO2"},
+        wavelength_um=1.55,
+        wavelength_span_um=0.1,
+        resolution=32,
+    )
+
+    silicon = materials["Si"]
+    silica = materials["SiO2"]
+    assert silicon.epsilon_diag == [1.0, 1.0, 1.0]
+    assert silica.epsilon_diag == [1.0, 1.0, 1.0]
+    assert len(silicon.epsilon_susceptibilities or []) == 3
+    assert len(silica.epsilon_susceptibilities or []) == 3
+    assert {term.kind for term in silica.epsilon_susceptibilities or []} == {
+        "lorentzian"
+    }
+
+
+def test_low_resolution_warns_for_high_sellmeier_pole() -> None:
+    with pytest.warns(RuntimeWarning, match="resolution >= 23"):
+        resolve_fdtd_materials(
+            {"SiO2"},
             wavelength_um=1.55,
-            dispersion="false",
+            wavelength_span_um=0.1,
+            resolution=20,
         )
-        assert "sio2" in materials
-        assert materials["sio2"].epsilon_diag == pytest.approx([3.9, 3.9, 3.9])
 
-    def test_duplicate_override_warns(self):
-        overrides = {
-            "SiO2": MaterialProperties(permittivity=3.9),
-            "sio2": MaterialProperties(permittivity=4.0),
-        }
-        with pytest.warns(UserWarning, match="Duplicate material entries"):
-            resolve_materials_with_dispersion(
-                {"SiO2"},
-                overrides=overrides,
-                wavelength_um=1.55,
-                dispersion="false",
-            )
 
-    def test_unmatched_override_warns(self):
-        overrides = {
-            "fake": MaterialProperties(permittivity=5.0),
-        }
-        with pytest.warns(UserWarning, match="do not match any material"):
-            resolve_materials_with_dispersion(
-                {"SiO2"},
-                overrides=overrides,
-                wavelength_um=1.55,
-                dispersion="false",
-            )
+def test_explicit_override_remains_nondispersive() -> None:
+    materials = resolve_fdtd_materials(
+        {"Si"},
+        overrides={"si": MaterialProperties(permittivity=12.0)},
+        wavelength_um=1.55,
+        wavelength_span_um=0.1,
+        resolution=20,
+    )
+
+    assert materials["Si"].epsilon_diag == [12.0, 12.0, 12.0]
+    assert materials["Si"].epsilon_susceptibilities is None
+
+
+def test_override_keys_are_case_insensitive() -> None:
+    materials = resolve_materials(
+        {"SiO2"},
+        overrides={"  sio2  ": MaterialProperties(permittivity=3.9)},
+        wavelength_um=1.55,
+    )
+
+    assert materials["SiO2"].epsilon_diag == [3.9, 3.9, 3.9]
+
+
+def test_duplicate_override_keys_warn() -> None:
+    overrides = {
+        "SiO2": MaterialProperties(permittivity=3.9),
+        "sio2": MaterialProperties(permittivity=4.0),
+    }
+
+    with pytest.warns(UserWarning, match="Duplicate material entries"):
+        resolve_materials({"SiO2"}, overrides=overrides, wavelength_um=1.55)
+
+
+def test_missing_material_card_fails_strictly() -> None:
+    with pytest.raises(MaterialNotFoundError, match="No MaterialCard"):
+        resolve_fdtd_materials(
+            {"unobtainium"},
+            wavelength_um=1.55,
+            wavelength_span_um=0.1,
+            resolution=32,
+        )
+
+
+def test_fdtd_resolution_runs_meep_compatibility_validator() -> None:
+    with pytest.raises(MeepMaterialCompatibilityError, match="causal Lorentz/Drude"):
+        resolve_fdtd_materials(
+            {"Si-Li-293K"},
+            wavelength_um=1.55,
+            wavelength_span_um=0.1,
+            resolution=32,
+        )

--- a/tests/meep/test_material_resolution.py
+++ b/tests/meep/test_material_resolution.py
@@ -62,11 +62,11 @@ def test_center_wavelength_resolution_uses_builtin_cards() -> None:
     materials = resolve_materials({"Si", "SiO2"}, wavelength_um=1.55)
 
     assert materials["Si"].epsilon_diag == pytest.approx([12.0945625246] * 3)
-    assert materials["SiO2"].epsilon_diag == pytest.approx([1.4440236217**2] * 3)
+    assert materials["SiO2"].epsilon_diag == pytest.approx([1.4440235342**2] * 3)
     assert materials["Si"].epsilon_susceptibilities is None
 
 
-def test_fdtd_resolution_preserves_sellmeier_poles() -> None:
+def test_fdtd_resolution_preserves_material_card_poles() -> None:
     materials = resolve_fdtd_materials(
         {"Si", "SiO2"},
         wavelength_um=1.55,
@@ -77,21 +77,21 @@ def test_fdtd_resolution_preserves_sellmeier_poles() -> None:
     silicon = materials["Si"]
     silica = materials["SiO2"]
     assert silicon.epsilon_diag == [1.0, 1.0, 1.0]
-    assert silica.epsilon_diag == [1.0, 1.0, 1.0]
+    assert silica.epsilon_diag == pytest.approx([1.2648942846816222] * 3)
     assert len(silicon.epsilon_susceptibilities or []) == 3
-    assert len(silica.epsilon_susceptibilities or []) == 3
+    assert len(silica.epsilon_susceptibilities or []) == 2
     assert {term.kind for term in silica.epsilon_susceptibilities or []} == {
         "lorentzian"
     }
 
 
-def test_low_resolution_warns_for_high_sellmeier_pole() -> None:
-    with pytest.warns(RuntimeWarning, match="resolution >= 23"):
+def test_low_resolution_warns_for_high_lorentz_pole() -> None:
+    with pytest.warns(RuntimeWarning, match="resolution >= 16"):
         resolve_fdtd_materials(
             {"SiO2"},
             wavelength_um=1.55,
             wavelength_span_um=0.1,
-            resolution=20,
+            resolution=15,
         )
 
 

--- a/tests/meep/test_mode_solver.py
+++ b/tests/meep/test_mode_solver.py
@@ -227,6 +227,22 @@ class TestResolveStackAndMaterials:
         for name, mat in materials.items():
             assert mat.epsilon_diag is not None, f"{name} missing epsilon_diag"
 
+    def test_slab_without_component_resolves_declared_dielectrics_only(self):
+        from gdsfactory import gpdk
+
+        from gsim.meep import Simulation
+
+        gpdk.PDK.activate()
+        sim = Simulation()
+        sim.materials = {"si": 12.0, "SiO2": 2.1}
+
+        stack, materials = sim._resolve_stack_and_materials(wavelength=1.55)
+
+        assert stack.dielectrics
+        assert set(materials) == {
+            dielectric["material"] for dielectric in stack.dielectrics
+        }
+
     def test_wavelength_affects_dispersive_materials(self):
         """Different wavelengths produce different epsilon for dispersive materials."""
         import gdsfactory as gf

--- a/tests/meep/test_mode_solver.py
+++ b/tests/meep/test_mode_solver.py
@@ -240,20 +240,20 @@ class TestResolveStackAndMaterials:
         sim.materials = {}
 
         _stack, mats_1550 = sim._resolve_stack_and_materials(wavelength=1.55)
-        _stack, mats_1310 = sim._resolve_stack_and_materials(wavelength=1.31)
+        _stack, mats_1400 = sim._resolve_stack_and_materials(wavelength=1.4)
 
         # si should be present in both (from default PDK stack)
-        if "si" in mats_1550 and "si" in mats_1310:
+        if "si" in mats_1550 and "si" in mats_1400:
             eps_1550 = mats_1550["si"].epsilon_diag
-            eps_1310 = mats_1310["si"].epsilon_diag
-            # si has material dispersion — eps at 1.31 != eps at 1.55
+            eps_1400 = mats_1400["si"].epsilon_diag
+            # Salzberg silicon is valid above 1.357 um and is dispersive.
             if isinstance(eps_1550, list):
                 eps_1550 = eps_1550[0]
-            if isinstance(eps_1310, list):
-                eps_1310 = eps_1310[0]
-            assert eps_1550 != eps_1310, (
+            if isinstance(eps_1400, list):
+                eps_1400 = eps_1400[0]
+            assert eps_1550 != eps_1400, (
                 f"Expected different epsilon at different wavelengths, "
-                f"got {eps_1550} at 1.55 and {eps_1310} at 1.31"
+                f"got {eps_1550} at 1.55 and {eps_1400} at 1.4"
             )
 
 

--- a/tests/meep/test_script_template.py
+++ b/tests/meep/test_script_template.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from types import SimpleNamespace
 
 from gsim.meep.script import _MEEP_RUNNER_TEMPLATE
 
@@ -30,6 +31,67 @@ def test_runner_has_fiber_source_path():
     assert "GaussianBeamSource" in _MEEP_RUNNER_TEMPLATE
 
 
+def test_runner_builds_lorentz_and_drude_materials():
+    """Serialized card terms must reach the corresponding MEEP classes."""
+
+    class FakeObject:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeVector3:
+        __slots__ = ("values",)
+
+        def __init__(self, *values):
+            self.values = values
+
+    class FakeLorentzian(FakeObject):
+        pass
+
+    class FakeDrude(FakeObject):
+        pass
+
+    fake_meep = SimpleNamespace(
+        Vector3=FakeVector3,
+        Medium=FakeObject,
+        FreqRange=FakeObject,
+        LorentzianSusceptibility=FakeLorentzian,
+        DrudeSusceptibility=FakeDrude,
+    )
+    build_materials = _extract_runner_func("build_materials", mp=fake_meep)
+    config = {
+        "materials": {
+            "mixed": {
+                "epsilon_diag": [2.0, 2.0, 2.0],
+                "epsilon_susceptibilities": [
+                    {
+                        "kind": "lorentzian",
+                        "frequency": 1.0,
+                        "gamma": 0.1,
+                        "sigma": 2.0,
+                    },
+                    {
+                        "kind": "drude",
+                        "frequency": 3.0,
+                        "gamma": 0.2,
+                        "sigma": 1.0,
+                    },
+                ],
+                "valid_freq_range": [0.5, 2.0],
+            }
+        }
+    }
+
+    medium = build_materials(config)["mixed"]
+
+    terms = medium.kwargs["E_susceptibilities"]
+    assert medium.kwargs["epsilon_diag"].values == (2.0, 2.0, 2.0)
+    assert isinstance(terms[0], FakeLorentzian)
+    assert isinstance(terms[1], FakeDrude)
+    assert terms[0].kwargs["sigma"] == 2.0
+    assert terms[1].kwargs["frequency"] == 3.0
+    assert medium.kwargs["valid_freq_range"].kwargs == {"min": 0.5, "max": 2.0}
+
+
 def test_resolved_z_bounds_are_identical_in_3d_and_xz():
     """Canonical bounds must bypass the legacy XZ margin path."""
     resolve_z_cell = _extract_runner_func("resolve_z_cell")
@@ -54,7 +116,7 @@ def test_legacy_xz_margins_are_applied_once():
     assert resolve_z_cell(domain, -0.5, 2.0, False, True) == (6.0, 1.0)
 
 
-def _extract_runner_func(name: str):
+def _extract_runner_func(name: str, **namespace):
     """Exec a single pure-Python helper from the runner template in isolation.
 
     The runner template can't be imported wholesale (it imports meep), so we
@@ -68,7 +130,7 @@ def _extract_runner_func(name: str):
         None,
     )
     assert func_node is not None, f"{name} not found in runner template"
-    ns: dict = {"np": np}
+    ns: dict = {"np": np, **namespace}
     exec(compile(ast.Module([func_node], []), "<runner>", "exec"), ns)  # noqa: S102
     return ns[name]
 

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -572,7 +572,7 @@ class Test2DMode:
         silicon = result.config.materials["si"]
         silica = result.config.materials["sio2"]
         assert len(silicon.epsilon_susceptibilities or []) == 3
-        assert len(silica.epsilon_susceptibilities or []) == 3
+        assert len(silica.epsilon_susceptibilities or []) == 2
 
     def test_solver_callable_mode_2d(self):
         sim = Simulation()

--- a/tests/meep/test_simulation.py
+++ b/tests/meep/test_simulation.py
@@ -33,6 +33,10 @@ class TestMaterial:
 class TestStoppingFields:
     """Tests for the FDTD stopping criteria."""
 
+    def test_dispersion_mode_is_no_longer_a_solver_option(self):
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            FDTD(dispersion="auto")  # ty: ignore[unknown-argument]
+
     def test_fixed_mode(self):
         f = FDTD(stopping="fixed", max_time=100)
         assert f.stopping == "fixed"
@@ -553,6 +557,22 @@ class Test2DMode:
         f = FDTD(mode="2d", z_cut="auto")
         assert f.mode == "2d"
         assert f.resolved_is_3d() is False
+
+    def test_build_config_uses_authored_material_card_dispersion(self):
+        import gdsfactory as gf
+
+        simulation = Simulation()
+        simulation.geometry.component = gf.components.straight(length=10, width=0.5)
+        simulation.source.port = "o1"
+        simulation.monitors = ["o1", "o2"]
+        simulation.solver(mode="2d", z_cut="auto")
+
+        result = simulation.build_config()
+
+        silicon = result.config.materials["si"]
+        silica = result.config.materials["sio2"]
+        assert len(silicon.epsilon_susceptibilities or []) == 3
+        assert len(silica.epsilon_susceptibilities or []) == 3
 
     def test_solver_callable_mode_2d(self):
         sim = Simulation()

--- a/tests/meep/test_viz_index.py
+++ b/tests/meep/test_viz_index.py
@@ -230,6 +230,29 @@ def test_xy_2d_index_plot_uses_resolved_background_material():
     plt.close(figure)
 
 
+def test_index_plot_ignores_unpopulated_stack_materials():
+    from gsim.common.stack import Layer
+
+    simulation = _xy_sim_for_index_plot()
+    assert simulation.geometry.stack is not None
+    simulation.geometry.stack.layers["unused_metal"] = Layer(
+        name="unused_metal",
+        gds_layer=(99, 0),
+        zmin=1.0,
+        zmax=2.0,
+        thickness=1.0,
+        material="Aluminum",
+        layer_type="conductor",
+    )
+    figure, ax = plt.subplots()
+
+    simulation.plot_2d(ax=ax)
+
+    material_ids = {patch.get_gid() for patch in ax.patches if patch.get_gid()}
+    assert "material:Aluminum" not in material_ids
+    plt.close(figure)
+
+
 def test_multi_slice_index_plot_uses_separate_figures(monkeypatch):
     simulation = _xz_sim_for_index_plot()
     existing_figure_numbers = set(plt.get_fignums())


### PR DESCRIPTION
Stacked on #245. Replaces #246.

- Resolve Meep materials from project or gsim MaterialCards and preserve authored constant, Sellmeier, Lorentz, and Drude dispersion.
- Add a lossless two-pole Malitson reduction over 0.4–2.0 µm and use it as the built-in `SiO2` fallback; retain the original three-pole Malitson card explicitly.
- Add the lossless Arosa and de la Fuente fused-silica Sellmeier model.
- Reject unsupported material representations instead of silently approximating them.