### PR TITLE
feat(palace): expose Palace's advanced wave-port eigensolver controls

### DIFF
--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -1073,6 +1073,11 @@ class PalaceSimMixin:
                     excited=port_config.excited,
                     mode=port_config.mode,
                     offset=port_config.offset,
+                    eigensolver_type=port_config.eigensolver_type,
+                    eigensolver_tol=port_config.eigensolver_tol,
+                    eigensolver_ksp_tol=port_config.eigensolver_ksp_tol,
+                    eigensolver_max_size=port_config.eigensolver_max_size,
+                    eigensolver_verbose=port_config.eigensolver_verbose,
                 )
 
         self._configured_ports = True
@@ -2428,6 +2433,11 @@ class PalaceSimMixin:
         mode: int = 1,
         excited: bool = True,
         offset: float = 0.0,
+        eigensolver_type: str | None = None,
+        eigensolver_tol: float | None = None,
+        eigensolver_ksp_tol: float | None = None,
+        eigensolver_max_size: int | None = None,
+        eigensolver_verbose: int | None = None,
     ) -> None:
         """Add a single element wave port.
 
@@ -2443,6 +2453,19 @@ class PalaceSimMixin:
             mode: Mode number to excite.
             excited: Whether this port is excited
             offset: Offset distance used for scattering parameter de-embedding.
+            eigensolver_type: Palace SolverType for this port's 2D mode
+                eigenproblem ("Default", "SLEPc" or "ARPACK"). None uses
+                Palace's own default.
+            eigensolver_tol: Palace EigenTol for this port's mode solve.
+                None uses Palace's own default.
+            eigensolver_ksp_tol: Palace KSPTol for this port's mode solve.
+                None uses Palace's own default.
+            eigensolver_max_size: Palace MaxSize (eigensolver subspace
+                dimension) for this port's mode solve - unrelated to
+                max_size above, which sizes geometry. None lets Palace
+                pick its own default.
+            eigensolver_verbose: Palace Verbose level for this port's
+                mode solve. None uses Palace's own default.
 
         Example:
             >>> sim.add_wave_port(
@@ -2466,5 +2489,10 @@ class PalaceSimMixin:
                 mode=mode,
                 excited=excited,
                 offset=offset,
+                eigensolver_type=eigensolver_type,
+                eigensolver_tol=eigensolver_tol,
+                eigensolver_ksp_tol=eigensolver_ksp_tol,
+                eigensolver_max_size=eigensolver_max_size,
+                eigensolver_verbose=eigensolver_verbose,
             )
         )

--- a/src/gsim/palace/mesh/config_generator.py
+++ b/src/gsim/palace/mesh/config_generator.py
@@ -590,15 +590,24 @@ def generate_palace_config(
                             lumped_ports.append(eigenmode_entry)
 
                     elif port.port_type == PortType.WAVEPORT:
-                        wave_ports.append(
-                            {
-                                "Index": port_idx,
-                                "Mode": port.mode,
-                                "Offset": port.offset,
-                                "Excitation": port_idx if port.excited else False,
-                                "Attributes": [port_group["phys_group"]],
-                            }
-                        )
+                        wave_port_entry: dict[str, object] = {
+                            "Index": port_idx,
+                            "Mode": port.mode,
+                            "Offset": port.offset,
+                            "Excitation": port_idx if port.excited else False,
+                            "Attributes": [port_group["phys_group"]],
+                        }
+                        if port.eigensolver_type is not None:
+                            wave_port_entry["SolverType"] = port.eigensolver_type
+                        if port.eigensolver_tol is not None:
+                            wave_port_entry["EigenTol"] = port.eigensolver_tol
+                        if port.eigensolver_ksp_tol is not None:
+                            wave_port_entry["KSPTol"] = port.eigensolver_ksp_tol
+                        if port.eigensolver_max_size is not None:
+                            wave_port_entry["MaxSize"] = port.eigensolver_max_size
+                        if port.eigensolver_verbose is not None:
+                            wave_port_entry["Verbose"] = port.eigensolver_verbose
+                        wave_ports.append(wave_port_entry)
             port_idx += 1
 
         # Assign unique indices to passive reactive ports now that all primary

--- a/src/gsim/palace/models/ports.py
+++ b/src/gsim/palace/models/ports.py
@@ -199,6 +199,21 @@ class WavePortConfig(BaseModel):
         mode: Mode number to excite
         offset: De-embedding distance in um
         excited: Whether this port is excited
+        eigensolver_type: Palace SolverType for this port's 2D mode
+            eigenproblem ("Default", "SLEPc" or "ARPACK"). None uses
+            Palace's own default.
+        eigensolver_tol: Palace EigenTol (eigenvalue solver relative
+            tolerance) for this port's mode solve. None uses Palace's
+            own default.
+        eigensolver_ksp_tol: Palace KSPTol (linear solver tolerance used
+            inside the eigenvalue iteration) for this port's mode solve.
+            None uses Palace's own default.
+        eigensolver_max_size: Palace MaxSize (eigensolver subspace
+            dimension) for this port's mode solve - unrelated to the
+            `max_size` domain-filling flag above. None lets Palace pick
+            its own default (max(2 x Mode, Mode + 15)).
+        eigensolver_verbose: Palace Verbose level for this port's mode
+            solve. None uses Palace's own default.
     """
 
     model_config = ConfigDict(validate_assignment=True)
