### PR TITLE
feat(palace): emit WavePortPEC for numeric wave ports

### DIFF
--- a/src/gsim/palace/mesh/config_generator.py
+++ b/src/gsim/palace/mesh/config_generator.py
@@ -680,6 +680,27 @@ def generate_palace_config(
     if impedance_entries:
         boundaries.setdefault("Impedance", []).extend(impedance_entries)
 
+    # Numeric wave ports: force every boundary that Palace would translate
+    # into a Robin term on the 2D port cross-section (absorbing walls,
+    # finite-conductivity conductors, impedance sheets) to act as PEC in
+    # the port eigenproblem only.  Without this the port pencil picks up a
+    # large imaginary part, which weakens Palace's real-valued
+    # preconditioner (orders of magnitude slower port solves) and can make
+    # the eigensolver select a spurious mode at low frequency.  The 3D
+    # model is unaffected: the box still absorbs and the metal keeps its
+    # finite conductivity.
+    if boundaries.get("WavePort"):
+        waveport_pec_attrs: set[int] = set()
+        absorbing_entry = boundaries.get("Absorbing")
+        if absorbing_entry:
+            waveport_pec_attrs.update(absorbing_entry.get("Attributes", []))
+        for cond_entry in boundaries.get("Conductivity", []):
+            waveport_pec_attrs.update(cond_entry.get("Attributes", []))
+        for imp_entry in boundaries.get("Impedance", []):
+            waveport_pec_attrs.update(imp_entry.get("Attributes", []))
+        if waveport_pec_attrs:
+            boundaries["WavePortPEC"] = {"Attributes": sorted(waveport_pec_attrs)}
+
     config["Boundaries"] = boundaries
 
     # Merge any extra hints into the config (strip internal keys first)

--- a/tests/palace/test_waveport_pec.py
+++ b/tests/palace/test_waveport_pec.py
@@ -1,0 +1,131 @@
+"""Tests for WavePortPEC emission with numeric wave ports.
+
+When a model has numeric wave ports, the generated config must list every
+boundary attribute that would otherwise contribute a Robin term to the 2D
+port eigenproblem (absorbing walls, finite-conductivity conductors, and
+impedance boundaries) under ``Boundaries.WavePortPEC``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gsim.common.stack.extractor import Layer, LayerStack
+from gsim.palace.mesh.config_generator import generate_palace_config
+from gsim.palace.models.ports import ImpedanceBoundaryConfig
+from gsim.palace.ports.config import PalacePort, PortType
+
+
+def _stack_with_metal() -> LayerStack:
+    stack = LayerStack()
+    stack.layers["metal"] = Layer(
+        name="metal",
+        gds_layer=(1, 0),
+        zmin=0.0,
+        zmax=3.0,
+        thickness=3.0,
+        material="aluminum",
+        layer_type="conductor",
+    )
+    stack.materials = {"aluminum": {"conductivity": 3.77e7}}
+    return stack
+
+
+def _groups(
+    *,
+    wave_ports: bool = True,
+    conductors: bool = True,
+    absorbing: bool = True,
+) -> dict:
+    groups: dict = {
+        "volumes": {"airbox": {"phys_group": 1}},
+        "conductor_surfaces": {},
+        "pec_surfaces": {},
+        "port_surfaces": {},
+        "boundary_surfaces": {},
+    }
+    if conductors:
+        groups["conductor_surfaces"] = {
+            "metal_xy": {"phys_group": 4},
+            "metal_z": {"phys_group": 5},
+        }
+    if wave_ports:
+        groups["port_surfaces"] = {
+            "P1": {"phys_group": 6},
+            "P2": {"phys_group": 7},
+        }
+    if absorbing:
+        groups["boundary_surfaces"] = {"absorbing": {"phys_group": [8, 12]}}
+    return groups
+
+
+def _wave_ports() -> list[PalacePort]:
+    return [
+        PalacePort(name="o1", port_type=PortType.WAVEPORT, layer="metal"),
+        PalacePort(
+            name="o2", port_type=PortType.WAVEPORT, layer="metal", excited=False
+        ),
+    ]
+
+
+def _lumped_ports() -> list[PalacePort]:
+    return [
+        PalacePort(name="o1", port_type=PortType.LUMPED, layer="metal"),
+        PalacePort(name="o2", port_type=PortType.LUMPED, layer="metal", excited=False),
+    ]
+
+
+def _generate(tmp_path, groups, ports, *, hints=None, absorbing_boundary=True):
+    config_path = generate_palace_config(
+        groups=groups,
+        ports=ports,
+        port_info=[],
+        stack=_stack_with_metal(),
+        output_path=tmp_path,
+        model_name="palace",
+        fmax=100e9,
+        simulation_type="driven",
+        absorbing_boundary=absorbing_boundary,
+        hints=hints,
+    )
+    return json.loads(config_path.read_text())
+
+
+class TestWavePortPEC:
+    def test_union_of_absorbing_and_conductivity(self, tmp_path):
+        config = _generate(tmp_path, _groups(), _wave_ports())
+        boundaries = config["Boundaries"]
+        assert boundaries["WavePortPEC"] == {"Attributes": [4, 5, 8, 12]}
+
+    def test_not_emitted_without_wave_ports(self, tmp_path):
+        config = _generate(tmp_path, _groups(wave_ports=False), _lumped_ports())
+        assert "WavePortPEC" not in config["Boundaries"]
+
+    def test_not_emitted_for_lumped_ports(self, tmp_path):
+        groups = _groups()
+        config = _generate(tmp_path, groups, _lumped_ports())
+        assert config["Boundaries"]["LumpedPort"]
+        assert not config["Boundaries"]["WavePort"]
+        assert "WavePortPEC" not in config["Boundaries"]
+
+    def test_includes_impedance_attributes(self, tmp_path):
+        hints = {
+            "_impedance_boundaries": [
+                ImpedanceBoundaryConfig(attributes=[20], resistance=1.0)
+            ]
+        }
+        config = _generate(tmp_path, _groups(), _wave_ports(), hints=hints)
+        assert config["Boundaries"]["WavePortPEC"] == {"Attributes": [4, 5, 8, 12, 20]}
+
+    def test_not_emitted_when_no_robin_boundaries(self, tmp_path):
+        groups = _groups(conductors=False, absorbing=False)
+        config = _generate(tmp_path, groups, _wave_ports(), absorbing_boundary=False)
+        boundaries = config["Boundaries"]
+        assert boundaries["WavePort"]
+        assert "WavePortPEC" not in boundaries
+
+    def test_absorbing_scalar_phys_group(self, tmp_path):
+        groups = _groups()
+        groups["boundary_surfaces"] = {"absorbing": {"phys_group": 8}}
+        config = _generate(tmp_path, groups, _wave_ports())
+        assert config["Boundaries"]["WavePortPEC"] == {"Attributes": [4, 5, 8]}


### PR DESCRIPTION
## Summary

When a model has numeric wave ports, emit a `Boundaries.WavePortPEC` block listing every boundary attribute that would otherwise contribute a Robin term to the 2D port eigenproblem: the absorbing outer-box surfaces plus the conductor (`Conductivity`) and `Impedance` surfaces. The set is derived from the generated boundaries, not hard-coded.

The 3D model is unchanged — the box still absorbs and the metal keeps its finite conductivity — so radiation and conductor loss remain fully modelled. Only the 2D port-mode solve treats these surfaces as PEC.

This is item 3 of #228.

## Why

Without this, the port eigenproblem inherits Robin terms from the absorbing walls and lossy metal:

- Palace preconditions the port solve with the real part of the pencil, so a large imaginary part makes the solve extremely slow (~12 s per port per frequency on the CPW notebook, projected ~2 h for the 300-point sweep).
- Mode selection goes wrong at low frequency: a spurious evanescent mode associated with the conductivity sheet sorts ahead of the real CPW mode at 1 GHz, and the mode ordering swaps partway up the band.

## Validation (local, coarse mesh, 300 points, 1–100 GHz)

- Emitted config on the CPW waveport notebook mesh: `WavePortPEC: {"Attributes": [4, 5, 8, 12]}` — walls + conductors.
- Wave-port timer bucket: ~40 s for the whole sweep (~0.06 s per port per frequency).
- Both ports report identical kₙ at all 300 frequencies; kₙ is continuous across the band (no mode crossing), n_eff flat at ~1.72.

Known trade-off: the port mode becomes the ideal lossless closed-guide mode, so the internal-inductance contribution to β below ~10 GHz is not represented in the port mode (a few % on n_eff at 1 GHz, ~1% by 30 GHz). Conductor loss in the line itself is unaffected.

Side benefit: results no longer depend on which side of Palace's v0.14 → v0.17 behaviour change (conductivity boundaries in the wave-port solve: PEC → Robin) the installed Palace sits on.

## Tests

- `tests/palace/test_waveport_pec.py`: union of absorbing + conductivity attributes, impedance attributes included, scalar vs list absorbing phys groups, and no `WavePortPEC` for lumped-only ports, no wave ports, or no Robin boundaries.
- Full suite passes (one pre-existing environment-dependent failure unrelated to this change: `test_returns_none_when_nothing_found` fails on machines with a palace binary installed).

Refs #228
