### PR TITLE
feat(palace): default to order 1 for coarse mesh preset

### DIFF
--- a/src/gsim/palace/base.py
+++ b/src/gsim/palace/base.py
@@ -1513,6 +1513,11 @@ class PalaceSimMixin:
         if merge_via_distance is not None:
             mesh_config.merge_via_distance = merge_via_distance
 
+        # A coarse mesh is for fast iteration; default to first-order elements
+        # unless the user already overrode the order explicitly.
+        if preset == "coarse" and self.numerical.order == NumericalConfig().order:
+            self.numerical.order = 1
+
         # Validate configuration
         validation = self.validate_config()
         if not validation.valid:


### PR DESCRIPTION
## Summary
- When `sim.mesh(preset="coarse")` is used, default `sim.numerical.order` to `1` (fast, first-order elements) to match the coarse preset's quick-iteration intent.
- An explicitly overridden order (e.g. `sim.set_numerical(order=2)`) is preserved.

## Change
`src/gsim/palace/base.py`: 5-line addition in `mesh()` after the preset is resolved.

## Testing
- `pre-commit run` passes.
- `pytest tests/palace/test_sim_classes.py -k numerical` passes.