### PR TITLE
feat: show progress bar while waiting for cloud simulations

### DIFF
--- a/src/gsim/fdtd/cloud.py
+++ b/src/gsim/fdtd/cloud.py
@@ -37,6 +37,7 @@ class CloudWorkflowMixin:
         from gsim.hashing import compute_input_hash
 
         directory = self._prepare_upload_dir()
+        self._estimated_runtime_seconds = gcloud.estimate_runtime_seconds(directory)
         self._input_hash = compute_input_hash(directory, "fdtd")
         self._job_id = gcloud.upload(
             directory,
@@ -79,6 +80,7 @@ class CloudWorkflowMixin:
             verbose=verbose,
             parent_dir=parent_dir,
             poll_interval=poll_interval,
+            estimated_runtime_seconds=getattr(self, "_estimated_runtime_seconds", None),
         )
 
     def run(
@@ -95,6 +97,7 @@ class CloudWorkflowMixin:
 
         if check_cache:
             directory = self._prepare_upload_dir()
+            self._estimated_runtime_seconds = gcloud.estimate_runtime_seconds(directory)
             self._input_hash, cached_job_id = gcloud.check_cache_for_dir(
                 directory, "fdtd"
             )

--- a/src/gsim/gcloud.py
+++ b/src/gsim/gcloud.py
@@ -553,11 +553,34 @@ def _fetch_and_print_logs(
     return cursor
 
 
+def estimate_runtime_seconds(input_dir: str | Path) -> float:
+    """Estimate cloud solver runtime from the generated mesh/input size.
+
+    Mesh size is the best solver-agnostic proxy available before execution:
+    finer meshes produce larger discretized systems and generally take longer.
+    The estimate deliberately excludes cloud-queue time.  It is a heuristic,
+    not a scheduling guarantee, and is refined as the solver runs.
+    """
+    directory = Path(input_dir)
+    sizes = [
+        path.stat().st_size
+        for path in directory.rglob("*")
+        if path.is_file() and path.suffix.lower() in {".msh", ".mesh"}
+    ]
+    input_bytes = sum(
+        path.stat().st_size for path in directory.rglob("*") if path.is_file()
+    )
+    size_bytes = max([input_bytes, *sizes])
+    size_mb = size_bytes / (1024 * 1024)
+    return 60.0 + 45.0 * max(size_mb, 0.1) ** 0.75
+
+
 def wait_for_results(
     *job_ids: str,
     verbose: Literal["quiet", "status", "full"] = "status",
     parent_dir: str | Path | None = None,
     poll_interval: float = 5.0,
+    estimated_runtime_seconds: float | None = None,
 ) -> Any:
     """Wait for one or more jobs to finish, then download and parse results.
 
@@ -577,6 +600,9 @@ def wait_for_results(
             ``"full"`` — stream solver logs live (timestamps stripped).
         parent_dir: Where to create sim-data directories (default: cwd).
         poll_interval: Seconds between status polls (default 5.0).
+        estimated_runtime_seconds: Expected solver runtime, excluding queue
+            time. When provided, status output includes an estimated percent
+            complete and remaining time.
 
     Returns:
         Parsed result (single job) or list of parsed results (multiple jobs).
@@ -623,7 +649,11 @@ def wait_for_results(
     while not all(_status_value(j.status) in terminal for j in jobs.values()):
         if verbose == "status":
             prev_lines = _print_status_table(
-                jobs, start_times, prev_lines, end_times=end_times
+                jobs,
+                start_times,
+                prev_lines,
+                end_times=end_times,
+                estimated_runtime_seconds=estimated_runtime_seconds,
             )
 
         time.sleep(poll_interval)
@@ -654,7 +684,12 @@ def wait_for_results(
     # Final status display — skip clear_output when logs were streamed
     if verbose == "status":
         _print_status_table(
-            jobs, start_times, prev_lines, end_times=end_times, final=True
+            jobs,
+            start_times,
+            prev_lines,
+            end_times=end_times,
+            final=True,
+            estimated_runtime_seconds=estimated_runtime_seconds,
         )
 
     # Download + parse all
@@ -698,6 +733,7 @@ def _print_status_table(
     *,
     end_times: dict[str, float] | None = None,
     final: bool = False,
+    estimated_runtime_seconds: float | None = None,
 ) -> int:
     """Print job status, updating in place.
 
@@ -733,14 +769,12 @@ def _print_status_table(
         mins, secs = divmod(int(t), 60)
         return f"{mins}m {secs:02d}s"
 
-    def _progress(job: Any) -> tuple[int, str]:
+    def _progress(jid: str, job: Any) -> tuple[int, str]:
         """Return a conservative lifecycle-based completion estimate.
 
-        The cloud API reports lifecycle states but not solver iteration counts,
-        so a running job cannot be assigned an exact percentage.  These values
-        make the transition through submission, queueing, execution, and
-        completion visible without suggesting that a solver is further along
-        than the backend can confirm.
+        The cloud API reports lifecycle states but not solver iteration counts.
+        When an input-size estimate is available, use its elapsed fraction for
+        the running phase; otherwise show only conservative lifecycle progress.
         """
         status = _status_value(job.status).casefold()
         if status == "completed":
@@ -748,6 +782,12 @@ def _print_status_table(
         if status == "failed":
             return 100, "failed"
         if status == "running":
+            if estimated_runtime_seconds is not None:
+                elapsed = time.monotonic() - start_times[jid]
+                percent = min(99, round(100 * elapsed / estimated_runtime_seconds))
+                remaining = max(0, estimated_runtime_seconds - elapsed)
+                mins, secs = divmod(round(remaining), 60)
+                return percent, f"running, ETA {mins}m {secs:02d}s"
             return 50, "running"
         if status == "queued":
             return 15, "queued"
@@ -762,7 +802,7 @@ def _print_status_table(
 
     if n == 1:
         jid, job = next(iter(jobs.items()))
-        percent, phase = _progress(job)
+        percent, phase = _progress(jid, job)
         msg = (
             f"  {job.job_name or jid}  {_bar(percent)}  {phase}"
             f"  elapsed {_elapsed(jid)}"
@@ -780,7 +820,7 @@ def _print_status_table(
     print(f"Waiting for {n} jobs...")  # noqa: T201
     lines_printed += 1
     for jid, job in jobs.items():
-        percent, phase = _progress(job)
+        percent, phase = _progress(jid, job)
         line = (
             f"  {job.job_name or jid:<30s} {_bar(percent)} {phase:<12s}"
             f" elapsed {_elapsed(jid)}"

--- a/src/gsim/gcloud.py
+++ b/src/gsim/gcloud.py
@@ -733,14 +733,42 @@ def _print_status_table(
         mins, secs = divmod(int(t), 60)
         return f"{mins}m {secs:02d}s"
 
+    def _progress(job: Any) -> tuple[int, str]:
+        """Return a conservative lifecycle-based completion estimate.
+
+        The cloud API reports lifecycle states but not solver iteration counts,
+        so a running job cannot be assigned an exact percentage.  These values
+        make the transition through submission, queueing, execution, and
+        completion visible without suggesting that a solver is further along
+        than the backend can confirm.
+        """
+        status = _status_value(job.status).casefold()
+        if status == "completed":
+            return 100, "complete"
+        if status == "failed":
+            return 100, "failed"
+        if status == "running":
+            return 50, "running"
+        if status == "queued":
+            return 15, "queued"
+        return 5, status or "starting"
+
+    def _bar(percent: int, width: int = 20) -> str:
+        filled = round(width * percent / 100)
+        return f"[{'#' * filled}{'.' * (width - filled)}] {percent:3d}%"
+
     lines_printed = 0
     n = len(jobs)
 
     if n == 1:
         jid, job = next(iter(jobs.items()))
-        msg = f"  {job.job_name or jid}  {_status_value(job.status)}  {_elapsed(jid)}"
+        percent, phase = _progress(job)
+        msg = (
+            f"  {job.job_name or jid}  {_bar(percent)}  {phase}"
+            f"  elapsed {_elapsed(jid)}"
+        )
         if mode == "tty":
-            sys.stdout.write(f"\r{msg:<60s}")
+            sys.stdout.write(f"\r{msg:<80s}")
             if final:
                 sys.stdout.write("\n")
         else:
@@ -752,8 +780,11 @@ def _print_status_table(
     print(f"Waiting for {n} jobs...")  # noqa: T201
     lines_printed += 1
     for jid, job in jobs.items():
-        status = _status_value(job.status)
-        line = f"  {job.job_name or jid:<30s} {status:<12s} {_elapsed(jid)}"
+        percent, phase = _progress(job)
+        line = (
+            f"  {job.job_name or jid:<30s} {_bar(percent)} {phase:<12s}"
+            f" elapsed {_elapsed(jid)}"
+        )
         print(line)  # noqa: T201
         lines_printed += 1
 

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -1816,6 +1816,7 @@ class Simulation(BaseModel):
         from gsim.hashing import compute_input_hash
 
         tmp = self._prepare_upload_dir()
+        self._estimated_runtime_seconds = gcloud.estimate_runtime_seconds(tmp)
         self._input_hash = compute_input_hash(tmp, "meep")
         self._job_id = gcloud.upload(
             tmp, "meep", verbose=verbose, input_hash=self._input_hash
@@ -1874,7 +1875,10 @@ class Simulation(BaseModel):
         if self._job_id is None:
             raise ValueError("No job submitted yet")
         return gcloud.wait_for_results(
-            self._job_id, verbose=verbose, parent_dir=parent_dir
+            self._job_id,
+            verbose=verbose,
+            parent_dir=parent_dir,
+            estimated_runtime_seconds=getattr(self, "_estimated_runtime_seconds", None),
         )
 
     # -------------------------------------------------------------------------
@@ -1911,6 +1915,7 @@ class Simulation(BaseModel):
         self._run_verbose = verbose
         if check_cache:
             tmp = self._prepare_upload_dir()
+            self._estimated_runtime_seconds = gcloud.estimate_runtime_seconds(tmp)
             self._input_hash, cached_job_id = gcloud.check_cache_for_dir(tmp, "meep")
             if cached_job_id is not None:
                 self._job_id = cached_job_id

--- a/src/gsim/meep/simulation.py
+++ b/src/gsim/meep/simulation.py
@@ -331,6 +331,7 @@ class Simulation(BaseModel):
     _job_id: str | None = PrivateAttr(default=None)
     _config_dir: Path | None = PrivateAttr(default=None)
     _input_hash: str | None = PrivateAttr(default=None)
+    _estimated_runtime_seconds: float | None = PrivateAttr(default=None)
 
     # PDK overlay (foundry-specific material values, loaded from YAML)
     _pdk_overlay: dict[str, Any] | None = PrivateAttr(default=None)

--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -1716,6 +1716,7 @@ class PalaceSimMixin:
 
         tmp = self._prepare_upload_dir()
         try:
+            self._estimated_runtime_seconds = gcloud.estimate_runtime_seconds(tmp)
             self._input_hash = compute_input_hash(tmp, "palace")
             self._job_id = gcloud.upload(
                 tmp, "palace", verbose=verbose, input_hash=self._input_hash
@@ -1778,7 +1779,10 @@ class PalaceSimMixin:
         if self._job_id is None:
             raise ValueError("No job submitted yet")
         return gcloud.wait_for_results(
-            self._job_id, verbose=verbose, parent_dir=parent_dir
+            self._job_id,
+            verbose=verbose,
+            parent_dir=parent_dir,
+            estimated_runtime_seconds=getattr(self, "_estimated_runtime_seconds", None),
         )
 
     # -------------------------------------------------------------------------
@@ -1833,6 +1837,7 @@ class PalaceSimMixin:
 
         if check_cache:
             tmp = self._prepare_upload_dir()
+            self._estimated_runtime_seconds = gcloud.estimate_runtime_seconds(tmp)
             self._input_hash, cached_job_id = gcloud.check_cache_for_dir(tmp, "palace")
             if cached_job_id is not None:
                 self._job_id = cached_job_id

--- a/tests/test_gcloud_start.py
+++ b/tests/test_gcloud_start.py
@@ -287,6 +287,22 @@ class TestGetStatus:
 class TestWaitForResultsSingle:
     """Tests for wait_for_results with a single job."""
 
+    @patch("gsim.gcloud._output_mode", new=lambda: "pipe")
+    @patch("gsim.gcloud.sim")
+    def test_status_display_includes_progress_bar(self, mock_sim, capsys):
+        """Status mode renders a lifecycle progress estimate and elapsed time."""
+        from gsim.gcloud import _print_status_table
+
+        mock_sim.SimStatus = SimStatus
+        job = FakeJob(job_name="meep-progress", status=SimStatus.RUNNING)
+
+        _print_status_table({"job-1": job}, {"job-1": 0.0}, final=True)
+
+        output = capsys.readouterr().out
+        assert "[##########..........]  50%" in output
+        assert "running" in output
+        assert "elapsed" in output
+
     @patch("gsim.gcloud.sim")
     def test_already_completed(self, mock_sim, tmp_path):
         """Completed job downloads and parses results immediately."""

--- a/tests/test_gcloud_start.py
+++ b/tests/test_gcloud_start.py
@@ -303,6 +303,25 @@ class TestWaitForResultsSingle:
         assert "running" in output
         assert "elapsed" in output
 
+    @patch("gsim.gcloud._output_mode", new=lambda: "pipe")
+    @patch("gsim.gcloud.time.monotonic", return_value=120.0)
+    def test_status_display_estimates_remaining_runtime(self, mock_monotonic, capsys):
+        """Input-size runtime estimates drive running progress and ETA output."""
+        from gsim.gcloud import _print_status_table
+
+        job = FakeJob(job_name="meep-progress", status=SimStatus.RUNNING)
+        _print_status_table(
+            {"job-1": job},
+            {"job-1": 0.0},
+            final=True,
+            estimated_runtime_seconds=240.0,
+        )
+
+        output = capsys.readouterr().out
+        assert "[##########..........]  50%" in output
+        assert "ETA 2m 00s" in output
+        assert mock_monotonic.called
+
     @patch("gsim.gcloud.sim")
     def test_already_completed(self, mock_sim, tmp_path):
         """Completed job downloads and parses results immediately."""
@@ -394,6 +413,23 @@ class TestWaitForResultsSingle:
 
         with pytest.raises(ValueError, match="At least one job_id"):
             wait_for_results(verbose="quiet")
+
+
+class TestRuntimeEstimate:
+    """Tests for the pre-run input-size runtime heuristic."""
+
+    def test_larger_mesh_has_a_larger_runtime_estimate(self, tmp_path):
+        """Mesh byte size is used as a solver-agnostic size proxy."""
+        from gsim.gcloud import estimate_runtime_seconds
+
+        small = tmp_path / "small"
+        large = tmp_path / "large"
+        small.mkdir()
+        large.mkdir()
+        (small / "mesh.msh").write_bytes(b"0" * 1024)
+        (large / "mesh.msh").write_bytes(b"0" * (10 * 1024 * 1024))
+
+        assert estimate_runtime_seconds(large) > estimate_runtime_seconds(small)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- render an in-place progress bar while `sim.run()` waits for cloud results
- estimate solver runtime from the generated mesh/input size and show an ETA while the job is running
- apply the estimate to MEEP, Palace, and FDTD cloud workflows
- retain elapsed-time visibility and add focused coverage

The estimate is a deliberately labeled heuristic: mesh/input size is a solver-agnostic workload proxy, while cloud queue time and backend solver behavior cannot be predicted client-side.

## Validation
- `uv run pytest tests/test_gcloud_start.py tests/meep/test_mode_solver.py tests/palace/test_sim_classes.py tests/fdtd/test_api.py -q`
- `uv run ruff check src/gsim/gcloud.py src/gsim/meep/simulation.py src/gsim/palace/base.py src/gsim/fdtd/cloud.py tests/test_gcloud_start.py`
- pre-commit hooks (including `ty`)