@@ -217,6 +232,30 @@ class WavePortConfig(BaseModel):
     mode: int = Field(default=1, ge=1, description="Mode number to excite")
     offset: float = Field(default=0.0, ge=0, description="De-embedding distance in um")
     excited: bool = True
+    eigensolver_type: Literal["Default", "SLEPc", "ARPACK"] | None = Field(
+        default=None,
+        description="Palace SolverType for this port's 2D mode eigenproblem",
+    )
+    eigensolver_tol: float | None = Field(
+        default=None, gt=0, description="Palace EigenTol for this port's mode solve"
+    )
+    eigensolver_ksp_tol: float | None = Field(
+        default=None, gt=0, description="Palace KSPTol for this port's mode solve"
+    )
+    eigensolver_max_size: int | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Palace MaxSize (eigensolver subspace dimension) for this "
+            "port's mode solve - unrelated to the max_size domain-filling "
+            "flag above"
+        ),
+    )
+    eigensolver_verbose: int | None = Field(
+        default=None,
+        ge=0,
+        description="Palace Verbose level for this port's mode solve",
+    )
 
 
 __all__ = [

--- a/src/gsim/palace/ports/config.py
+++ b/src/gsim/palace/ports/config.py
@@ -74,6 +74,15 @@ class PalacePort:
     mode: int = 1  # Mode number to excite.
     offset: float = 0.0  # Offset distance used for scattering parameter de-embedding.
 
+    # Waveport 2D eigensolver controls (Palace SolverType/EigenTol/KSPTol/
+    # MaxSize/Verbose) - unrelated to max_size above, which sizes geometry.
+    # None for any of these lets Palace use its own default.
+    eigensolver_type: str | None = None
+    eigensolver_tol: float | None = None
+    eigensolver_ksp_tol: float | None = None
+    eigensolver_max_size: int | None = None
+    eigensolver_verbose: int | None = None
+
     @property
     def direction(self) -> str:
         """Get direction from orientation."""
@@ -292,6 +301,11 @@ def configure_wave_port(
     mode: int = 1,
     excited: bool = True,
     offset: float = 0.0,
+    eigensolver_type: str | None = None,
+    eigensolver_tol: float | None = None,
+    eigensolver_ksp_tol: float | None = None,
+    eigensolver_max_size: int | None = None,
+    eigensolver_verbose: int | None = None,
 ):
     """Configure gdsfactory port(s) as wave ports for Palace simulation.
 
@@ -307,6 +321,19 @@ def configure_wave_port(
         mode: Mode number to excite.
         offset: Offset distance used for scattering parameter de-embedding.
         excited: Whether port is excited vs just measured (default: True)
+        eigensolver_type: Palace SolverType for this port's 2D mode
+            eigenproblem ("Default", "SLEPc" or "ARPACK"). None uses
+            Palace's own default.
+        eigensolver_tol: Palace EigenTol for this port's mode solve. None
+            uses Palace's own default.
+        eigensolver_ksp_tol: Palace KSPTol for this port's mode solve.
+            None uses Palace's own default.
+        eigensolver_max_size: Palace MaxSize (eigensolver subspace
+            dimension) for this port's mode solve - unrelated to
+            max_size above, which sizes geometry. None lets Palace pick
+            its own default.
+        eigensolver_verbose: Palace Verbose level for this port's mode
+            solve. None uses Palace's own default.
 
     Examples:
         ```python
@@ -330,6 +357,11 @@ def configure_wave_port(
         port.info["mode"] = mode
         port.info["offset"] = offset
         port.info["excited"] = excited
+        port.info["eigensolver_type"] = eigensolver_type
+        port.info["eigensolver_tol"] = eigensolver_tol
+        port.info["eigensolver_ksp_tol"] = eigensolver_ksp_tol
+        port.info["eigensolver_max_size"] = eigensolver_max_size
+        port.info["eigensolver_verbose"] = eigensolver_verbose
 
 
 def extract_ports(component, stack: LayerStack) -> list[PalacePort]:
@@ -473,6 +505,11 @@ def extract_ports(component, stack: LayerStack) -> list[PalacePort]:
             excited=info.get("excited", True),
             mode=info.get("mode", 1),
             offset=info.get("offset", 0.0),
+            eigensolver_type=info.get("eigensolver_type"),
+            eigensolver_tol=info.get("eigensolver_tol"),
+            eigensolver_ksp_tol=info.get("eigensolver_ksp_tol"),
+            eigensolver_max_size=info.get("eigensolver_max_size"),
+            eigensolver_verbose=info.get("eigensolver_verbose"),
         )
         palace_ports.append(palace_port)
 

--- a/tests/palace/test_waveport_eigensolver_controls.py
+++ b/tests/palace/test_waveport_eigensolver_controls.py
@@ -1,0 +1,149 @@
+"""Tests for exposing Palace's advanced wave-port eigensolver controls.
+
+Palace's numeric wave ports support per-port SolverType/EigenTol/KSPTol/
+MaxSize/Verbose on the 2D port-mode eigenproblem (see the WavePort object
+in Palace's own JSON schema), but WavePortConfig previously had nowhere to
+put them - gsim always emitted a bare Index/Mode/Offset/Excitation/Attributes
+entry. These fields are per-port on the emitted config (matching Palace's
+own schema), independent of the max_size flag on WavePortConfig/PalacePort,
+which sizes port geometry and predates this feature.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gsim.common.stack.extractor import Layer, LayerStack
+from gsim.palace.mesh.config_generator import generate_palace_config
+from gsim.palace.models.ports import WavePortConfig
+from gsim.palace.ports.config import PalacePort, PortType
+
+
+def _stack_with_metal() -> LayerStack:
+    stack = LayerStack()
+    stack.layers["metal"] = Layer(
+        name="metal",
+        gds_layer=(1, 0),
+        zmin=0.0,
+        zmax=3.0,
+        thickness=3.0,
+        material="aluminum",
+        layer_type="conductor",
+    )
+    stack.materials = {"aluminum": {"conductivity": 3.77e7}}
+    return stack
+
+
+def _groups() -> dict:
+    return {
+        "volumes": {"airbox": {"phys_group": 1}},
+        "conductor_surfaces": {
+            "metal_xy": {"phys_group": 4},
+            "metal_z": {"phys_group": 5},
+        },
+        "pec_surfaces": {},
+        "port_surfaces": {"P1": {"phys_group": 6}, "P2": {"phys_group": 7}},
+        "boundary_surfaces": {"absorbing": {"phys_group": [8, 12]}},
+    }
+
+
+def _generate(tmp_path, ports):
+    config_path = generate_palace_config(
+        groups=_groups(),
+        ports=ports,
+        port_info=[],
+        stack=_stack_with_metal(),
+        output_path=tmp_path,
+        model_name="palace",
+        fmax=100e9,
+        simulation_type="driven",
+        absorbing_boundary=True,
+        hints=None,
+    )
+    return json.loads(config_path.read_text())
+
+
+class TestWavePortConfigEigensolverFields:
+    def test_defaults_are_none(self) -> None:
+        wp = WavePortConfig(name="o1", layer="metal")
+        assert wp.eigensolver_type is None
+        assert wp.eigensolver_tol is None
+        assert wp.eigensolver_ksp_tol is None
+        assert wp.eigensolver_max_size is None
+        assert wp.eigensolver_verbose is None
+
+    def test_max_size_bool_and_eigensolver_max_size_int_coexist(self) -> None:
+        """The pre-existing `max_size` (geometry, bool) and the new
+        `eigensolver_max_size` (Palace MaxSize, int) are independent
+        fields on the same model - setting one must not affect the other.
+        """
+        wp = WavePortConfig(
+            name="o1", layer="metal", max_size=True, eigensolver_max_size=40
+        )
+        assert wp.max_size is True
+        assert wp.eigensolver_max_size == 40
+
+
+class TestWavePortEigensolverControlsInConfig:
+    def test_all_five_fields_emitted_when_set(self, tmp_path):
+        ports = [
+            PalacePort(
+                name="o1",
+                port_type=PortType.WAVEPORT,
+                layer="metal",
+                eigensolver_type="SLEPc",
+                eigensolver_tol=1e-6,
+                eigensolver_ksp_tol=1e-8,
+                eigensolver_max_size=40,
+                eigensolver_verbose=2,
+            ),
+        ]
+        config = _generate(tmp_path, ports)
+        entry = config["Boundaries"]["WavePort"][0]
+        assert entry["SolverType"] == "SLEPc"
+        assert entry["EigenTol"] == 1e-6
+        assert entry["KSPTol"] == 1e-8
+        assert entry["MaxSize"] == 40
+        assert entry["Verbose"] == 2
+
+    def test_none_fields_omitted_not_emitted_as_null(self, tmp_path):
+        """Unset controls must be absent from the emitted dict entirely -
+        matching the existing R/L/C 'only if not None' pattern in this
+        same function - not present with a JSON null value, which Palace
+        would have to specifically treat as 'unset' rather than simply
+        not seeing the key.
+        """
+        ports = [
+            PalacePort(name="o1", port_type=PortType.WAVEPORT, layer="metal"),
+        ]
+        config = _generate(tmp_path, ports)
+        entry = config["Boundaries"]["WavePort"][0]
+        for key in ("SolverType", "EigenTol", "KSPTol", "MaxSize", "Verbose"):
+            assert key not in entry
+
+    def test_per_port_independence(self, tmp_path):
+        """Two wave ports with different eigensolver settings must not
+        leak into each other's emitted entry."""
+        ports = [
+            PalacePort(
+                name="o1",
+                port_type=PortType.WAVEPORT,
+                layer="metal",
+                eigensolver_type="SLEPc",
+            ),
+            PalacePort(
+                name="o2",
+                port_type=PortType.WAVEPORT,
+                layer="metal",
+                excited=False,
+                eigensolver_type="ARPACK",
+                eigensolver_max_size=64,
+            ),
+        ]
+        config = _generate(tmp_path, ports)
+        entries = config["Boundaries"]["WavePort"]
+        by_index = {e["Index"]: e for e in entries}
+        assert by_index[1]["SolverType"] == "SLEPc"
+        assert "MaxSize" not in by_index[1]
+        assert by_index[2]["SolverType"] == "ARPACK"
+        assert by_index[2]["MaxSize"] == 64


### PR DESCRIPTION
Item 2 of #228: "Expose Palace advanced wave-port solver controls in gsim
and benchmark SLEPc versus ARPACK, solver tolerances, and subspace sizing."

## What's missing

`WavePortConfig` only ever produces a bare
`Index`/`Mode`/`Offset`/`Excitation`/`Attributes` entry for numeric wave
ports - there is nowhere to set Palace's own per-port eigensolver controls
(`SolverType`, `EigenTol`, `KSPTol`, `MaxSize`, `Verbose`), all marked
`x-palace-advanced` in Palace's own JSON schema
(`awslabs/palace`, `scripts/schema/config-schema.json`, `$defs.WavePort`).

## The change

Five new optional fields on `WavePortConfig`
(`eigensolver_type`/`eigensolver_tol`/`eigensolver_ksp_tol`/
`eigensolver_max_size`/`eigensolver_verbose`), threaded through
`Simulation.add_wave_port()` -> `configure_wave_port()` -> `PalacePort` ->
the emitted `WavePort` config entry in `generate_palace_config`. Each field
is only emitted when set, matching the existing R/L/C "only if not None"
pattern already used for lumped ports a few lines above the change in
`config_generator.py`.

**Naming note:** `WavePortConfig` already has a field called `max_size` -
a `bool` meaning "fill the full simulation domain" (geometry sizing).
Palace's own `MaxSize` (eigensolver subspace dimension) is an unrelated
`int`, so the new field is `eigensolver_max_size` to avoid the collision,
and the same `eigensolver_` prefix is used on all five new fields for
consistency.

## Verification

Not just unit-tested in isolation - ran the real
`generate_palace_config()` end to end on a two-port config with all five
fields set on one port and left at their defaults on the other:

```python
ports = [
    PalacePort(name="o1", port_type=PortType.WAVEPORT, layer="metal",
               eigensolver_type="SLEPc", eigensolver_tol=1e-6,
               eigensolver_ksp_tol=1e-8, eigensolver_max_size=40,
               eigensolver_verbose=2),
    PalacePort(name="o2", port_type=PortType.WAVEPORT, layer="metal", excited=False),
]
```

emits exactly:

```json
{"Index": 1, "Mode": 1, "Offset": 0.0, "Excitation": 1, "Attributes": [6],
 "SolverType": "SLEPc", "EigenTol": 1e-06, "KSPTol": 1e-08, "MaxSize": 40, "Verbose": 2}
{"Index": 2, "Mode": 1, "Offset": 0.0, "Excitation": false, "Attributes": [7]}
```

- all five keys present with the right values on the configured port, none
of them present on the default one.

The full existing `tests/palace/` suite (314 tests, cloud-marked ones
excluded) passes unmodified against these changes. 5 new tests added
(`tests/palace/test_waveport_eigensolver_controls.py`) covering: model
defaults, the `max_size`/`eigensolver_max_size` field independence,
all-five-emitted, none-emitted-when-unset, and per-port independence
across two ports with different settings.

## Scope

This is item 2 only - it does not itself benchmark SLEPc vs ARPACK or
change any default solver behaviour (every field defaults to `None`,
Palace's own default is unchanged unless a caller opts in). It also
doesn't touch item 3's `WavePortPEC` work (#251, merged) or attempt item 6
(port-mode interpolation/ROM) - see the comment on #228 itself for a
closed-form prototype of that direction. `MaxIts` (GMRES iteration cap,
also `x-palace-advanced` in Palace's schema, alongside the five here) was
deliberately left out - happy to add it in this PR or a follow-up,
whichever you'd prefer.

Refs #228
